### PR TITLE
Files Endpoint -- Stream large files in civis.io.file_to_civis

### DIFF
--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -5,6 +5,12 @@ import requests
 from civis import APIClient
 from civis.base import EmptyResultError
 
+try:
+    from requests_toolbelt.multipart.encoder import MultipartEncoder
+    NO_TOOLBELT = False
+except ImportError:
+    NO_TOOLBELT = True
+
 
 def file_to_civis(buf, name, api_key=None, **kwargs):
     """Upload a file to Civis.
@@ -43,7 +49,13 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
     form_key['file'] = buf
 
     url = file_response.upload_url
-    response = requests.post(url, files=form_key)
+
+    if NO_TOOLBELT:
+        response = requests.post(url, files=form_key)
+    else:
+        encoder = MultipartEncoder(form_key)
+        response = requests.post(url, data=encoder, headers={'Content-Type': encoder.content_type})
+
     response.raise_for_status()
 
     return file_response.id

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -54,7 +54,8 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
         response = requests.post(url, files=form_key)
     else:
         encoder = MultipartEncoder(form_key)
-        response = requests.post(url, data=encoder, headers={'Content-Type': encoder.content_type})
+        header = {'Content-Type': encoder.content_type}
+        response = requests.post(url, data=encoder, headers=header)
 
     response.raise_for_status()
 

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import requests
 
+from io import TextIOBase
 from civis import APIClient
 from civis.base import EmptyResultError
 
@@ -50,7 +51,7 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
 
     url = file_response.upload_url
 
-    if NO_TOOLBELT:
+    if NO_TOOLBELT or isinstance(buf, TextIOBase):
         response = requests.post(url, files=form_key)
     else:
         encoder = MultipartEncoder(form_key)


### PR DESCRIPTION
Currently when you post a file using the `civis.io.file_to_civis` function, the entire file must be able to fit into memory. This can cause problems when running jobs on resource-limited hosts.

This PR allows for streaming the upload if the `requests_toolbelt` extension library is installed.