### PR TITLE
Clear LRU cache on test cases that mock swagger spec

### DIFF
--- a/civis/tests/test_client.py
+++ b/civis/tests/test_client.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 from civis import APIClient
+from civis.resources._resources import get_swagger_spec, generate_classes
 from civis.tests.testcase import CivisVCRTestCase
 
 swagger_import_str = 'civis.resources._resources.get_swagger_spec'
@@ -13,6 +14,16 @@ with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
 
 
 class ClientTests(CivisVCRTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
 
     @patch(swagger_import_str, return_value=civis_api_spec)
     def test_feature_flags(self, *mocks):

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -15,6 +15,7 @@ except ImportError:
     has_pandas = False
 
 import civis
+from civis.resources._resources import get_swagger_spec, generate_classes
 from civis.tests.testcase import (CivisVCRTestCase,
                                   cassette_dir,
                                   conditionally_patch)
@@ -30,6 +31,16 @@ with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
                      return_value=True)
 @patch(swagger_import_str, return_value=civis_api_spec)
 class ImportTests(CivisVCRTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
 
     @classmethod
     @conditionally_patch('civis.polling.time.sleep', return_value=None)

--- a/civis/tests/test_pubnub.py
+++ b/civis/tests/test_pubnub.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from civis.base import CivisJobFailure
+from civis.resources._resources import get_swagger_spec, generate_classes
 try:
     from civis.pubnub import (SubscribableResult,
                               has_pubnub,
@@ -23,6 +24,17 @@ with open(os.path.join(THIS_DIR, "civis_api_spec_channels.json")) as f:
 
 
 class PubnubTests(CivisVCRTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        get_swagger_spec.cache_clear()
+        generate_classes.cache_clear()
+
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     def test_listener_calls_callback_when_message_matches(self):
         match = mock.Mock()


### PR DESCRIPTION
There was a transient test failure where the `get_swagger_spec` and `generate_classes` functions would not use the expected swagger mock. In the tests, there are 2 swagger specs: one is the base spec, the other is the base + channels. Different test files will mock different swagger specs, but since the `get_swagger_spec` and `generate_classes` functions use an LRU cache, the cached value would persist between tests which would cause a failure on Pubnub tests when the base swagger spec is cached.

The fix for this is clearing the LRU cache on these functions on setup and tear down of the classes that mock the swagger spec.