### PR TITLE
Allow tests to pass with warning in sphinx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
 before_script: flake8 civis
 script:
     - py.test --cov civis
-    - sphinx-build -b html -nW docs/source/ docs/build/
+    - sphinx-build -b html -n docs/source/ docs/build/


### PR DESCRIPTION
Moved from https://github.com/civisanalytics/civis-python/pull/34.  This relaxes our tests so that warnings from `sphinx_build` don't raise errors in Travis.  This is a work around to avoid non-deterministic network errors in the sphinx build.  An alternative approach would be to cache external doc resources in the repo and increase the complexity of docs, which seems to me to be worse than slightly relaxing our tests for doc building.