### PR TITLE
[CIVP-10381] Allow base url to be configured from environment variable

### DIFF
--- a/civis/base.py
+++ b/civis/base.py
@@ -1,3 +1,4 @@
+import os
 from posixpath import join
 import threading
 from concurrent import futures
@@ -19,6 +20,9 @@ for name in NOT_FINISHED:
     STATE_TRANS[name] = futures._base.RUNNING
 for name in CANCELLED:
     STATE_TRANS[name] = futures._base.CANCELLED_AND_NOTIFIED
+
+
+DEFAULT_API_ENDPOINT = 'https://api.civisanalytics.com/'
 
 
 def tostr_urljoin(*x):
@@ -60,14 +64,21 @@ class CivisAPIKeyError(Exception):
     pass
 
 
+def get_base_url():
+    base_url = os.environ.get('CIVIS_API_ENDPOINT', DEFAULT_API_ENDPOINT)
+    if not base_url.endswith('/'):
+        base_url += '/'
+    return base_url
+
+
 class Endpoint:
 
-    _base_url = "https://api.civisanalytics.com/"
     _lock = threading.Lock()
 
     def __init__(self, session, return_type='civis'):
         self._session = session
         self._return_type = return_type
+        self._base_url = get_base_url()
 
     def _build_path(self, path):
         if not path:

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -13,7 +13,7 @@ except ImportError:
 from jsonref import JsonRef
 import requests
 
-from civis.base import Endpoint
+from civis.base import Endpoint, get_base_url
 from civis._utils import camel_to_snake, to_camelcase
 
 
@@ -423,7 +423,7 @@ def get_swagger_spec(api_key, user_agent, api_version):
     session.auth = (api_key, '')
     session.headers.update({"User-Agent": user_agent.strip()})
     if api_version == "1.0":
-        response = session.get("{}endpoints".format(Endpoint._base_url))
+        response = session.get("{}endpoints".format(get_base_url()))
     else:
         msg = "swagger spec for api version {} cannot be found"
         raise ValueError(msg.format(api_version))

--- a/civis/tests/test_base.py
+++ b/civis/tests/test_base.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import requests
+
+from civis.base import Endpoint, get_base_url
+
+
+def test_base_url_default():
+    assert get_base_url() == 'https://api.civisanalytics.com/'
+
+
+def test_base_url_from_env():
+    custom_url = 'https://api1.civisanalytics.com'
+    with mock.patch.dict('os.environ', {'CIVIS_API_ENDPOINT': custom_url}):
+        assert get_base_url() == custom_url + '/'
+
+
+@mock.patch('civis.base.get_base_url', return_value='https://base.api.url/')
+def test_endpoint_base_url(mock_get_base_url):
+    session = mock.MagicMock(spec=requests.Session)
+    endpoint = Endpoint(session)
+
+    assert endpoint._base_url == 'https://base.api.url/'


### PR DESCRIPTION
Allow the base url of the API to be configured through the `CIVIS_API_ENDPOINT` environment variable.