### PR TITLE
[CIVP-9993] Default Credential: use default=true option in LIST request

### DIFF
--- a/civis/civis.py
+++ b/civis/civis.py
@@ -244,7 +244,6 @@ class MetaMixin():
         """The current user's default credential."""
         # NOTE: this should be optional to endpoints...so this could go away
         creds = self.credentials.list(default=True)
-        cred = creds[0]
         return creds[0]['id'] if len(creds) > 0 else None
 
     @property

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -243,9 +243,9 @@ class MetaMixin():
     def default_credential(self):
         """The current user's default credential."""
         # NOTE: this should be optional to endpoints...so this could go away
-        cred = find_one(self.credentials.list(), remote_host_id=None,
-                        username=self.username, type='Database')
-        return cred.id
+        creds = self.credentials.list(default=True)
+        cred = creds[0]
+        return creds[0]['id'] if len(creds) > 0 else None
 
     @property
     @functools.lru_cache()


### PR DESCRIPTION
The GET `/credentials` endpoint is now paginated. So it is possible your default credential is not in the first page of results when doing a GET on `/credential`s. However, there is a request param you can use to ensure you get the default credential so we should use that in the `default_credential` helper method.