### PR TITLE
[CIVP-10867] Use cache to create APIClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Retries to http request in ``get_swagger_spec`` to make calls to ``APIClient`` robust to network failure
+- Parameter ``local_api_spec`` to ``APIClient`` to allow creation of client from local cache
 
 ### Fixed
 - Corrected the defaults listed in the docstring for ``civis.io.civis_to_multifile_csv``.

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -314,7 +314,6 @@ class APIClient(MetaMixin):
 
         classes = generate_classes_maybe_cached(local_api_spec,
                                                 session_auth_key,
-                                                user_agent,
                                                 api_version,
                                                 resources)
         for class_name, cls in classes.items():

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -7,7 +7,7 @@ from requests.adapters import HTTPAdapter
 
 import civis
 from civis.base import AggressiveRetry
-from civis.resources._resources import generate_classes_maybe_cached
+from civis.resources import generate_classes_maybe_cached
 
 
 log = logging.getLogger(__name__)

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -7,7 +7,7 @@ from requests.adapters import HTTPAdapter
 
 import civis
 from civis.base import AggressiveRetry
-from civis.resources import generate_classes
+from civis.resources._resources import generate_classes_maybe_cached
 
 
 log = logging.getLogger(__name__)
@@ -282,9 +282,17 @@ class APIClient(MetaMixin):
         client object. Set to "all" to include all endpoints available for
         a given user, including those that may be in development and subject
         to breaking changes at a later date.
+    local_api_spec : collections.OrderedDict or string, optional
+        The methods on this class are dynamically built from the Civis API
+        specification, which can be retrieved from the /endpoints endpoint.
+        When local_api_spec is None, the default, this specification is
+        downloaded the first time APIClient is instantiated. Alternatively,
+        a local cache of the specification may be passed as either an
+        OrderedDict or a filename which points to a json file.
     """
     def __init__(self, api_key=None, return_type='snake',
-                 retry_total=6, api_version="1.0", resources="base"):
+                 retry_total=6, api_version="1.0", resources="base",
+                 local_api_spec=None):
         if return_type not in ['snake', 'raw', 'pandas']:
             raise ValueError("Return type must be one of 'snake', 'raw', "
                              "'pandas'")
@@ -304,10 +312,11 @@ class APIClient(MetaMixin):
 
         session.mount("https://", adapter)
 
-        classes = generate_classes(api_key=session_auth_key,
-                                   user_agent=user_agent,
-                                   api_version=api_version,
-                                   resources=resources)
+        classes = generate_classes_maybe_cached(local_api_spec,
+                                                session_auth_key,
+                                                user_agent,
+                                                api_version,
+                                                resources)
         for class_name, cls in classes.items():
             setattr(self, class_name, cls(session, return_type))
 

--- a/civis/resources/__init__.py
+++ b/civis/resources/__init__.py
@@ -1,3 +1,3 @@
-from ._resources import generate_classes
+from ._resources import generate_classes, get_api_spec
 
-__all__ = ["generate_classes"]
+__all__ = ["generate_classes", "get_api_spec"]

--- a/civis/resources/__init__.py
+++ b/civis/resources/__init__.py
@@ -4,4 +4,4 @@ from ._resources import (generate_classes,
 
 __all__ = ["generate_classes",
            "get_api_spec",
-           "generate_classes_maybed_cached"]
+           "generate_classes_maybe_cached"]

--- a/civis/resources/__init__.py
+++ b/civis/resources/__init__.py
@@ -1,3 +1,7 @@
-from ._resources import generate_classes, get_api_spec
+from ._resources import (generate_classes,
+                         get_api_spec,
+                         generate_classes_maybe_cached)
 
-__all__ = ["generate_classes", "get_api_spec"]
+__all__ = ["generate_classes",
+           "get_api_spec",
+           "generate_classes_maybed_cached"]

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -424,7 +424,6 @@ def parse_api_spec(api_spec, api_version, resources):
         client object.  Set to "all" to include all endpoints available for
         a given user, including those that may be in development and subject
         to breaking changes at a later date.
-
     """
     paths = api_spec['paths']
     classes = {}

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -444,8 +444,7 @@ def get_api_spec(api_key, user_agent, api_version):
     Parameters
     ----------
     api_key : str
-        Your API key obtained from the Civis Platform. If not given, the
-        client will use the :envvar:`CIVIS_API_KEY` environment variable.
+        Your API key obtained from the Civis Platform.
     user_agent : str
         The user agent used in the request to get api endpoint specification.
     api_version : string, optional

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -221,7 +221,7 @@ def test_expired_api_key(mock_response):
     msg = "401 error downloading API specification. API key may be expired."
     http_error_raised = False
     try:
-        _resources.get_api_spec("expired_key", "fake_user_agent", "1.0")
+        _resources.get_api_spec("expired_key", "1.0")
     except HTTPError as err:
         http_error_raised = True
         assert str(err) == msg
@@ -250,33 +250,31 @@ def test_create_method_unexpected_kwargs():
 @mock.patch('builtins.open', new_callable=mock.mock_open,
             read_data='{"test": true}')
 @mock.patch('civis.resources._resources.generate_classes')
-@mock.patch('civis.resources._resources.parse_swagger')
+@mock.patch('civis.resources._resources.parse_api_spec')
 def test_generate_classes_maybe_cached(mock_parse, mock_gen, mock_open):
     api_key = "mock"
-    user_agent = "mock"
     api_version = "1.0"
     resources = "all"
 
     # Calls generate_classes when no cache is passed
-    _resources.generate_classes_maybe_cached(None, api_key, user_agent,
-                                             api_version, resources)
-    mock_gen.assert_called_once_with(api_key, user_agent, api_version,
-                                     resources)
+    _resources.generate_classes_maybe_cached(None, api_key, api_version,
+                                             resources)
+    mock_gen.assert_called_once_with(api_key, api_version, resources)
 
     # Handles OrderedDict
     spec = OrderedDict({"test": True})
-    _resources.generate_classes_maybe_cached(spec, api_key, user_agent,
-                                             api_version, resources)
+    _resources.generate_classes_maybe_cached(spec, api_key, api_version,
+                                             resources)
     mock_parse.assert_called_once_with(spec, api_version, resources)
 
     # Handles str
     mock_parse.reset_mock()
-    _resources.generate_classes_maybe_cached('mock', api_key, user_agent,
-                                             api_version, resources)
+    _resources.generate_classes_maybe_cached('mock', api_key, api_version,
+                                             resources)
     mock_parse.assert_called_once_with(spec, api_version, resources)
 
     # Error when a regular dict is passed
     bad_spec = {"test": True}
     with pytest.raises(ValueError):
-        _resources.generate_classes_maybe_cached(bad_spec, api_key, user_agent,
+        _resources.generate_classes_maybe_cached(bad_spec, api_key,
                                                  api_version, resources)

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -249,8 +249,8 @@ def test_create_method_unexpected_kwargs():
 
 @mock.patch('builtins.open', new_callable=mock.mock_open,
             read_data='{"test": true}')
-@mock.patch('civis.resources._resources.generate_classes')
-@mock.patch('civis.resources._resources.parse_api_spec')
+@mock.patch('civis.resources._resources.generate_classes', autospec=True)
+@mock.patch('civis.resources._resources.parse_api_spec', autospec=True)
 def test_generate_classes_maybe_cached(mock_parse, mock_gen, mock_open):
     api_key = "mock"
     api_version = "1.0"
@@ -260,18 +260,21 @@ def test_generate_classes_maybe_cached(mock_parse, mock_gen, mock_open):
     _resources.generate_classes_maybe_cached(None, api_key, api_version,
                                              resources)
     mock_gen.assert_called_once_with(api_key, api_version, resources)
+    mock_gen.reset_mock()
 
     # Handles OrderedDict
     spec = OrderedDict({"test": True})
     _resources.generate_classes_maybe_cached(spec, api_key, api_version,
                                              resources)
     mock_parse.assert_called_once_with(spec, api_version, resources)
+    assert not mock_gen.called
 
     # Handles str
     mock_parse.reset_mock()
     _resources.generate_classes_maybe_cached('mock', api_key, api_version,
                                              resources)
     mock_parse.assert_called_once_with(spec, api_version, resources)
+    assert not mock_gen.called
 
     # Error when a regular dict is passed
     bad_spec = {"test": True}

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -12,6 +12,30 @@ requests are made with the following syntax:
    client = civis.APIClient()
    response = client.resource.method(params)
 
+The methods on :class:`~civis.APIClient` are created dynamically at runtime
+by parsing an :class:`python:collections.OrderedDict` representation of the
+Civis API specification.  By default, this specification is downloaded from
+the ``/endpoints`` endpoint the first time :class:`~civis.APIClient` is
+instantiated (and cached in memory for the remainder of the program's run).
+In some circumstances, it may be useful to use a local cache of the API
+specification rather than downloading the spec.  This can be done by passing
+the specification to the client through the parameter ``local_api_spec`` as
+either the :class:`python:collections.OrderedDict` or a filename where the
+specification has been saved.
+
+.. code-block:: python
+
+   api_key = os.environ['CIVIS_API_KEY']
+   spec = civis.resources.get_swagger_spec(api_key)
+
+   # From OrderedDict
+   client = civis.APIClient(local_api_spec=spec)
+
+   # From file
+   with open('local_api_spec.json', 'w') as f:
+       json.dump(spec, f)
+   client = civis.APIClient(local_api_spec='local_api_spec.json')
+
 .. currentmodule:: civis
 
 .. autoclass:: civis.APIClient

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -26,7 +26,7 @@ specification has been saved.
 .. code-block:: python
 
    api_key = os.environ['CIVIS_API_KEY']
-   spec = civis.resources.get_swagger_spec(api_key)
+   spec = civis.resources.get_api_spec(api_key)
 
    # From OrderedDict
    client = civis.APIClient(local_api_spec=spec)


### PR DESCRIPTION
This PR adds the parameter `local_api_spec` to `APIClient` to allow users to create a client object from a local cache of the Civis API specification.  This parameter can be either an OrderedDict or a string which points to a file of the specification (parsing expects an order to the specification, hence why a regular dict cannot be used).

I'm also exposing `get_swagger_spec` in `civis.resources` as the intended workflow is to call `get_swagger_spec` to download the specification for caching.