### PR TITLE
Update documentation: docs/index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,7 @@ Open ``.bash_profile`` in TextEdit:
 
 Then add the following line, replacing ``api_key_here`` with your key::
 
-   CIVIS_API_KEY="api_key_here"
+   export CIVIS_API_KEY="api_key_here"
 
 **Linux**
 
@@ -73,7 +73,7 @@ Open ``.bash_profile`` in your favorite editor (nano is used here):
 
 Then add the following line, replacing ``api_key_here`` with your key::
 
-   CIVIS_API_KEY="api_key_here"
+   export CIVIS_API_KEY="api_key_here"
 
 
 User Guide


### PR DESCRIPTION
Without the `export ` it doesn't work.  John Means and @dianecarroll encountered this difficulty when trying to set up from docs.