### PR TITLE
Removing intersphinx references

### DIFF
--- a/civis/civis.py
+++ b/civis/civis.py
@@ -264,12 +264,12 @@ class APIClient(MetaMixin):
     return_type : str, optional
         The following types are implemented:
 
-        - ``'raw'`` Returns the raw :class:`requests:requests.Response` object.
+        - ``'raw'`` Returns the raw ``requests.Response`` object.
         - ``'snake'`` Returns a :class:`civis.response.Response` object for the
           json-encoded content of a response. This maps the top-level json
           keys to snake_case.
-        - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
-          list-like responses and a :class:`pandas:pandas.Series` for single a
+        - ``'pandas'`` Returns a ``pandas.DataFrame`` for
+          list-like responses and a ``pandas.Series`` for single a
           json response.
     retry_total : int, optional
         A number indicating the maximum number of retries for 429, 502, 503, or

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -45,7 +45,7 @@ def read_civis(table, database, columns=None, use_pandas=False,
         A list of column names. Column SQL transformations are possible.
         If omitted, all columns are exported.
     use_pandas : bool, optional
-        If ``True``, return a :class:`pandas:pandas.DataFrame`. Otherwise,
+        If ``True``, return a ``pandas.DataFrame``. Otherwise,
         return a list of results from :func:`python:csv.reader`.
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
@@ -64,15 +64,15 @@ def read_civis(table, database, columns=None, use_pandas=False,
         If ``True`` (the default), this job will not appear in the Civis UI.
     **kwargs : kwargs
         Extra keyword arguments are passed into
-        :func:`pandas:pandas.read_csv` if `use_pandas` is ``True`` or
+        ``pandas.read_csv`` if `use_pandas` is ``True`` or
         passed into :func:`python:csv.reader` if `use_pandas` is
         ``False``.
 
     Returns
     -------
-    data : :class:`pandas:pandas.DataFrame` or list
+    data : ``pandas.DataFrame`` or list
         A list of rows (with header as first row) if `use_pandas` is
-        ``False``, otherwise a `pandas` `DataFrame`. Note that if
+        ``False``, otherwise a ``pandas.DataFrame``. Note that if
         `use_pandas` is ``False``, no parsing of types is performed and
         each row will be a list of strings.
 
@@ -127,7 +127,7 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
         Execute the query against this database. Can be the database name
         or ID.
     use_pandas : bool, optional
-        If ``True``, return a :class:`pandas:pandas.DataFrame`. Otherwise,
+        If ``True``, return a ``pandas.DataFrame``. Otherwise,
         return a list of results from :func:`python:csv.reader`.
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
@@ -146,15 +146,15 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
         If ``True`` (the default), this job will not appear in the Civis UI.
     **kwargs : kwargs
         Extra keyword arguments are passed into
-        :func:`pandas:pandas.read_csv` if `use_pandas` is ``True`` or
+       ``pandas.read_csv`` if `use_pandas` is ``True`` or
         passed into :func:`python:csv.reader` if `use_pandas` is
         ``False``.
 
     Returns
     -------
-    data : :class:`pandas:pandas.DataFrame` or list
+    data : ``pandas.DataFrame`` or list
         A list of rows (with header as first row) if `use_pandas` is
-        ``False``, otherwise a `pandas` `DataFrame`. Note that if
+        ``False``, otherwise a ``pandas.DataFrame``. Note that if
         `use_pandas` is ``False``, no parsing of types is performed and
         each row will be a list of strings.
 
@@ -400,7 +400,7 @@ def dataframe_to_civis(df, database, table, api_key=None,
 
     Parameters
     ----------
-    df : :class:`pandas:pandas.DataFrame`
+    df : ``pandas.DataFrame``
         The `DataFrame` to upload to Civis.
     database : str or int
         Upload data into this database. Can be the database name or ID.
@@ -438,7 +438,7 @@ def dataframe_to_civis(df, database, table, api_key=None,
         If ``True`` (the default), this job will not appear in the Civis UI.
     **kwargs : kwargs
         Extra keyword arguments will be passed to
-        :meth:`pandas:pandas.DataFrame.to_csv`.
+        ``pandas.DataFrame.to_csv``.
 
     Returns
     -------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,9 +40,7 @@ extensions = [
 autosummary_generate = True
 
 intersphinx_mapping = {
-    'pandas': ('http://pandas.pydata.org/pandas-docs/stable', None),
     'python': ('https://docs.python.org/3.4', None),
-    'requests': ('https://requests.readthedocs.org/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
References to 3rd party documentation is occasionally causing build errors.  The upside from having the linked documentation is probably not worth the downside of having nondeterministic errors, so I'm removing the links in this PR to `pandas` and `requests` libraries.