### PR TITLE
ENH Improve wait-for-job completion in jobs wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Decorator function for deprecating parameters (#46)
+- ``wait`` parameter for function ``utils.run_job``
+- Function ``utils.wait_for_run``
 
 ## 1.3.0 - 2017-03-07
 ### Added

--- a/civis/utils/__init__.py
+++ b/civis/utils/__init__.py
@@ -1,3 +1,3 @@
-from ._jobs import run_job
+from ._jobs import run_job, wait_for_run
 
-__all__ = ["run_job"]
+__all__ = ["run_job", "wait_for_run"]

--- a/civis/utils/_jobs.py
+++ b/civis/utils/_jobs.py
@@ -4,18 +4,22 @@ from civis.utils._deprecation import deprecate_param
 
 
 @deprecate_param('v2.0.0', 'api_key')
-def run_job(job_id, api_key=None, client=None):
+def run_job(job_id, wait=False, api_key=None, client=None):
     """Run a job.
+
+    A "job" could be a Container Script, a Query, a Python 3 script, etc.
 
     Parameters
     ----------
     job_id : str or int
         The ID of the job.
+    wait : bool
+        If True, block until the run completes.
     api_key : DEPRECATED str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.
-    client : :class:`civis.APIClient`, optional
-        If not provided, an :class:`civis.APIClient` object will be
+    client : :class:`~civis.APIClient`, optional
+        If not provided, an :class:`~civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
 
     Returns
@@ -26,7 +30,41 @@ def run_job(job_id, api_key=None, client=None):
     if client is None:
         client = APIClient(api_key=api_key, resources='all')
     run = client.jobs.post_runs(job_id)
-    return CivisFuture(client.jobs.get_runs,
-                       (job_id, run['id']),
-                       client=client,
-                       poll_on_creation=False)
+    fut = CivisFuture(client.jobs.get_runs,
+                      (job_id, run['id']),
+                      client=client,
+                      poll_on_creation=False)
+    if wait:
+        fut.result()
+    return fut
+
+
+def wait_for_run(job_id, run_id, timeout=None, client=None):
+    """Wait for a run to complete
+
+    This can be any kind of run.
+
+    Parameters
+    ----------
+    job_id : str or int
+        The ID of the job.
+    run_id : str or int
+        The ID of the run.
+    timeout : float or int
+        If provided, raise a TimeoutError after this many seconds
+        if the run has not finished. Otherwise wait indefinitely.
+    client : :class:`~civis.APIClient`, optional
+        If not provided, an :class:`~civis.APIClient` object will be
+        created from the :envvar:`CIVIS_API_KEY`.
+
+    Returns
+    -------
+    results : :class:`~civis.response.Response`
+        The result of the ``jobs.get_runs`` call after the run has finished
+    """
+    if client is None:
+        client = APIClient(resources='all')
+    fut = CivisFuture(client.jobs.get_runs,
+                      (job_id, run_id),
+                      client=client)
+    return fut.result(timeout=timeout)


### PR DESCRIPTION
Add a `wait` parameter to the `utils.run_jobs`; users often want to immediately wait for completion after starting a run, so make that easy. Similarly, add a `wait_for_run` wrapper which handles creation of the `CivisFuture` and waiting for completion.