### PR TITLE
ENH Use requests-toolbelt for streaming uploads of Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Performance Enhancements
+- ``civis.io.file_to_civis`` will perform a streaming upload to Platform if the optional ``requests-toolbelt`` package is installed.
 
 ## 1.2.0 - 2017-02-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ requests directly to the Civis API. See the
     ```
     pip install civis
     ```
-6. Optionally, install `pandas` to enable some functionality in `civis-python`
+6. Optionally, install `pandas` and `requests-toolbelt` to enable some functionality in `civis-python`
 
     ```
     pip install pandas
+    pip install requests-toolbelt
     ```
 
 # Usage

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -6,9 +6,9 @@ from civis import APIClient
 from civis.base import EmptyResultError
 try:
     from requests_toolbelt.multipart.encoder import MultipartEncoder
-    has_toolbelt = True
+    HAS_TOOLBELT = True
 except ImportError:
-    has_toolbelt = False
+    HAS_TOOLBELT = False
 
 
 def file_to_civis(buf, name, api_key=None, **kwargs):
@@ -66,7 +66,7 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
     form_key['file'] = buf
 
     url = file_response.upload_url
-    if has_toolbelt:
+    if HAS_TOOLBELT:
         # This streams from the open file buffer without holding the
         # contents in memory.
         en = MultipartEncoder(fields=form_key)

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -69,9 +69,14 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
     if has_toolbelt:
         # This streams from the open file buffer without holding the
         # contents in memory.
-        enc = MultipartEncoder(fields=form_key)
-        response = requests.post(url, data=enc,
-                                 headers={'Content-Type': enc.content_type})
+        en = MultipartEncoder(fields=form_key)
+        if en.len / 2 ** 20 < 100:
+            # Semi-arbitrary cutoff for "small" files.
+            # Send these with requests directly because that uses less CPU
+            response = requests.post(url, files=form_key)
+        else:
+            response = requests.post(url, data=en,
+                                     headers={'Content-Type': en.content_type})
     else:
         response = requests.post(url, files=form_key)
     response.raise_for_status()

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -4,6 +4,11 @@ import requests
 
 from civis import APIClient
 from civis.base import EmptyResultError
+try:
+    from requests_toolbelt.multipart.encoder import MultipartEncoder
+    has_toolbelt = True
+except ImportError:
+    has_toolbelt = False
 
 
 def file_to_civis(buf, name, api_key=None, **kwargs):
@@ -41,18 +46,34 @@ def file_to_civis(buf, name, api_key=None, **kwargs):
     If you are opening a binary file (e.g., a compressed archive) to
     pass to this function, do so using the ``'rb'`` (read binary)
     mode (e.g., ``open('myfile.zip', 'rb')``).
+
+    If you have the `requests-toolbelt` package installed
+    (`pip install requests-toolbelt`), then this function will stream
+    from the open file pointer into Platform. If `requests-toolbelt`
+    is not installed, then it will need to read the entire buffer
+    into memory before writing.
     """
     client = APIClient(api_key=api_key)
     file_response = client.files.post(name, **kwargs)
 
+    # Platform has given us a URL to which we can upload a file.
+    # The file must be uploaded with a POST formatted as per
+    # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+    # Note that the payload must have "key" first and "file" last.
     form = file_response.upload_fields
-    # order matters here! key must be first
     form_key = OrderedDict(key=form.pop('key'))
     form_key.update(form)
     form_key['file'] = buf
 
     url = file_response.upload_url
-    response = requests.post(url, files=form_key)
+    if has_toolbelt:
+        # This streams from the open file buffer without holding the
+        # contents in memory.
+        enc = MultipartEncoder(fields=form_key)
+        response = requests.post(url, data=enc,
+                                 headers={'Content-Type': enc.content_type})
+    else:
+        response = requests.post(url, files=form_key)
     response.raise_for_status()
 
     return file_response.id


### PR DESCRIPTION
If users have `requests-toolbelt` installed, then we can stream files into AWS without needing to read them into memory all at once. This allows users to upload files larger than they could have otherwise (e.g. tens of GB).