### PR TITLE
[CIVP-10738] Poll on a lower interval when PubNub fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.
 - Add CSV settings arguments to ``civis.io.civis_to_csv`` function.
 - Refactored use of "swagger" language.  ``get_swagger_spec`` is now ``get_api_spec`` and ``parse_swagger`` is now ``parse_api_spec``.
+- Modified ``CivisFuture`` so if PubNub is disconnected, it will fall back to polling on a shorter interval.  
 
 ## 1.4.0 - 2017-03-17
 ### API Changes

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -185,7 +185,8 @@ class PollableResult(CivisAsyncResultBase):
 
     def _reset_polling_thread(self,
                               polling_interval=_DEFAULT_POLLING_INTERVAL):
-        self.cleanup()
+        if self._polling_thread.is_alive():
+            self._polling_thread.cancel()
         self.polling_interval = polling_interval
         self._polling_thread = _ResultPollingThread(self._check_result, (),
                                                     polling_interval)

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -182,3 +182,10 @@ class PollableResult(CivisAsyncResultBase):
         # Ensure that the polling thread shuts down when it's no longer needed.
         if self._polling_thread.is_alive():
             self._polling_thread.cancel()
+
+    def _reset_polling_thread(self,
+                              polling_interval=_DEFAULT_POLLING_INTERVAL):
+        self.cleanup()
+        self.polling_interval = polling_interval
+        self._polling_thread = _ResultPollingThread(self._check_result, (),
+                                                    polling_interval)

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -74,6 +74,24 @@ class TestPolling(unittest.TestCase):
         time.sleep(0.015)
         assert poller.call_count == 1
 
+    def test_reset_polling_thread(self):
+        pollable = PollableResult(
+            mock.Mock(return_value=Response({"state": "running"})),
+            poller_args=(),
+            polling_interval=0.1
+        )
+        initial_polling_thread = pollable._polling_thread
+        assert pollable.polling_interval == 0.1
+        assert pollable._polling_thread.polling_interval == 0.1
+        pollable._reset_polling_thread(0.2)
+        # Check that the polling interval was updated
+        assert pollable.polling_interval == 0.2
+        assert pollable._polling_thread.polling_interval == 0.2
+        # Check that the _polling_thread is a new thread
+        assert pollable._polling_thread != initial_polling_thread
+        # Check that the old thread was stopped
+        assert not initial_polling_thread.is_alive()
+
 
 def test_repeated_polling():
     # Verify that we poll the expected number of times.


### PR DESCRIPTION
* Added `_reset_polling_thread` to `PollableResult` which stops the current polling thread and creates a new one with the specified polling interval (defaults to the default interval of 15)
* Added a status handler in the PubNub listener class which will check if the status matches a set of statuses that pertain to unexpected disconnects or network errors and call the `_reset_polling_thread` function if it is disconnected.