### PR TITLE
BUG Make sure that the CivisFuture always cleans up after exceptions

### DIFF
--- a/civis/futures.py
+++ b/civis/futures.py
@@ -1,6 +1,5 @@
 from civis import APIClient
-from civis.base import FAILED, DONE
-from civis.response import Response
+from civis.base import DONE
 from civis.polling import PollableResult
 
 try:
@@ -148,5 +147,4 @@ class CivisFuture(PollableResult):
                 result = self.poller(*self.poller_args)
                 self._set_api_result(result)
             except Exception as e:
-                self._result = Response({"state": FAILED[0]})
-                self.set_exception(e)
+                self._set_api_exception(exc=e)


### PR DESCRIPTION
There were a couple of circumstances where exceptions raised in polling could have left us still subscribed to the `pubnub` notifications channel. Refactor the exception setting so that it only happens in one place; that way we can be sure that `cleanup` always gets called.

After this change, there's now only one place where we call `set_exception`, just as there's only one place where we call `set_result`.