### PR TITLE
[CIVP-10635] Adding retries during the call to /endpoints in get_swagger_spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+Retries to http request in ``get_swagger_spec`` to make calls to ``APIClient`` robust to network failure
 
 ## 1.4.0 - 2017-03-17
 ### API Changes


### PR DESCRIPTION
This retries the call to `/endpoints` while instantiating the client for certain errors.   Another possible route might be to pass the `_session` object from `APIClient`, but this would prevent us from being able to memoize `generate_classes`.