### PR TITLE
[CIVP-10208] Retry all HTTP verbs with a Retry-After header and an approved error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 Retries to http request in ``get_swagger_spec`` to make calls to ``APIClient`` robust to network failure
 
+### Changed
+- Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.
+
 ## 1.4.0 - 2017-03-17
 ### API Changes
 - Deprecate ``api_key`` input to higher-level functions and classes in favor of an ``APIClient`` input. The ``api_key`` will be removed in v2.0.0. (#46)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ database = client.databases.list()
 See the [full documentation](https://civis-python.readthedocs.io) for a more
 complete user guide.
 
+## Retries
+
+The API client will automatically retry for certain API error responses.
+
+If the error is one of [413, 429, 503] and the API client is told how long it needs
+to wait before it's safe to retry (this is always the case with 429s, which are
+rate limit errors), then the client will wait the specified amount of time
+before retrying the request.
+
+If the error is one of [429, 502, 503, 504] and the request is not a `patch*` or `post*`
+method, then the API client will retry the request several times, with a delay,
+to see if it will succeed.
+
 # Build Documentation Locally
 To build the API documentation locally
 

--- a/civis/base.py
+++ b/civis/base.py
@@ -2,9 +2,14 @@ import os
 from posixpath import join
 import threading
 from concurrent import futures
+import logging
 import warnings
 
+from requests.packages.urllib3.util import Retry
+
 from civis.response import PaginatedResponse, convert_response_data_type
+
+log = logging.getLogger(__name__)
 
 FINISHED = ['success', 'succeeded']
 FINISHED = ['success', 'succeeded']
@@ -70,6 +75,29 @@ def get_base_url():
     if not base_url.endswith('/'):
         base_url += '/'
     return base_url
+
+
+class AggressiveRetry(Retry):
+    # Subclass Retry so that it retries more things. In particular,
+    # always retry API requests with a Retry-After header, regardless
+    # of the verb.
+    def is_retry(self, method, status_code, has_retry_after=False):
+        """ Is this method/status code retryable? (Based on whitelists and control
+        variables such as the number of total retries to allow, whether to
+        respect the Retry-After header, whether this header is present, and
+        whether the returned status code is on the list of status codes to
+        be retried upon on the presence of the aforementioned header)
+        """
+        if (self.total and
+                self.respect_retry_after_header and
+                has_retry_after and
+                (status_code in self.RETRY_AFTER_STATUS_CODES)):
+            log.debug("Retrying %s error from a %s call.", status_code, method)
+            return True
+
+        else:
+            return super().is_retry(method=method, status_code=status_code,
+                                    has_retry_after=has_retry_after)
 
 
 class Endpoint:

--- a/civis/base.py
+++ b/civis/base.py
@@ -2,16 +2,12 @@ import os
 from posixpath import join
 import threading
 from concurrent import futures
-import logging
 import warnings
 
 from requests.packages.urllib3.util import Retry
 
 from civis.response import PaginatedResponse, convert_response_data_type
 
-log = logging.getLogger(__name__)
-
-FINISHED = ['success', 'succeeded']
 FINISHED = ['success', 'succeeded']
 FAILED = ['failed']
 NOT_FINISHED = ['queued', 'running']
@@ -92,7 +88,6 @@ class AggressiveRetry(Retry):
                 self.respect_retry_after_header and
                 has_retry_after and
                 (status_code in self.RETRY_AFTER_STATUS_CODES)):
-            log.debug("Retrying %s error from a %s call.", status_code, method)
             return True
 
         else:

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -4,9 +4,9 @@ import os
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
 
 import civis
+from civis.base import AggressiveRetry
 from civis.resources import generate_classes
 
 
@@ -298,8 +298,8 @@ class APIClient(MetaMixin):
         user_agent = "civis-python/{} {}".format(civis_version, session_agent)
         session.headers.update({"User-Agent": user_agent.strip()})
 
-        max_retries = Retry(retry_total, backoff_factor=.75,
-                            status_forcelist=RETRY_CODES)
+        max_retries = AggressiveRetry(retry_total, backoff_factor=.75,
+                                      status_forcelist=RETRY_CODES)
         adapter = HTTPAdapter(max_retries=max_retries)
 
         session.mount("https://", adapter)

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -13,10 +13,9 @@ except ImportError:
 from jsonref import JsonRef
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
 
 import civis
-from civis.base import Endpoint, get_base_url
+from civis.base import AggressiveRetry, Endpoint, get_base_url
 from civis._utils import camel_to_snake, to_camelcase
 
 
@@ -426,8 +425,8 @@ def get_swagger_spec(api_key, user_agent, api_version):
     session = requests.Session()
     session.auth = (api_key, '')
     session.headers.update({"User-Agent": user_agent.strip()})
-    max_retries = Retry(MAX_RETRIES, backoff_factor=.75,
-                        status_forcelist=civis.civis.RETRY_CODES)
+    max_retries = AggressiveRetry(MAX_RETRIES, backoff_factor=.75,
+                                  status_forcelist=civis.civis.RETRY_CODES)
     adapter = HTTPAdapter(max_retries=max_retries)
     session.mount("https://", adapter)
     if api_version == "1.0":

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -77,12 +77,13 @@ class TestPolling(unittest.TestCase):
 
 def test_repeated_polling():
     # Verify that we poll the expected number of times.
+    poll_interval = 0.2
     poller = mock.Mock(return_value=Response({"state": "running"}))
-    pollable = PollableResult(poller, (), polling_interval=0.1)
+    pollable = PollableResult(poller, (), polling_interval=poll_interval)
     pollable.done()  # Check status once to start the polling thread
     assert poller.call_count == 1, "Poll once on the first status check"
-    time.sleep(0.25)
-    assert poller.call_count == 3, "After waiting 2.5x the polling interval"
+    time.sleep(2.2 * poll_interval)
+    assert poller.call_count == 3, "After waiting 2.2x the polling interval"
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml>=3.0,<=3.99
 click>=6.0,<=6.99
 jsonref>=0.1.0,<=0.1.99
-requests>=2.7.0,==2.*
+requests>=2.12.0,==2.*
 jsonschema>=2.5.1,==2.*


### PR DESCRIPTION
If we have a rate limit error (429) and a Retry-After header, it should always be safe to retry the request, regardless of the verb. The `Retry.is_retry` method starts by checking if the verb is on the whitelist (defaults to ['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE']) and immediately returns False if it is not. This PR changes our code so that we will retry on the `RETRY_AFTER_STATUS_CODES` ([413, 429, 503]) regardless of verb.

See https://github.com/shazow/urllib3/blob/50705abd83be4ad7997eeefe9e732564af1db118/urllib3/util/retry.py#L285L299 .

`urllib3` respects the "Retry-After" header starting at v1.19. We get `urllib3` from `requests`; `requests` updated `urllib3` to a compatible version at v2.12.0. Therefore this PR also needs to increase the version of `requests` which we require.