### PR TITLE
[CIVP-10806] Add more utility functions for working with Civis files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Retries to http request in ``get_swagger_spec`` to make calls to ``APIClient`` robust to network failure
 - Parameter ``local_api_spec`` to ``APIClient`` to allow creation of client from local cache
 - Clarify ``civis.io.dataframe_to_civis`` docstring with a note about treatment of the index.
+- Added functions ``civis.io.file_id_from_run_output``, ``civis.io.file_to_dataframe``, and ``civis.io.file_to_json``.
 
 ### Fixed
 - Corrected the defaults listed in the docstring for ``civis.io.civis_to_multifile_csv``.
@@ -16,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Modified retry behavior so that 413, 429, or 503 errors accompanied by a "Retry-After" header will be retried regardless of the HTTP verb used.
 - Add CSV settings arguments to ``civis.io.civis_to_csv`` function.
 - Refactored use of "swagger" language.  ``get_swagger_spec`` is now ``get_api_spec`` and ``parse_swagger`` is now ``parse_api_spec``.
-- Modified ``CivisFuture`` so if PubNub is disconnected, it will fall back to polling on a shorter interval.  
+- Modified ``CivisFuture`` so if PubNub is disconnected, it will fall back to polling on a shorter interval. 
 
 ## 1.4.0 - 2017-03-17
 ### API Changes

--- a/civis/io/__init__.py
+++ b/civis/io/__init__.py
@@ -1,8 +1,3 @@
-from ._databases import query_civis, transfer_table
-from ._files import file_to_civis, civis_to_file
-from ._tables import (read_civis, read_civis_sql, civis_to_csv,
-                      civis_to_multifile_csv, dataframe_to_civis, csv_to_civis)
-
-__all__ = ["query_civis", "transfer_table", "file_to_civis", "civis_to_file",
-           "read_civis", "read_civis_sql", "civis_to_csv",
-           "dataframe_to_civis", "csv_to_civis", "civis_to_multifile_csv"]
+from ._databases import query_civis, transfer_table  # NOQA
+from ._files import *  # NOQA
+from ._tables import *  # NOQA

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     NO_PANDAS = True
 
+__all__ = ['read_civis', 'read_civis_sql', 'civis_to_csv',
+           'civis_to_multifile_csv', 'dataframe_to_civis', 'csv_to_civis']
 
 DELIMITERS = {
     ',': 'comma',

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -235,11 +235,11 @@ def test_file_id_from_run_output_approximate():
 def test_file_id_from_run_output_approximate_multiple():
     # Fuzzy name matching with muliple matches should return the first
     m_cl = Mock()
-    m_cl.scripts.list_containers_runs_outputs.return_value = \
-        [Response({'name': 'spam.csv.gz', 'object_id': 2013,
-                   'object_type': 'File'}),
-         Response({'name': 'eggs.csv.gz', 'object_id': 2014,
-                   'object_type': 'File'})]
+    m_cl.scripts.list_containers_runs_outputs.return_value = [
+        Response({'name': 'spam.csv.gz', 'object_id': 2013,
+                  'object_type': 'File'}),
+        Response({'name': 'eggs.csv.gz', 'object_id': 2014,
+                  'object_type': 'File'})]
 
     fid = civis.io.file_id_from_run_output('.csv', 17, 13, regex=True,
                                            client=m_cl)
@@ -249,9 +249,9 @@ def test_file_id_from_run_output_approximate_multiple():
 def test_file_id_from_run_output_no_file():
     # Get an IOError if we request a file which doesn't exist
     m_client = Mock()
-    m_client.scripts.list_containers_runs_outputs.return_value = \
-        [Response({'name': 'spam', 'object_id': 2013,
-                   'object_type': 'File'})]
+    m_client.scripts.list_containers_runs_outputs.return_value = [
+        Response({'name': 'spam', 'object_id': 2013,
+                  'object_type': 'File'})]
 
     with pytest.raises(FileNotFoundError) as err:
         civis.io.file_id_from_run_output('eggs', 17, 13, client=m_client)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -3,7 +3,7 @@ from io import StringIO, BytesIO
 import json
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import pytest
 import vcr
@@ -15,6 +15,8 @@ except ImportError:
     has_pandas = False
 
 import civis
+from civis.response import Response
+from civis.base import CivisAPIError
 from civis.resources._resources import get_api_spec, generate_classes
 from civis.tests.testcase import (CivisVCRTestCase,
                                   cassette_dir,
@@ -24,6 +26,12 @@ api_import_str = 'civis.resources._resources.get_api_spec'
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THIS_DIR, "civis_api_spec.json")) as f:
     civis_api_spec = json.load(f, object_pairs_hook=OrderedDict)
+
+
+class MockAPIError(CivisAPIError):
+    """A fake API error with only a status code"""
+    def __init__(self, sc):
+        self.status_code = sc
 
 
 @patch(api_import_str, return_value=civis_api_spec)
@@ -200,3 +208,114 @@ class ImportTests(CivisVCRTestCase):
             with open(tmp.name, "r") as f:
                 data = f.read()
         assert data == expected
+
+
+def test_file_id_from_run_output_exact():
+    m_client = Mock()
+    m_client.scripts.list_containers_runs_outputs.return_value = \
+        [Response({'name': 'spam', 'object_id': 2013,
+                   'object_type': 'File'})]
+
+    fid = civis.io.file_id_from_run_output('spam', 17, 13, client=m_client)
+    assert fid == 2013
+
+
+def test_file_id_from_run_output_approximate():
+    # Test fuzzy name matching
+    m_client = Mock()
+    m_client.scripts.list_containers_runs_outputs.return_value = \
+        [Response({'name': 'spam.csv.gz', 'object_id': 2013,
+                   'object_type': 'File'})]
+
+    fid = civis.io.file_id_from_run_output('^spam', 17, 13, regex=True,
+                                           client=m_client)
+    assert fid == 2013
+
+
+def test_file_id_from_run_output_approximate_multiple():
+    # Fuzzy name matching with muliple matches should return the first
+    m_cl = Mock()
+    m_cl.scripts.list_containers_runs_outputs.return_value = \
+        [Response({'name': 'spam.csv.gz', 'object_id': 2013,
+                   'object_type': 'File'}),
+         Response({'name': 'eggs.csv.gz', 'object_id': 2014,
+                   'object_type': 'File'})]
+
+    fid = civis.io.file_id_from_run_output('.csv', 17, 13, regex=True,
+                                           client=m_cl)
+    assert fid == 2013
+
+
+def test_file_id_from_run_output_no_file():
+    # Get an IOError if we request a file which doesn't exist
+    m_client = Mock()
+    m_client.scripts.list_containers_runs_outputs.return_value = \
+        [Response({'name': 'spam', 'object_id': 2013,
+                   'object_type': 'File'})]
+
+    with pytest.raises(FileNotFoundError) as err:
+        civis.io.file_id_from_run_output('eggs', 17, 13, client=m_client)
+    assert 'not an output' in str(err.value)
+
+
+def test_file_id_from_run_output_no_run():
+    # Get an IOError if we request a file from a run which doesn't exist
+    m_client = Mock()
+    m_client.scripts.list_containers_runs_outputs.side_effect =\
+        MockAPIError(404)  # Mock a run which doesn't exist
+
+    with pytest.raises(IOError) as err:
+        civis.io.file_id_from_run_output('name', 17, 13, client=m_client)
+    assert 'could not find job/run id 17/13' in str(err.value).lower()
+
+
+def test_file_id_from_run_output_platform_error():
+    # Make sure we don't swallow real Platform errors
+    m_client = Mock()
+    m_client.scripts.list_containers_runs_outputs.side_effect =\
+        MockAPIError(500)  # Mock a platform error
+    with pytest.raises(CivisAPIError):
+        civis.io.file_id_from_run_output('name', 17, 13, client=m_client)
+
+
+@pytest.mark.skipif(not has_pandas, reason="pandas not installed")
+@patch.object(civis.io._files.pd, 'read_csv')
+def test_file_to_dataframe_infer(mock_read_csv):
+    m_client = Mock()
+    m_client.files.get.return_value = Response({'name': 'spam.csv',
+                                                'file_url': 'url'})
+    civis.io.file_to_dataframe(121, compression='infer', client=m_client)
+    assert mock_read_csv.called_once_with(121, compression='infer')
+
+
+@pytest.mark.skipif(not has_pandas, reason="pandas not installed")
+@patch.object(civis.io._files.pd, 'read_csv')
+def test_file_to_dataframe_infer_gzip(mock_read_csv):
+    m_client = Mock()
+    m_client.files.get.return_value = Response({'name': 'spam.csv.gz',
+                                                'file_url': 'url'})
+    civis.io.file_to_dataframe(121, compression='infer', client=m_client)
+    assert mock_read_csv.called_once_with(121, compression='gzip')
+
+
+@pytest.mark.skipif(not has_pandas, reason="pandas not installed")
+@patch.object(civis.io._files.pd, 'read_csv')
+def test_file_to_dataframe_kwargs(mock_read_csv):
+    m_client = Mock()
+    m_client.files.get.return_value = Response({'name': 'spam.csv',
+                                                'file_url': 'url'})
+    civis.io.file_to_dataframe(121, compression='special', client=m_client,
+                               delimiter='|', nrows=10)
+    assert mock_read_csv.called_once_with(121, compression='special',
+                                          delimiter='|', nrows=10)
+
+
+@patch.object(civis.io._files, 'civis_to_file', autospec=True)
+def test_load_json(mock_c2f):
+    obj = {'spam': 'eggs'}
+
+    def _dump_json(file_id, buf, *args, **kwargs):
+        buf.write(json.dumps(obj).encode())
+    mock_c2f.side_effect = _dump_json
+    out = civis.io.file_to_json(13, client=Mock())
+    assert out == obj

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -279,35 +279,35 @@ def test_file_id_from_run_output_platform_error():
 
 
 @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
-@patch.object(civis.io._files.pd, 'read_csv')
-def test_file_to_dataframe_infer(mock_read_csv):
+def test_file_to_dataframe_infer():
     m_client = Mock()
     m_client.files.get.return_value = Response({'name': 'spam.csv',
                                                 'file_url': 'url'})
-    civis.io.file_to_dataframe(121, compression='infer', client=m_client)
-    assert mock_read_csv.called_once_with(121, compression='infer')
+    with patch.object(civis.io._files.pd, 'read_csv') as mock_read_csv:
+        civis.io.file_to_dataframe(121, compression='infer', client=m_client)
+        assert mock_read_csv.called_once_with(121, compression='infer')
 
 
 @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
-@patch.object(civis.io._files.pd, 'read_csv')
-def test_file_to_dataframe_infer_gzip(mock_read_csv):
+def test_file_to_dataframe_infer_gzip():
     m_client = Mock()
     m_client.files.get.return_value = Response({'name': 'spam.csv.gz',
                                                 'file_url': 'url'})
-    civis.io.file_to_dataframe(121, compression='infer', client=m_client)
-    assert mock_read_csv.called_once_with(121, compression='gzip')
+    with patch.object(civis.io._files.pd, 'read_csv') as mock_read_csv:
+        civis.io.file_to_dataframe(121, compression='infer', client=m_client)
+        assert mock_read_csv.called_once_with(121, compression='gzip')
 
 
 @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
-@patch.object(civis.io._files.pd, 'read_csv')
-def test_file_to_dataframe_kwargs(mock_read_csv):
+def test_file_to_dataframe_kwargs():
     m_client = Mock()
     m_client.files.get.return_value = Response({'name': 'spam.csv',
                                                 'file_url': 'url'})
-    civis.io.file_to_dataframe(121, compression='special', client=m_client,
-                               delimiter='|', nrows=10)
-    assert mock_read_csv.called_once_with(121, compression='special',
-                                          delimiter='|', nrows=10)
+    with patch.object(civis.io._files.pd, 'read_csv') as mock_read_csv:
+        civis.io.file_to_dataframe(121, compression='special', client=m_client,
+                                   delimiter='|', nrows=10)
+        assert mock_read_csv.called_once_with(121, compression='special',
+                                              delimiter='|', nrows=10)
 
 
 @patch.object(civis.io._files, 'civis_to_file', autospec=True)


### PR DESCRIPTION
Add the functions `civis.io._files.file_id_from_run_output`, `civis.io._files.file_to_dataframe`, and `civis.io._files.file_to_json`. These functions will be used for the forthcoming modeling interface code, but are also of general interest.