### PR TITLE
[CIVP-10864] ENH: Error on file too large.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Corrected the defaults listed in the docstring for ``civis.io.civis_to_multifile_csv``.
+- Do not allow uploading of files greater than 5GB to S3 (#58).
 
 ### Changed
 - Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import requests
+from requests import HTTPError
 
 from civis import APIClient
 from civis.base import EmptyResultError
@@ -10,6 +11,26 @@ try:
     HAS_TOOLBELT = True
 except ImportError:
     HAS_TOOLBELT = False
+
+
+def _get_aws_error_message(response):
+    # NOTE: This is cribbed from response.raise_for_status with AWS
+    # message appended
+    msg = ''
+
+    if 400 <= response.status_code < 500:
+        msg = '%s Client Error: %s for url: %s' % (response.status_code,
+                                                   response.reason,
+                                                   response.url)
+
+    elif 500 <= response.status_code < 600:
+        msg = '%s Server Error: %s for url: %s' % (response.status_code,
+                                                   response.reason,
+                                                   response.url)
+
+    msg += '\nAWS Content: %s' % response.content
+
+    return msg
 
 
 @deprecate_param('v2.0.0', 'api_key')
@@ -89,7 +110,12 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
                                      headers={'Content-Type': en.content_type})
     else:
         response = requests.post(url, files=form_key)
-    response.raise_for_status()
+
+    if not response.ok:
+        # Amazon gives back informative error messages
+        # http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+        msg = _get_aws_error_message(response)
+        raise HTTPError(msg, response=response)
 
     return file_response.id
 


### PR DESCRIPTION
We can't upload files larger than 5GB to s3. Also, AWS provides more informative errors than what requests will raise by default.