### PR TITLE
Use 'all' resources when generating local docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ database = client.databases.list()
 See the [full documentation](https://civis-python.readthedocs.io) for a more
 complete user guide.
 
+# Build Documentation Locally
+To build the API documentation locally
+
+```bash
+cd docs
+make html
+```
+
+Then open `docs/build/html/index.html`.
+
+Note that this will use your API key in the `CIVIS_API_KEY` environment
+variable so it will generate documentation for all the endpoints that you have access to.
 
 # Contributing
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -384,7 +384,7 @@ else:
     user_agent = "civis-python/SphinxDocs"
     api_version = "1.0"
     extra_classes = civis.resources._resources.generate_classes(
-        api_key=api_key, user_agent=user_agent, api_version=api_version)
+        api_key=api_key, user_agent=user_agent, api_version=api_version, resources='all')
 sorted_class_names = sorted(extra_classes.keys())
 
 civis.APIClient.__doc__ += _make_attr_docs(sorted_class_names,


### PR DESCRIPTION
This will ensure the local documentation generated includes all the resources the current user has access to