### PR TITLE
[CIVP-10187] Dynamically decide between polling and notifications

### DIFF
--- a/civis/base.py
+++ b/civis/base.py
@@ -10,6 +10,7 @@ FAILED = ['failed']
 NOT_FINISHED = ['queued', 'running']
 CANCELLED = ['cancelled']
 DONE = FINISHED + FAILED + CANCELLED
+_DEFAULT_POLLING_INTERVAL = 15
 
 # Translate Civis state strings into `future` state strings
 STATE_TRANS = {}
@@ -132,7 +133,7 @@ class CivisAsyncResultBase(futures.Future):
         super().__init__()
         self.poller = poller
         self.poller_args = poller_args
-        self.polling_interval = polling_interval
+        self.polling_interval = polling_interval or _DEFAULT_POLLING_INTERVAL
         self.api_key = api_key
 
     def __repr__(self):
@@ -186,7 +187,7 @@ class CivisAsyncResultBase(futures.Future):
 
     @property
     def _state(self):
-        """State of the PollableResult in `future` language."""
+        """State of the CivisAsyncResultBase in `future` language."""
         with self._condition:
             return STATE_TRANS[self._civis_state]
 

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -4,7 +4,7 @@ import io
 from civis import APIClient
 from civis._utils import maybe_get_random_name
 from civis.base import EmptyResultError
-from civis.polling import PollableResult, _DEFAULT_POLLING_INTERVAL
+from civis.result import make_platform_future
 import requests
 import warnings
 
@@ -28,8 +28,10 @@ DELIMITERS = {
 
 def read_civis(table, database, columns=None, use_pandas=False,
                job_name=None, api_key=None, credential_id=None,
-               polling_interval=_DEFAULT_POLLING_INTERVAL,
-               archive=False, hidden=True, **kwargs):
+               polling_interval=None,
+               archive=False,
+               hidden=True,
+               **kwargs):
     """Read data from a Civis table.
 
     Parameters
@@ -113,8 +115,10 @@ def read_civis(table, database, columns=None, use_pandas=False,
 
 def read_civis_sql(sql, database, use_pandas=False, job_name=None,
                    api_key=None, credential_id=None,
-                   polling_interval=_DEFAULT_POLLING_INTERVAL,
-                   archive=False, hidden=True, **kwargs):
+                   polling_interval=None,
+                   archive=False,
+                   hidden=True,
+                   **kwargs):
     """Read data from Civis using a custom SQL string.
 
     Parameters
@@ -190,16 +194,17 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
     script_id, run_id = _sql_script(client, sql, database,
                                     job_name, credential_id,
                                     hidden=hidden)
-    poll = PollableResult(client.scripts.get_sql_runs,
-                          (script_id, run_id),
-                          polling_interval)
+    result = make_platform_future(client.scripts.get_sql_runs,
+                                  (script_id, run_id),
+                                  polling_interval=polling_interval,
+                                  api_key=api_key)
     if archive:
 
         def f(x):
             return client.scripts.put_sql_archive(script_id, True)
 
-        poll.add_done_callback(f)
-    poll.result()
+        result.add_done_callback(f)
+    result.result()
     outputs = client.scripts.get_sql_runs(script_id, run_id)["output"]
     if not outputs:
         raise EmptyResultError("Query {} returned no output."
@@ -216,7 +221,7 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
 
 def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
                  credential_id=None, archive=False, hidden=True,
-                 polling_interval=_DEFAULT_POLLING_INTERVAL):
+                 polling_interval=None):
     """Export data from Civis to a local CSV file.
 
     Parameters
@@ -245,14 +250,14 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
 
     Returns
     -------
-    results : :class:`~civis.polling.PollableResult`
-        A `PollableResult` object.
+    results : :class:`~civis.polling.PollableResult` or
+              :class:`~civis.pubnub.SubscribableResult`
 
     Examples
     --------
     >>> sql = "SELECT * FROM schema.table"
-    >>> poll = civis_to_csv("file.csv", sql, "my_database")
-    >>> poll.result()  # Wait for job to complete
+    >>> fut = civis_to_csv("file.csv", sql, "my_database")
+    >>> fut.result()  # Wait for job to complete
 
     See Also
     --------
@@ -266,26 +271,27 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
     script_id, run_id = _sql_script(client, sql, database,
                                     job_name, credential_id,
                                     hidden=hidden)
-    poll = PollableResult(client.scripts.get_sql_runs,
-                          (script_id, run_id),
-                          polling_interval)
+    result = make_platform_future(client.scripts.get_sql_runs,
+                                  (script_id, run_id),
+                                  polling_interval=polling_interval,
+                                  api_key=api_key)
     download = _download_callback(script_id, run_id, client, filename)
-    poll.add_done_callback(download)
+    result.add_done_callback(download)
     if archive:
 
         def f(x):
             return client.scripts.put_sql_archive(script_id, True)
 
-        poll.add_done_callback(f)
+        result.add_done_callback(f)
 
-    return poll
+    return result
 
 
 def dataframe_to_civis(df, database, table, api_key=None,
                        max_errors=None, existing_table_rows="fail",
                        distkey=None, sortkey1=None, sortkey2=None,
                        headers=None, credential_id=None,
-                       polling_interval=_DEFAULT_POLLING_INTERVAL,
+                       polling_interval=None,
                        archive=False, hidden=True, **kwargs):
     """Upload a `pandas` `DataFrame` into a Civis table.
 
@@ -333,16 +339,16 @@ def dataframe_to_civis(df, database, table, api_key=None,
 
     Returns
     -------
-    poll : :class:`~civis.polling.PollableResult`
-        A `PollableResult` object.
+    results : :class:`~civis.polling.PollableResult` or
+              :class:`~civis.pubnub.SubscribableResult`
 
     Examples
     --------
     >>> import pandas as pd
     >>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
-    >>> poller = civis.io.dataframe_to_civis(df, 'my-database',
-    ...                                      'scratch.df_table')
-    >>> poller.result()
+    >>> fut = civis.io.dataframe_to_civis(df, 'my-database',
+    ...                                   'scratch.df_table')
+    >>> fut.result()
     """
     if archive:
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
@@ -364,7 +370,7 @@ def csv_to_civis(filename, database, table, api_key=None,
                  distkey=None, sortkey1=None, sortkey2=None,
                  delimiter=",", headers=None,
                  credential_id=None,
-                 polling_interval=_DEFAULT_POLLING_INTERVAL,
+                 polling_interval=None,
                  archive=False, hidden=True):
     """Upload the contents of a local CSV file to Civis.
 
@@ -411,8 +417,8 @@ def csv_to_civis(filename, database, table, api_key=None,
 
     Returns
     -------
-    results : :class:`~civis.polling.PollableResult`
-        A `PollableResult` object.
+    results : :class:`~civis.polling.PollableResult` or
+              :class:`~civis.pubnub.SubscribableResult`
 
     Notes
     -----
@@ -422,10 +428,10 @@ def csv_to_civis(filename, database, table, api_key=None,
     --------
     >>> with open('input_file.csv', 'w') as _input:
     ...     _input.write('a,b,c\\n1,2,3')
-    >>> poller = civis.io.csv_to_civis('input_file.csv',
-    ...                                'my-database',
-    ...                                'scratch.my_data')
-    >>> poller.result()
+    >>> fut = civis.io.csv_to_civis('input_file.csv',
+    ...                             'my-database',
+    ...                             'scratch.my_data')
+    >>> fut.result()
     """
     if archive:
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
@@ -503,13 +509,14 @@ def _import_bytes(buf, database, table, api_key, max_errors,
     run_job_result = client._session.post(import_job.run_uri)
     run_job_result.raise_for_status()
     run_info = run_job_result.json()
-    poll = PollableResult(client.imports.get_files_runs,
-                          (run_info['importId'], run_info['id']),
-                          polling_interval=polling_interval)
+    result = make_platform_future(client.imports.get_files_runs,
+                                  (run_info['importId'], run_info['id']),
+                                  polling_interval=polling_interval,
+                                  api_key=api_key)
     if archive:
 
         def f(x):
             return client.imports.put_archive(import_job.id, True)
 
-        poll.add_done_callback(f)
-    return poll
+        result.add_done_callback(f)
+    return result

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -2,10 +2,8 @@ from concurrent import futures
 import time
 
 from civis.base import CivisJobFailure, CivisAsyncResultBase, FAILED, DONE
+from civis.base import _DEFAULT_POLLING_INTERVAL
 from civis.response import Response
-
-
-_DEFAULT_POLLING_INTERVAL = 15
 
 
 class PollableResult(CivisAsyncResultBase):
@@ -14,6 +12,12 @@ class PollableResult(CivisAsyncResultBase):
     This class will begin polling immediately upon creation, and poll for
     job completion once every `polling_interval` seconds until the job
     completes in Civis.
+
+    .. note:: Functions should create instances of this class through
+              the `civis.results.make_platform_future` function.
+              That will automatically select the more performant
+              :class:`~civis.pubnub.SubscribableResult`
+              when available and otherwise fall back on this class.
 
     Parameters
     ----------

--- a/civis/pubnub.py
+++ b/civis/pubnub.py
@@ -35,6 +35,12 @@ class SubscribableResult(CivisAsyncResultBase):
     This class will subscribe to a Pubnub channel upon creation, and listen
     for messages that indicate a job completion.
 
+    .. note:: Functions should create instances of this class through
+              the `civis.results.make_platform_future` function.
+              That will automatically select this class
+              when available and otherwise fall back on the
+              :class:`~civis.polling.PollableResult`.
+
     Parameters
     ----------
     poller : func

--- a/civis/result.py
+++ b/civis/result.py
@@ -1,0 +1,51 @@
+from civis import APIClient
+from civis.pubnub import has_pubnub, SubscribableResult
+from civis.polling import PollableResult
+
+
+def make_platform_future(poller, poller_args,
+                         polling_interval=None,
+                         api_key=None):
+    """Return the best Future subclass for monitoring your Civis job
+
+    This function checks the local environment to see if
+    the `pubnub` package is installed (required to use the
+    notifications API endpoint) and the "channels" API endpoint
+    is accessible. If so, you get a
+    :class:`~civis.pubnub.SubscribableResult`.
+    This is faster and uses fewer API calls.
+    If `pubnub` is not available, the result is a
+    :class:`~civis.polling.PollableResult`, which uses API calls
+    to determine when a run completes.
+
+    Parameters
+    ----------
+    poller : func
+        A function which returns an object that has a ``state`` attribute.
+    poller_args : tuple
+        The arguments with which to call the poller function.
+    polling_interval : int or float, optional
+        This is not used by SubscribableResult, but is required to match the
+        interface from CivisAsyncResultBase.
+    api_key : str, optional
+        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
+        environment variable will be used.
+
+    Returns
+    -------
+    :class:`~civis.polling.PollableResult` or
+    :class:`~civis.pubnub.SubscribableResult`
+
+    See Also
+    --------
+    :class:`~civis.base.CivisAsyncResultBase`
+    """
+    client = APIClient(api_key=api_key, resources='all')
+    if has_pubnub and hasattr(client, 'channels'):
+        klass = SubscribableResult
+    else:
+        klass = PollableResult
+    return klass(poller=poller,
+                 poller_args=poller_args,
+                 polling_interval=polling_interval,
+                 api_key=api_key)

--- a/civis/tests/test_result.py
+++ b/civis/tests/test_result.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+from civis import result
+
+
+@mock.patch.object(result, 'has_pubnub', True)
+@mock.patch.object(result, 'APIClient', mock.Mock())
+@mock.patch.object(result, 'SubscribableResult')
+@mock.patch.object(result, 'PollableResult')
+def test_pubnub_available(mock_pollable, mock_subscribable):
+    mock_poller = mock.Mock()
+    out = result.make_platform_future(mock_poller, 11,
+                                      polling_interval=29,
+                                      api_key='secret')
+
+    assert mock_pollable.call_count == 0
+    mock_subscribable.assert_called_once_with(poller=mock_poller,
+                                              poller_args=11,
+                                              polling_interval=29,
+                                              api_key='secret')
+    assert out == mock_subscribable()
+
+
+@mock.patch.object(result, 'has_pubnub', False)
+@mock.patch.object(result, 'APIClient', mock.Mock())
+@mock.patch.object(result, 'SubscribableResult')
+@mock.patch.object(result, 'PollableResult')
+def test_pubnub_not_available(mock_pollable, mock_subscribable):
+    mock_poller = mock.Mock()
+    out = result.make_platform_future(mock_poller, 11,
+                                      polling_interval=29,
+                                      api_key='secret')
+
+    assert mock_subscribable.call_count == 0
+    mock_pollable.assert_called_once_with(poller=mock_poller,
+                                          poller_args=11,
+                                          polling_interval=29,
+                                          api_key='secret')
+    assert out == mock_pollable()

--- a/civis/utils/_jobs.py
+++ b/civis/utils/_jobs.py
@@ -1,15 +1,18 @@
 from civis import APIClient
-from civis.polling import PollableResult
-from civis.pubnub import SubscribableResult, has_pubnub
+from civis.result import make_platform_future
 
 
-def run_job(job_id, api_key=None):
+def run_job(job_id, polling_interval=None, api_key=None):
     """Run a job.
 
     Parameters
     ----------
     job_id : str or int
         The ID of the job.
+    polling_interval : int or float
+        The number of seconds between API requests to check whether
+        a result is ready. Used only if the notifications endpoint
+        is not available.
     api_key : str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.
@@ -23,8 +26,6 @@ def run_job(job_id, api_key=None):
     """
     client = APIClient(api_key=api_key, resources='all')
     run = client.jobs.post_runs(job_id)
-    if 'pubnub' in client.feature_flags and has_pubnub:
-        return SubscribableResult(client.jobs.get_runs,
-                                  (job_id, run['id']),
-                                  api_key=api_key)
-    return PollableResult(client.jobs.get_runs, (job_id, run['id']))
+    return make_platform_future(client.jobs.get_runs, (job_id, run['id']),
+                                polling_interval=polling_interval,
+                                api_key=api_key)

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -29,29 +29,42 @@ uploads the data back into Civis:
    ...                          use_pandas=True)
    >>> correlation_matrix = df.corr()
    >>> correlation_matrix["corr_var"] = correlation_matrix.index
-   >>> poller = civis.io.dataframe_to_civis(df=correlation_matrix,
-   ...                                      database="database",
-   ...                                      table="my_schema.my_correlations")
-   >>> poller.result()
+   >>> fut = civis.io.dataframe_to_civis(df=correlation_matrix,
+   ...                                   database="database",
+   ...                                   table="my_schema.my_correlations")
+   >>> fut.result()
 
 
-Pollable Results
-================
+Civis Platform Futures
+======================
 
 In the code above, :func:`~civis.io.dataframe_to_civis` returns a special
-:class:`~civis.polling.PollableResult` object. Making a request to the Civis
+:class:`~civis.polling.PollableResult` or
+:class:`~civis.pubnub.SubscribableResult` object.
+Making a request to the Civis
 API usually results in a long running job. To account for this, various
 functions in the ``civis`` namespace return a
-:class:`PollableResult <civis.polling.PollableResult>` to allow you to
+subclass of the :class:`python:concurrent.futures.Future` to allow you to
 process multiple long running jobs simultaneously. For instance, you may
 want to start many jobs in parallel and wait for them all to finish rather
 than wait for each job to finish before starting the next one.
 
-The :class:`PollableResult <civis.polling.PollableResult>` follows the
+The Civis API classes follow the
 :class:`python:concurrent.futures.Future` API fairly closely. For example,
-calling ``result()`` on ``poller`` above forces the program to wait for the
+calling ``result()`` on ``fut`` above forces the program to wait for the
 job started with :func:`~civis.io.dataframe_to_civis` to finish and
 returns the result.
+
+The difference between the two classes,
+:class:`~civis.polling.PollableResult` and
+:class:`~civis.pubnub.SubscribableResult`, is in how they check
+for job completion. The :class:`~civis.polling.PollableResult` always
+works, but it relies on periodically polling the Civis Platform
+to check for run completion. The :class:`~civis.pubnub.SubscribableResult`
+requires an optional external package, ``pubnub``, but can see
+jobs complete immediately instead of waiting for the next ping.
+The Civis API Python client will automatically select the
+:class:`~civis.pubnub.SubscribableResult` if it's available.
 
 
 Working Directly with the Client


### PR DESCRIPTION
Now that the `pubnub.SubscribableResult` is available, create a function `result.make_platform_future` which instantiates either a new `SubscribableResult` (if `pubnub` is available and the user has access to the notifications endpoint) or a `PollableResult` object. We should prefer to use the `SubscribableResult`, since notifications are much faster (we don't have to wait for polling) and greatly decrease API traffic.