### PR TITLE
Use Endpoint._base_url when fetching swagger

### DIFF
--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -409,7 +409,7 @@ def get_swagger_spec(api_key, user_agent, api_version):
     session.auth = (api_key, '')
     session.headers.update({"User-Agent": user_agent.strip()})
     if api_version == "1.0":
-        response = session.get("https://api.civisanalytics.com/endpoints")
+        response = session.get("{}endpoints".format(Endpoint._base_url))
     else:
         msg = "swagger spec for api version {} cannot be found"
         raise ValueError(msg.format(api_version))


### PR DESCRIPTION
The url for fetching the swagger was harcoded in `civis/resources/_resources.py`. Using `Endpoint._base_url` in case the url ever changes we only need to update it in one place.