### PR TITLE
DOC Add `CivisFuture` to docs, remove `PollableResult`

### DIFF
--- a/civis/futures.py
+++ b/civis/futures.py
@@ -40,8 +40,8 @@ class CivisFuture(PollableResult):
     job completion events. If you don't have access to Pubnub channels, then
     it will fallback to polling.
 
-    This is a subclass of ``concurrent.futures.Future`` from the Python
-    standard library. See:
+    This is a subclass of :class:`python:concurrent.futures.Future` from the
+    Python standard library. See:
     https://docs.python.org/3/library/concurrent.futures.html
 
     Parameters
@@ -64,7 +64,8 @@ class CivisFuture(PollableResult):
 
     Examples
     --------
-    This example is provided as a function at ``civis.io.query_civis``.
+    This example is provided as a function at :func:`~civis.io.query_civis`.
+
     >>> client = civis.APIClient()
     >>> database_id = client.get_database_id("my_database")
     >>> cred_id = client.default_credential

--- a/docs/source/responses.rst
+++ b/docs/source/responses.rst
@@ -7,6 +7,5 @@ API Response Types
 .. autoclass:: civis.response.PaginatedResponse
    :members:
 
-.. autoclass:: civis.polling.PollableResult
-   :show-inheritance:
+.. autoclass:: civis.futures.CivisFuture
    :members:


### PR DESCRIPTION
Replace `PollableResult` with `CivisFuture` in the sphinx documentation.

<img width="819" alt="screen shot 2017-03-24 at 10 00 28 am" src="https://cloud.githubusercontent.com/assets/4984629/24300137/73eefc7e-1079-11e7-89e6-7703d4a737bd.png">
