### PR TITLE
[CIVP-10002] Cache swagger generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - civis.io functions use the "hidden" API option to keep jobs out of the UI. Deprecate the "archive" parameter in favor of "hidden".
 - civis.io.query_civis now has a "hidden" parameter which defaults to True
 
+### Performance Enhancements
+- Decrease time required to create client objects from ~0.6 seconds to ~150 us for all objects after the first in a session
+
 ## 1.1.0 - 2016-12-09
 ### Changed
 - civis.io reads/writes to/from memory instead of disk where appropriate

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -418,6 +418,7 @@ def get_swagger_spec(api_key, user_agent, api_version):
     return spec
 
 
+@lru_cache(maxsize=4)
 def generate_classes(api_key, user_agent, api_version="1.0", resources="base"):
     """ Dynamically create classes to interface with the Civis API.
 


### PR DESCRIPTION
The API endpoints returned by the Platform were already being cached, but parsing the results of this call takes > 0.5 seconds. Caching the result of the entire swagger-parsing process is memory-cheap and gives a 1000x decrease in time required to create identical client objects. Creation is now ~150 us, fast enough that we can re-create client objects as needed with no performance overhead.