### PR TITLE
BUG remove argument that prevents sphinx from building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -385,7 +385,7 @@ else:
     user_agent = "civis-python/SphinxDocs"
     api_version = "1.0"
     extra_classes = civis.resources._resources.generate_classes(
-        api_key=api_key, user_agent=user_agent, api_version=api_version, resources='all')
+        api_key=api_key, api_version=api_version, resources='all')
 sorted_class_names = sorted(extra_classes.keys())
 
 civis.APIClient.__doc__ += _make_attr_docs(sorted_class_names,


### PR DESCRIPTION
Sphinx's `make html` was failing for me, and I think it's because `user_agent` is no longer an argument for `generate_classes`.