### PR TITLE
fixing a small typo in the user_guide

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.7.0,<=2.7.9
-sphinx
-flake8
-pytest-cov
+sphinx>=1.4.6,==1.*
+flake8>=3.0.4,==3.*
+pytest-cov>=2.4.0,==2.*
 vcrpy>=1.10.0,<=1.10.9
 vcrpy-unittest==0.1.6

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -30,7 +30,7 @@ uploads the data back into Civis:
    >>> correlation_matrix = df.corr()
    >>> correlation_matrix["corr_var"] = correlation_matrix.index
    >>> poller = civis.io.dataframe_to_civis(df=df,
-   ...                                      database="database")
+   ...                                      database="database",
    ...                                      table="my_schema.my_correlations")
    >>> poller.result()
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -29,7 +29,7 @@ uploads the data back into Civis:
    ...                          use_pandas=True)
    >>> correlation_matrix = df.corr()
    >>> correlation_matrix["corr_var"] = correlation_matrix.index
-   >>> poller = civis.io.dataframe_to_civis(df=df,
+   >>> poller = civis.io.dataframe_to_civis(df=correlation_matrix,
    ...                                      database="database",
    ...                                      table="my_schema.my_correlations")
    >>> poller.result()


### PR DESCRIPTION
Found a small error in the user_guide documentation.  This fixes that error.

In the process of this PR, a new version of `flake8` came out which caused the code to fail tests.  Those changes were addressed in #3.  However, that prompted me to pin the versions of dev requirements (which is also included in this PR).