### PR TITLE
[CIVP-10066] Catch unexpected keyword arguments passed to methods

### DIFF
--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -256,8 +256,8 @@ def raise_for_unexpected_kwargs(method_name, arguments, sig_args, sig_kwargs,
         expected |= {'iterator'}
     unexpected = set(arguments.keys()) - expected
     if unexpected:
-        msg_fmt = "{}() got an unexpected keyword argument '{}'"
-        raise TypeError(msg_fmt.format(method_name, next(iter(unexpected))))
+        msg_fmt = "{}() got an unexpected keyword argument(s) {}"
+        raise TypeError(msg_fmt.format(method_name, str(unexpected)))
 
 
 def bracketed(x):

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -223,27 +223,41 @@ def create_method(params, verb, method_name, path, doc):
         A function which will make an API call
     """
     elements = split_method_params(params)
-    args, kwargs, body_params, query_params, path_params = elements
-    sig = create_signature(args, kwargs)
+    sig_args, sig_kwargs, body_params, query_params, path_params = elements
+    sig = create_signature(sig_args, sig_kwargs)
+    is_iterable = iterable_method(verb, query_params)
 
     def f(self, *args, **kwargs):
         arguments = sig.bind(*args, **kwargs).arguments
         if arguments.get("kwargs"):
             arguments.update(arguments.pop("kwargs"))
+        raise_for_unexpected_kwargs(method_name, arguments, sig_args,
+                                    sig_kwargs, is_iterable)
         body = {x: arguments[x] for x in body_params if x in arguments}
         query = {x: arguments[x] for x in query_params if x in arguments}
         path_vals = {x: arguments[x] for x in path_params if x in arguments}
         url = path.format(**path_vals) if path_vals else path
-        iterator = (arguments.get('iterator', False) and
-                    iterable_method(verb, query_params))
+        iterator = arguments.get('iterator', False)
         return self._call_api(verb, url, query, body, iterator=iterator)
 
     # Add signature to function, including 'self' for class method
-    sig_self = create_signature(["self"] + args, kwargs)
+    sig_self = create_signature(["self"] + sig_args, sig_kwargs)
     f.__signature__ = sig_self
     f.__doc__ = doc
     f.__name__ = method_name
     return f
+
+
+def raise_for_unexpected_kwargs(method_name, arguments, sig_args, sig_kwargs,
+                                is_iterable):
+    """Raise TypeError if arguments are not in sig_args or sig_kwargs."""
+    expected = set(sig_args) | set(sig_kwargs)
+    if is_iterable:
+        expected |= {'iterator'}
+    unexpected = set(arguments.keys()) - expected
+    if unexpected:
+        msg_fmt = "{}() got an unexpected keyword argument '{}'"
+        raise TypeError(msg_fmt.format(method_name, next(iter(unexpected))))
 
 
 def bracketed(x):

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -237,7 +237,7 @@ def test_create_method_unexpected_kwargs():
     # Method works without unexpected kwarg
     method(mock_endpoint, foo=0, bar=0)
     mock_endpoint._call_api.assert_called_once_with(
-        'get', '/objects', {"foo":0, "bar": 0}, {}, iterator=False)
+        'get', '/objects', {"foo": 0, "bar": 0}, {}, iterator=False)
 
     # Method raises TypeError with unexpected kwarg
     expected_msg = "mock_name() got an unexpected keyword argument 'baz'"

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -55,7 +55,8 @@ def test_create_method_iterator_kwarg():
 
 def test_create_method_no_iterator_kwarg():
 
-    # Test for TypeError when iterator is present and no **kwargs
+    # Test that dynamically-created function errors when an
+    # unexpected "iterator" parameter is passed in
     args = [{"name": 'id', "in": 'query', "required": True, "doc": ""}]
     method = _resources.create_method(args, 'get', 'mock_name', '/objects',
                                       'fake_doc')
@@ -66,8 +67,8 @@ def test_create_method_no_iterator_kwarg():
 
     assert 'keyword argument' in str(excinfo.value)
 
-    # Test for TypeError when iterator is present and method takes **kwargs,
-    # but iterator is not valid
+    # Dynamic functions handle optional argument through a different
+    # code path; verify that this also rejects unexpected arguments.
     args2 = [{"name": 'foo', "in": 'query', "required": False, "doc": ""}]
     method2 = _resources.create_method(args2, 'get', 'mock_name', '/objects',
                                        'fake_doc')
@@ -240,7 +241,7 @@ def test_create_method_unexpected_kwargs():
         'get', '/objects', {"foo": 0, "bar": 0}, {}, iterator=False)
 
     # Method raises TypeError with unexpected kwarg
-    expected_msg = "mock_name() got an unexpected keyword argument 'baz'"
+    expected_msg = "mock_name() got an unexpected keyword argument(s) {'baz'}"
     with pytest.raises(TypeError) as excinfo:
         method(mock_endpoint, foo=0, bar=0, baz=0)
     assert str(excinfo.value) == expected_msg


### PR DESCRIPTION
Currently, API resource methods take optional parameters in the form of `**kwargs` in the method signature.  This is convenient for parsing the API specification, but can produce unexpected behavior when an unexpected keyword argument is passed into the method.  Instead of alerting the user that the argument is unexpected, it is simply ignored (causing some confusion).  This change adds an explicit check on all method calls for unexpected arguments so that they may be caught earlier.