### PR TITLE
Add file ID to multifile manifest

### DIFF
--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -402,11 +402,13 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
         raise EmptyResultError("Unload query {} returned no manifest."
                                .format(script_id))
 
+    manifest_file_id = outputs[0]['file_id']
     buf = io.BytesIO()
-    civis_to_file(outputs[0]['file_id'], buf)
+    civis_to_file(manifest_file_id, buf)
     txt = io.TextIOWrapper(buf, encoding='utf-8')
     txt.seek(0)
     unload_manifest = json.load(txt)
+    unload_manifest['file_id'] = manifest_file_id
 
     return unload_manifest
 

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -155,7 +155,7 @@ class ImportTests(CivisVCRTestCase):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
         result = civis.io.civis_to_multifile_csv(
             sql, database='redshift-general', polling_interval=POLL_INTERVAL)
-        assert set(result.keys()) == {'entries', 'query', 'header'}
+        assert set(result.keys()) == {'entries', 'query', 'header', 'file_id'}
         assert result['query'] == sql
         assert result['header'] == ['a', 'b', 'c']
         assert isinstance(result['entries'], list)


### PR DESCRIPTION
There is currently no logging available to store this but it is incredibly useful for anyone interested in replicating an analysis on the result of this unload.