### PR TITLE
REF: Refactoring out use of 'swagger'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.
 - Add CSV settings arguments to ``civis.io.civis_to_csv`` function.
+- Refactored used of "swagger" language.  ``get_swagger_spec`` is now ``get_api_spec`` and ``parse_swagger`` is now ``parse_api_spec``.
 
 ## 1.4.0 - 2017-03-17
 ### API Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.
 - Add CSV settings arguments to ``civis.io.civis_to_csv`` function.
-- Refactored used of "swagger" language.  ``get_swagger_spec`` is now ``get_api_spec`` and ``parse_swagger`` is now ``parse_api_spec``.
+- Refactored use of "swagger" language.  ``get_swagger_spec`` is now ``get_api_spec`` and ``parse_swagger`` is now ``parse_api_spec``.
 
 ## 1.4.0 - 2017-03-17
 ### API Changes

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -403,12 +403,12 @@ def parse_path(path, operations, api_version, resources):
     return class_name, methods
 
 
-def parse_swagger(swagger, api_version, resources):
-    """ Parse a swagger specifiction into a dictionary of classes
+def parse_api_spec(api_spec, api_version, resources):
+    """ Parse the Civis API specifiction into a dictionary of classes
     where each class represents an endpoint resource and contains
     methods to make http requests on that resource.
     """
-    paths = swagger['paths']
+    paths = api_spec['paths']
     classes = {}
     for path, ops in paths.items():
         class_name, methods = parse_path(path, ops, api_version, resources)
@@ -421,7 +421,7 @@ def parse_swagger(swagger, api_version, resources):
 
 
 @lru_cache(maxsize=4)
-def get_swagger_spec(api_key, user_agent, api_version):
+def get_api_spec(api_key, user_agent, api_version):
     session = requests.Session()
     session.auth = (api_key, '')
     session.headers.update({"User-Agent": user_agent.strip()})
@@ -432,7 +432,7 @@ def get_swagger_spec(api_key, user_agent, api_version):
     if api_version == "1.0":
         response = session.get("{}endpoints".format(get_base_url()))
     else:
-        msg = "swagger spec for api version {} cannot be found"
+        msg = "API specification for api version {} cannot be found"
         raise ValueError(msg.format(api_version))
     if response.status_code in (401, 403):
         msg = "{} error downloading API specification. API key may be expired."
@@ -473,6 +473,6 @@ def generate_classes(api_key, user_agent, api_version="1.0", resources="base"):
         "APIClient api_version must be one of {}".format(API_VERSIONS))
     assert resources in ["base", "all"], (
         "resources must be one of {}".format(["base", "all"]))
-    raw_swagger = get_swagger_spec(api_key, user_agent, api_version)
-    swagger = JsonRef.replace_refs(raw_swagger)
-    return parse_swagger(swagger, api_version, resources)
+    raw_spec = get_api_spec(api_key, user_agent, api_version)
+    spec = JsonRef.replace_refs(raw_spec)
+    return parse_api_spec(spec, api_version, resources)

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -404,7 +404,7 @@ def parse_path(path, operations, api_version, resources):
 
 
 def parse_api_spec(api_spec, api_version, resources):
-    """ Parse the Civis API specifiction into a dictionary of classes
+    """ Parse the Civis API specification into a dictionary of classes
     where each class represents an endpoint resource and contains
     methods to make http requests on that resource.
     """

--- a/civis/tests/test_client.py
+++ b/civis/tests/test_client.py
@@ -4,10 +4,10 @@ import json
 from unittest.mock import patch
 
 from civis import APIClient
-from civis.resources._resources import get_swagger_spec, generate_classes
+from civis.resources._resources import get_api_spec, generate_classes
 from civis.tests.testcase import CivisVCRTestCase
 
-swagger_import_str = 'civis.resources._resources.get_swagger_spec'
+api_import_str = 'civis.resources._resources.get_api_spec'
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
     civis_api_spec = json.load(f, object_pairs_hook=OrderedDict)
@@ -17,22 +17,22 @@ class ClientTests(CivisVCRTestCase):
 
     @classmethod
     def setUpClass(cls):
-        get_swagger_spec.cache_clear()
+        get_api_spec.cache_clear()
         generate_classes.cache_clear()
 
     @classmethod
     def tearDownClass(cls):
-        get_swagger_spec.cache_clear()
+        get_api_spec.cache_clear()
         generate_classes.cache_clear()
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_feature_flags(self, *mocks):
         client = APIClient()
         feature_flags = client.feature_flags
         expected = ('python_3_scripts', 'container_scripts', 'pubnub')
         self.assertCountEqual(feature_flags, expected)
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_feature_flags_memoized(self, *mocks):
         client = APIClient()
         with patch.object(client.users, 'list_me', wraps=client.users.list_me):

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from civis.base import CivisJobFailure
-from civis.resources._resources import get_swagger_spec, generate_classes
+from civis.resources._resources import get_api_spec, generate_classes
 try:
     from civis.futures import (CivisFuture,
                                has_pubnub,
@@ -18,7 +18,7 @@ except ImportError:
 
 from civis.tests.testcase import CivisVCRTestCase
 
-swagger_import_str = 'civis.resources._resources.get_swagger_spec'
+api_import_str = 'civis.resources._resources.get_api_spec'
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
     civis_api_spec_base = json.load(f, object_pairs_hook=OrderedDict)
@@ -29,8 +29,8 @@ with open(os.path.join(THIS_DIR, "civis_api_spec_channels.json")) as f:
 
 def clear_lru_cache():
     # LRU cache persists between tests so these caches need to be cleared
-    # when different swagger specs are used in different test cases
-    get_swagger_spec.cache_clear()
+    # when different api specs are used in different test cases
+    get_api_spec.cache_clear()
     generate_classes.cache_clear()
 
 
@@ -71,7 +71,7 @@ class CivisFutureTests(CivisVCRTestCase):
         self.assertEqual(callback.call_count, 0)
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_check_message(self, *mocks):
         result = CivisFuture(lambda x: x, (1, 20))
@@ -87,7 +87,7 @@ class CivisFutureTests(CivisVCRTestCase):
         self.assertTrue(result._check_message(message))
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_check_message_with_different_run_id(self, *mocks):
         result = CivisFuture(lambda x: x, (1, 20))
@@ -103,7 +103,7 @@ class CivisFutureTests(CivisVCRTestCase):
         self.assertFalse(result._check_message(message))
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_check_message_when_job_is_running(self, *mocks):
         result = CivisFuture(lambda x: x, (1, 20))
@@ -119,7 +119,7 @@ class CivisFutureTests(CivisVCRTestCase):
         self.assertFalse(result._check_message(message))
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_set_api_result_result_succeeded(self, mock_subscribe, mock_api):
         mock_pubnub = mock.Mock()
@@ -136,7 +136,7 @@ class CivisFutureTests(CivisVCRTestCase):
         assert result._state == 'FINISHED'
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_set_api_result_failed(self, mock_subscribe, mock_api):
         mock_pubnub = mock.Mock()
@@ -154,7 +154,7 @@ class CivisFutureTests(CivisVCRTestCase):
             result.result()
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_channels(self, *mocks):
         future = CivisFuture(lambda x: x,
@@ -163,7 +163,7 @@ class CivisFutureTests(CivisVCRTestCase):
         assert future.subscribed is True
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_no_subscription(self, *mocks):
         future = CivisFuture(lambda x: x,
@@ -172,7 +172,7 @@ class CivisFutureTests(CivisVCRTestCase):
         assert future.subscribed is False
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_base)
+    @patch(api_import_str, return_value=civis_api_spec_base)
     @patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_no_channels(self, *mocks):
         clear_lru_cache()
@@ -182,7 +182,7 @@ class CivisFutureTests(CivisVCRTestCase):
         clear_lru_cache()
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_overwrite_polling_interval_with_channels(self, *mocks):
         future = CivisFuture(lambda x: x, (1, 20))
@@ -190,7 +190,7 @@ class CivisFutureTests(CivisVCRTestCase):
         assert hasattr(future, '_pubnub')
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_channels)
+    @patch(api_import_str, return_value=civis_api_spec_channels)
     @patch.object(CivisFuture, '_subscribe')
     def test_explicit_polling_interval_with_channels(self, *mocks):
         future = CivisFuture(lambda x: x, (1, 20), polling_interval=5)
@@ -198,11 +198,11 @@ class CivisFutureTests(CivisVCRTestCase):
         assert hasattr(future, '_pubnub')
 
     @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec_base)
+    @patch(api_import_str, return_value=civis_api_spec_base)
     @patch.object(CivisFuture, '_subscribe')
     def test_polling_interval(self, *mocks):
         # This tests the fallback to polling when channels is not available.
-        # It uses a different swagger spec than the other tests so it
+        # It uses a different api spec than the other tests so it
         # should clear the cached values before and after
         clear_lru_cache()
 

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -15,18 +15,18 @@ except ImportError:
     has_pandas = False
 
 import civis
-from civis.resources._resources import get_swagger_spec, generate_classes
+from civis.resources._resources import get_api_spec, generate_classes
 from civis.tests.testcase import (CivisVCRTestCase,
                                   cassette_dir,
                                   POLL_INTERVAL)
 
-swagger_import_str = 'civis.resources._resources.get_swagger_spec'
+api_import_str = 'civis.resources._resources.get_api_spec'
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
     civis_api_spec = json.load(f, object_pairs_hook=OrderedDict)
 
 
-@patch(swagger_import_str, return_value=civis_api_spec)
+@patch(api_import_str, return_value=civis_api_spec)
 class ImportTests(CivisVCRTestCase):
     # Note that all functions tested here should use a
     # `polling_interval=POLL_INTERVAL` input. This lets us use
@@ -35,16 +35,16 @@ class ImportTests(CivisVCRTestCase):
 
     @classmethod
     def setUpClass(cls):
-        get_swagger_spec.cache_clear()
+        get_api_spec.cache_clear()
         generate_classes.cache_clear()
 
     @classmethod
     def tearDownClass(cls):
-        get_swagger_spec.cache_clear()
+        get_api_spec.cache_clear()
         generate_classes.cache_clear()
 
     @classmethod
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def setup_class(cls, *mocks):
         setup_vcr = vcr.VCR(filter_headers=['Authorization'])
         setup_cassette = os.path.join(cassette_dir(), 'io_setup.yml')
@@ -84,20 +84,20 @@ class ImportTests(CivisVCRTestCase):
 
             cls.export_job_id = result.sql_id
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_get_url_from_file_id(self, *mocks):
         client = civis.APIClient()
         url = civis.io._files._get_url_from_file_id(self.file_id, client)
         assert url.startswith('https://civis-console.s3.amazonaws.com/files/')
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_civis_to_file(self, *mocks):
         buf = BytesIO()
         civis.io.civis_to_file(self.file_id, buf)
         buf.seek(0)
         assert buf.read() == b'a,b,c\n1,2,3'
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_csv_to_civis(self, *mocks):
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(b'a,b,c\n1,2,3')
@@ -114,7 +114,7 @@ class ImportTests(CivisVCRTestCase):
         assert result.state == 'succeeded'
 
     @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_read_civis_pandas(self, *mocks):
         expected = pd.DataFrame([[1, 2, 3]], columns=['a', 'b', 'c'])
         df = civis.io.read_civis('scratch.api_client_test_fixture',
@@ -122,7 +122,7 @@ class ImportTests(CivisVCRTestCase):
                                  polling_interval=POLL_INTERVAL)
         assert df.equals(expected)
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_read_civis_no_pandas(self, *mocks):
         expected = [['a', 'b', 'c'], ['1', '2', '3']]
         data = civis.io.read_civis('scratch.api_client_test_fixture',
@@ -130,7 +130,7 @@ class ImportTests(CivisVCRTestCase):
                                    polling_interval=POLL_INTERVAL)
         assert data == expected
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_read_civis_sql(self, *mocks):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
         expected = [['a', 'b', 'c'], ['1', '2', '3']]
@@ -140,7 +140,7 @@ class ImportTests(CivisVCRTestCase):
         assert data == expected
 
     @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_dataframe_to_civis(self, *mocks):
         df = pd.DataFrame([['1', '2', '3']], columns=['a', 'b', 'c'])
         result = civis.io.dataframe_to_civis(df, 'redshift-general',
@@ -150,7 +150,7 @@ class ImportTests(CivisVCRTestCase):
         result = result.result()
         assert result.state == 'succeeded'
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_civis_to_multifile_csv(self, *mocks):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
         result = civis.io.civis_to_multifile_csv(
@@ -165,7 +165,7 @@ class ImportTests(CivisVCRTestCase):
                                                              'console.s3.'
                                                              'amazonaws.com/')
 
-    @patch(swagger_import_str, return_value=civis_api_spec)
+    @patch(api_import_str, return_value=civis_api_spec)
     def test_transfer_table(self, *mocks):
         result = civis.io.transfer_table('redshift-general', 'redshift-test',
                                          'scratch.api_client_test_fixture',

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -196,7 +196,7 @@ def test_parse_method_name():
     assert c == "list_containers_id_shares"
 
 
-def test_duplicate_names_generated_from_swagger():
+def test_duplicate_names_generated_from_api_spec():
     resolved_civis_api_spec = JsonRef.replace_refs(civis_api_spec)
     paths = resolved_civis_api_spec['paths']
     classes = defaultdict(list)
@@ -221,7 +221,7 @@ def test_expired_api_key(mock_response):
     msg = "401 error downloading API specification. API key may be expired."
     http_error_raised = False
     try:
-        _resources.get_swagger_spec("expired_key", "fake_user_agent", "1.0")
+        _resources.get_api_spec("expired_key", "fake_user_agent", "1.0")
     except HTTPError as err:
         http_error_raised = True
         assert str(err) == msg

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -374,12 +374,12 @@ if _test_build:
 
     this_dir = os.path.dirname(os.path.realpath(__file__))
     test_dir = os.path.join(this_dir, os.pardir, os.pardir, 'civis', 'tests')
-    swagger_path = os.path.join(test_dir, 'civis_api_spec.json')
-    with open(swagger_path) as _raw:
-        swagger = JsonRef.replace_refs(
+    api_path = os.path.join(test_dir, 'civis_api_spec.json')
+    with open(api_path) as _raw:
+        api_spec = JsonRef.replace_refs(
             json.load(_raw, object_hook=OrderedDict))
-    extra_classes = civis.resources._resources.parse_swagger(
-        swagger, '1.0', 'base')
+    extra_classes = civis.resources._resources.parse_api_spec(
+        api_spec, '1.0', 'base')
 else:
     api_key = os.environ.get("CIVIS_API_KEY")
     user_agent = "civis-python/SphinxDocs"


### PR DESCRIPTION
The Swagger Specification has been renamed to OpenAPI Specification.  This PR removes references of "swagger" to make the code more clear.