### PR TITLE
ENH Allow use of existing client objects without re-creating

### DIFF
--- a/civis/tests/test_client.py
+++ b/civis/tests/test_client.py
@@ -39,3 +39,13 @@ class ClientTests(CivisVCRTestCase):
             client.feature_flags
             client.feature_flags
             self.assertEqual(client.users.list_me.call_count, 1)
+
+    def test_passthrough_creation_from_existing_client(self):
+        # If we input an existing client object, we should use that
+        # instead of creating a new object.
+        client = APIClient()
+        client2 = APIClient(client)
+        assert client2 is client
+
+        client3 = APIClient(api_key=client)
+        assert client3 is client


### PR DESCRIPTION
High-level functions and classes in this library all take `api_key` inputs and instantiate new `APIClient` objects, rather than allowing users to pass in an existing `APIClient` object. There are cases when it can be very helpful to be able to pass in existing client objects. The top two:
- Sometimes we have an `APIClient` but not an `api_key`. I've written `api_key=self.client._session.auth[0]` a couple of times in my code now, and that's not good practice.
- For testing, it's very helpful to be able to create one `APIClient` mock and pass that around. If all functions instantiate new objects, the `APIClient` needs to be patched separately in each module.

This PR modifies the `APIClient` so that if one provides an existing `APIClient` to the `api_key` parameter, that object will be used unchanged, rather than instantiating a new object.