### PR TITLE
Return a valid Response object on None responses

### DIFF
--- a/civis/base.py
+++ b/civis/base.py
@@ -65,9 +65,6 @@ class Endpoint:
             response = self._session.request(method, url, json=data,
                                              params=params, **kwargs)
 
-        if response.status_code in [204, 205]:
-            return
-
         if response.status_code == 401:
             auth_error = response.headers["www-authenticate"]
             raise CivisAPIKeyError(auth_error) from CivisAPIError(response)

--- a/civis/tests/test_response.py
+++ b/civis/tests/test_response.py
@@ -19,6 +19,14 @@ def _create_mock_response(data, headers):
     mock_response = mock.MagicMock(spec=requests.Response)
     mock_response.json.return_value = data
     mock_response.headers = headers
+    mock_response.status_code = 200
+    return mock_response
+
+
+def _create_empty_response(code, headers):
+    mock_response = mock.MagicMock(spec=requests.Response)
+    mock_response.status_code = code
+    mock_response.headers = headers
     return mock_response
 
 
@@ -69,9 +77,18 @@ def test_pagination():
 
 
 def test_response_to_json_no_error():
-    raw_response = mock.MagicMock()
-    raw_response.json.return_value = {'key': 'value'}
+    raw_response = _create_mock_response({'key': 'value'}, None)
     assert _response_to_json(raw_response) == {'key': 'value'}
+
+
+def test_response_to_no_content_snake():
+    for code in [204, 205]:
+        raw_response = _create_empty_response(code, {'header1': 'val1'})
+        data = convert_response_data_type(raw_response, return_type='snake')
+
+        assert isinstance(data, Response)
+        assert data.json_data is None
+        assert data.headers == {'header1': 'val1'}
 
 
 def test_response_to_json_parsing_error():


### PR DESCRIPTION
### Issue

If a 204/205 response is returned from the API, and the client is set to the default return type of `'snake'`, an exception would be thrown.

### Solution

This PR returns a valid civis.response.Response object from these responses.  The `json_data` attribute is set to `None` to disambiguate empty JSON responses from no content responses.

An alternative is to propagate the `None` value back to the user, instead of returning a `Response` object.  This is significantly easier, but loses the response headers.  I'm not opposed to switching to that approach if we think it would be better.