### PR TITLE
DOC Add note about index to dataframe_to_civis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Retries to http request in ``get_swagger_spec`` to make calls to ``APIClient`` robust to network failure
 - Parameter ``local_api_spec`` to ``APIClient`` to allow creation of client from local cache
+- Clarify ``civis.io.dataframe_to_civis`` docstring with a note about treatment of the index.
 
 ### Fixed
 - Corrected the defaults listed in the docstring for ``civis.io.civis_to_multifile_csv``.

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -444,6 +444,10 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
                        archive=False, hidden=True, **kwargs):
     """Upload a `pandas` `DataFrame` into a Civis table.
 
+    The `DataFrame`'s index will not be included. To store the index
+    along with the other values, use `df.reset_index()` instead
+    of `df` as the first argument to this function.
+
     Parameters
     ----------
     df : :class:`pandas:pandas.DataFrame`


### PR DESCRIPTION
Clarify that the index is not stored, and point users to `reset_index`.

Closes #61 .