### PR TITLE
MAINT Be less strict with requirements

### DIFF
--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -53,6 +53,7 @@ class YAMLParamType(click.ParamType):
         except Exception:
             self.fail("Could not load YAML from path: %s", value)
 
+
 YAML = YAMLParamType()
 
 

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -97,5 +97,6 @@ class TestPolling(unittest.TestCase):
             polling_interval=0.1)
         pytest.raises(ZeroDivisionError, pollable.result, timeout=5)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/civis/tests/testcase.py
+++ b/civis/tests/testcase.py
@@ -43,6 +43,8 @@ def github_serialize(cassette_dict, serializer):
         'recorded_with': 'VCR'
     }
     return serializer.serialize(data)
+
+
 persist.serialize = github_serialize
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml>=3.0,<=3.99
 click>=6.0,<=6.99
 jsonref>=0.1.0,<=0.1.99
-requests==2.7.0
-jsonschema==2.5.1
+requests>=2.7.0,==2.*
+jsonschema>=2.5.1,==2.*


### PR DESCRIPTION
We don't need to pin to specific minor and micro versions of `requests` and `pyyaml`. Tell pip that it's okay to have newer versions of those libraries with the same major version.