### PR TITLE
ENH Switch "archive" to "hidden"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ swagger.json
 # Sphinx docs
 docs/source/generated/
 docs/source/api_resources.rst
+
+# IDEs
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
+### Changed
+- civis.io functions use the "hidden" API option to keep jobs out of the UI. Deprecate the "archive" parameter in favor of "hidden".
+- civis.io.query_civis now has a "hidden" parameter which defaults to True
 
 ## 1.1.0 - 2016-12-09
 ### Changed

--- a/civis/io/_databases.py
+++ b/civis/io/_databases.py
@@ -5,7 +5,8 @@ from civis.polling import PollableResult, _DEFAULT_POLLING_INTERVAL
 
 def query_civis(sql, database, api_key=None, credential_id=None,
                 preview_rows=10,
-                polling_interval=_DEFAULT_POLLING_INTERVAL):
+                polling_interval=_DEFAULT_POLLING_INTERVAL,
+                hidden=True):
     """Execute a SQL statement as a Civis query.
 
     Run a query that may return no results or where only a small
@@ -29,6 +30,8 @@ def query_civis(sql, database, api_key=None, credential_id=None,
         returned at once.
     polling_interval : int or float, optional
         Number of seconds to wait between checks for query completion.
+    hidden : bool, optional
+        If ``True`` (the default), this job will not appear in the Civis UI.
 
     Returns
     -------
@@ -43,8 +46,11 @@ def query_civis(sql, database, api_key=None, credential_id=None,
     client = APIClient(api_key=api_key)
     database_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
-    resp = client.queries.post(database_id, sql, preview_rows,
-                               credential=cred_id)
+    resp = client.queries.post(database_id,
+                               sql,
+                               preview_rows,
+                               credential=cred_id,
+                               hidden=hidden)
     return PollableResult(client.queries.get, (resp.id, ), polling_interval)
 
 


### PR DESCRIPTION
For the `civis.io` functions, change the `archive` parameter (this ran a callback which archived the script after completion) to `hidden`. Instead of archiving scripts when they finish, hide them on creation. This is what the `archive` parameter had been trying to accomplish. Setting `hidden` keeps the scripts from cluttering the UI while leaving them accessible to e.g. status queries from the API. We also save the latency of an extra API call on script completion.

This PR also adds the `hidden` option to the `query_civis` function, which didn't have it before.