### PR TITLE
[CIVP-10806] Add ModelFuture

### DIFF
--- a/civis/ml/__init__.py
+++ b/civis/ml/__init__.py
@@ -1,0 +1,3 @@
+"""Machine learning in Civis
+"""
+from civismodel.ml._model import *  # NOQA

--- a/civis/ml/__init__.py
+++ b/civis/ml/__init__.py
@@ -1,3 +1,3 @@
 """Machine learning in Civis
 """
-from civismodel.ml._model import *  # NOQA
+from civis.ml._model import *  # NOQA

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -291,8 +291,7 @@ class ModelFuture(CivisFuture):
             # but showing the resulting KeyError can be confusing and
             # mask the real error.
             warnings.warn("Received malformed metadata from Civis Platform. "
-                          "Something went wrong with execution. "
-                          "Please report this error.")
+                          "Something went wrong with job execution.")
 
     def cancel(self):
         """Submit a request to cancel the container/script/run.

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -115,7 +115,7 @@ def _retrieve_file(fname, job_id, run_id, local_dir, client=None):
     job_id, run_id: int
         Job ID and run ID of the run holding a reference to this file
     local_dir: str
-        Download the file `fname` from Civis to this directory
+        Download the file `fname` from Civis Platform to this directory
 
     Returns
     -------
@@ -142,17 +142,18 @@ def _load_table_from_outputs(job_id, run_id, filename, client=None,
 def _load_estimator(job_id, run_id, filename='estimator.pkl', client=None):
     """Load a joblib-serialized Estimator from run outputs"""
     if not HAS_JOBLIB:
-        raise ImportError('Install joblib to download models from Civis.')
+        raise ImportError('Install joblib to download models '
+                          'from Civis Platform.')
     with tempfile.TemporaryDirectory() as tempdir:
         path = _retrieve_file(filename, job_id, run_id, tempdir, client=client)
         return joblib.load(path)
 
 
 class ModelFuture(CivisFuture):
-    """Encapsulates asynchronous execution of a Civis-ML job
+    """Encapsulates asynchronous execution of a CivisML job
 
     This object knows where to find modeling outputs
-    from Civis-ML jobs. All data attributes are
+    from CivisML jobs. All data attributes are
     lazily retrieved and block on job completion.
     This object can be pickled.
 
@@ -180,7 +181,7 @@ class ModelFuture(CivisFuture):
 
     [These attributes are non-blocking]
     state : str
-        The current state of the Civis run
+        The current state of the Civis Platform run
     job_id : int
     run_id : int
     train_job_id : int
@@ -206,7 +207,7 @@ class ModelFuture(CivisFuture):
     done()
         (Non-blocking) Is the job finished?
     result()
-        (Blocking) Return the final status of the Civis job.
+        (Blocking) Return the final status of the Civis Platform job.
 
     See Also
     --------
@@ -279,7 +280,7 @@ class ModelFuture(CivisFuture):
             # KeyErrors always represent a bug in the modeling code,
             # but showing the resulting KeyError can be confusing and
             # mask the real error.
-            warnings.warn("Received malformed metadata from Civis. "
+            warnings.warn("Received malformed metadata from Civis Platform. "
                           "Something went wrong with execution. "
                           "Please report this error.")
 

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -106,22 +106,7 @@ def _decode_train_run(train_job_id, train_run_id, client):
 
 
 def _retrieve_file(fname, job_id, run_id, local_dir, client=None):
-    """Download a Civis file using a reference on a previous run
-
-    Parameters
-    ----------
-    fname: str
-        Name of the Civis file you wish to retrieve
-    job_id, run_id: int
-        Job ID and run ID of the run holding a reference to this file
-    local_dir: str
-        Download the file `fname` from Civis Platform to this directory
-
-    Returns
-    -------
-    str
-        The path of the downloaded file
-    """
+    """Download a Civis file using a reference on a previous run"""
     file_id = cio.file_id_from_run_output(fname, job_id, run_id, client=client)
     fpath = os.path.join(local_dir, fname)
     os.makedirs(os.path.dirname(fpath), exist_ok=True)
@@ -156,6 +141,31 @@ class ModelFuture(CivisFuture):
     from CivisML jobs. All data attributes are
     lazily retrieved and block on job completion.
     This object can be pickled.
+
+    Parameters
+    ----------
+    job_id : int
+        ID of the modeling job
+    run_id : int
+        ID of the modeling run
+    train_job_id : int, optional
+        If not provided, this object is assumed to encapsulate a training
+        job, and ``train_job_id`` will equal ``job_id``.
+    train_run_id : int, optional
+        If not provided, this object is assumed to encapsulate a training
+        run, and ``train_run_id`` will equal ``run_id``.
+    polling_interval : int or float, optional
+        The number of seconds between API requests to check whether a result
+        is ready. The default intelligently switches between a short
+        interval if ``pubnub`` is not available and a long interval
+        for ``pubnub`` backup if that library is installed.
+    client : :class:`civis.APIClient`, optional
+        If not provided, an :class:`civis.APIClient` object will be
+        created from the :envvar:`CIVIS_API_KEY`.
+    poll_on_creation : bool, optional
+        If ``True`` (the default), it will poll upon calling ``result()`` the
+        first time. If ``False``, it will wait the number of seconds specified
+        in `polling_interval` from object creation before polling.
 
     Attributes
     ----------

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -1,0 +1,470 @@
+"""Running CivisML jobs and retrieving the results
+"""
+from concurrent import futures
+from functools import wraps
+import io
+import os
+import tempfile
+import threading
+from typing import Callable, Dict, Union
+import warnings
+
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
+
+from civis import APIClient, find_one
+from civis.base import CivisAPIError, CivisJobFailure
+from civis.io import civis_to_file, file_to_civis
+from civis.futures import CivisFuture
+from civis.polling import _ResultPollingThread
+
+
+class ModelError(RuntimeError):
+    def __init__(self, msg: str,
+                 estimator: 'sklearn.base.BaseEstimator'=None,
+                 metadata: Dict=None):
+        self.metadata = metadata
+        self.estimator = estimator
+        super().__init__(msg)
+
+
+def check_is_fit(method: Callable) -> Callable:
+    """Makes sure that the ModelPipeline's been trained
+    """
+    @wraps(method)
+    def wrapper(*args, **kwargs):
+        self = args[0]
+        if not self.train_result_:
+            raise ValueError("This model hasn't been trained yet.")
+        return method(*args, **kwargs)
+    return wrapper
+
+
+def _block_and_handle_missing(method: Callable) -> Callable:
+    """For ModelFuture file-retrieving property methods.
+    Block until completion and attempt to retrieve result.
+    Raise exception only if the result isn't found.
+    """
+    @wraps(method)
+    def wrapper(self):
+        futures.wait((self,))  # Block until done
+        try:
+            return method(self)
+        except FileNotFoundError:
+            # We get here if the modeling job failed to produce
+            # any output and we don't have metadata.
+            if self.exception():
+                raise self.exception() from None
+            else:
+                raise
+    return wrapper
+
+
+def _stash_local_data(X: Union['pandas.DataFrame', str],
+                      client: APIClient=None) -> int:
+    """Store data in a temporary Civis File and return the file ID
+    """
+    civis_fname = 'modelpipeline_data.csv'
+    if HAS_PANDAS and isinstance(X, pd.DataFrame):
+        buf = io.BytesIO()
+        txt = io.TextIOWrapper(buf, encoding='utf-8')
+        X.to_csv(txt, encoding='utf-8', index=False)
+        txt.flush()
+        buf.seek(0)
+        file_id = file_to_civis(buf, name=civis_fname, client=client)
+    else:
+        with open(X) as _fin:
+            file_id = file_to_civis(_fin, name=civis_fname, client=client)
+
+    return file_id
+
+
+def decode_train_run(train_job_id: int, train_run_id: str,
+                     client: APIClient) -> int:
+    """Determine correct run ID for use for a given training job ID.
+    """
+    try:
+        return int(train_run_id)
+    except ValueError:
+        container = client.scripts.get_containers(train_job_id)
+        if train_run_id == 'active':
+            train_run_id = container.arguments.get('ACTIVE_BUILD', find_one(
+                container.params, name='ACTIVE_BUILD'))['default']
+
+        if train_run_id == 'latest':
+            return container.last_run.id
+
+        try:
+            return int(train_run_id)
+        except Exception as exc:
+            raise ValueError('Please provide valid train_run_id! Needs to be '
+                             'integer corresponding to a training run ID '
+                             'or one of "active" or "latest".') from exc
+
+
+def retrieve_file(fname: str, job_id: int, run_id: int, local_dir: str,
+                  client: APIClient=None) -> str:
+    """Download a Civis file using a reference on a previous run
+
+    Parameters
+    ----------
+    fname: str
+        Name of the Civis file you wish to retrieve
+    job_id, run_id: int
+        Job ID and run ID of the run holding a reference to this file
+    local_dir: str
+        Download the file `fname` from Civis to this directory
+
+    Returns
+    -------
+    str
+        The path of the downloaded file
+
+    Raises
+    ------
+    IOError
+        If the given job/run doesn't exist
+        or doesn't have the requested file
+    """
+    try:
+        file_id = _file_id_from_run_output(fname, job_id, run_id,
+                                           client=client)
+    except CivisAPIError as err:
+        if err.status_code == 404:
+            raise IOError('Could not find job/run ID {}/{}'
+                          .format(job_id, run_id)) from err
+        else:
+            raise
+    fpath = os.path.join(local_dir, fname)
+    os.makedirs(os.path.dirname(fpath), exist_ok=True)
+    with open(fpath, 'wb') as down_file:
+        civis_to_file(file_id, down_file, client=client)
+    return fpath
+
+
+def load_table_from_outputs(job_id: int,
+                            run_id: int,
+                            filename: str,
+                            client: APIClient=None,
+                            **table_kwargs) -> 'pandas.DataFrame':
+    """Load a table from a run output directly into a ``DataFrame``
+    """
+    client = APIClient(resources='all') if client is None else client
+    file_id = _file_id_from_run_output(filename, job_id, run_id, client, False)
+    return load_table(file_id, client=client, **table_kwargs)
+
+
+def load_estimator(job_id: int,
+                   run_id: int,
+                   filename: str='estimator.pkl',
+                   client: APIClient=None) -> dict:
+    """Load a joblib-serialized Estimator from run outputs
+    """
+    import joblib
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = retrieve_file(filename, job_id, run_id, tempdir, client=client)
+        return joblib.load(path)
+
+
+class ModelFuture(CivisFuture):
+    """Encapsulates asynchronous execution of a Civis-ML job
+
+    This object knows where to find modeling outputs
+    from Civis-ML jobs. All data attributes are
+    lazily retrieved and block on job completion.
+    This object can be pickled.
+
+    Attributes
+    ----------
+    [Accessing these attributes blocks until the Platform run completes]
+    metadata : dict
+        The metadata associated with this modeling job
+    metrics : dict
+        Validation metrics from this job's training
+    validation_metadata : dict
+        Metadata from this modeling job's validation run
+    train_metadata : dict
+        Metadata from this modeling job's training run
+        (will be identical to `metadata` if this is a training run)
+    estimator : Pipeline
+        The fitted scikit-learn Pipeline resulting from this model run
+    table : pandas.DataFrame
+        The table output from this modeling job: out-of-sample
+        predictions on the training set for a training job, or
+        a table of predictions for a prediction job.
+        If the prediction job was split into multiple files
+        (this happens automatically for large tables),
+        this attribute will provide only predictions for the first file.
+
+    [These attributes are non-blocking]
+    state : str
+        The current state of the Civis run
+    job_id : int
+    run_id : int
+    train_job_id : int
+        Container ID for the training job -- identical to ``job_id``
+        if this is a training job.
+    train_run_id : int
+        As ``train_job_id`` but for runs
+    is_training : bool
+        True if this ``ModelFuture`` corresponds to a train-validate job.
+
+    Methods
+    -------
+    cancel()
+        Cancels the corresponding Platform job before completion
+    succeeded()
+        (Non-blocking) Is the job a success?
+    failed()
+        (Non-blocking) Did the job fail?
+    cancelled()
+        (Non-blocking) Was the job cancelled?
+    running()
+        (Non-blocking) Is the job still running?
+    done()
+        (Non-blocking) Is the job finished?
+    result()
+        (Blocking) Return the final status of the Civis job.
+
+    See Also
+    --------
+    :class:`~civis.futures.CivisFuture`
+    :class:`~concurrent.futures.Future`
+    """
+    def __init__(self, job_id, run_id,
+                 train_job_id: int=None,
+                 train_run_id: int=None,
+                 polling_interval: float=None,
+                 client: APIClient=None,
+                 poll_on_creation: bool=True):
+        if client is None:
+            client = APIClient(resources='all')
+        super().__init__(client.scripts.get_containers_runs,
+                         [job_id, run_id],
+                         polling_interval=polling_interval,
+                         client=client,
+                         poll_on_creation=poll_on_creation)
+        if train_job_id and train_run_id:
+            self.is_training = False
+            self.train_job_id = train_job_id
+            self.train_run_id = train_run_id
+        else:
+            self.is_training = True
+            self.train_job_id = self.job_id
+            self.train_run_id = self.run_id
+        self._metadata, self._val_metadata = None, None
+        self._train_data, self._train_data_fname = None, None
+        self._train_metadata = None
+        self._table, self._estimator = None, None
+        self.add_done_callback(self._set_model_exception)
+
+    @property
+    def job_id(self):
+        return self.poller_args[0]
+
+    @property
+    def run_id(self):
+        return self.poller_args[1]
+
+    @staticmethod
+    def _set_model_exception(fut: "ModelFuture"):
+        """Callback: On job completion, check the metadata.
+        If it indicates an exception, replace the generic
+        ``CivisJobFailure`` by a more informative ``ModelError``.
+        """
+        try:
+            meta = fut.metadata
+            if fut.is_training and meta['run']['status'] == 'succeeded':
+                # if training job and job succeeded, check validation job
+                meta = fut.validation_metadata
+            if (meta['run']['status'] == 'exception' and
+                    not isinstance(fut._exception, ModelError)):
+                # `set_exception` invokes callbacks, so make sure
+                # we haven't already set a `ModelError` to avoid
+                # infinite recursion.
+                try:
+                    # This will fail if the user doesn't have joblib installed
+                    est = fut.estimator
+                except Exception:  # NOQA
+                    est = None
+                fut.set_exception(
+                      ModelError('Model run failed with stack trace:\n'
+                                 '{}'.format(meta['run']['stack_trace']),
+                                 est, meta))
+        except (FileNotFoundError, CivisJobFailure):
+            # If there's no metadata file
+            # (we get FileNotFound or CivisJobFailure),
+            # then there's no improvements to make on
+            # any existing exception.
+            pass
+        except KeyError:
+            # KeyErrors always represent a bug in the modeling code,
+            # but showing the resulting KeyError can be confusing and
+            # mask the real error.
+            warnings.warn("Received malformed metadata from Civis. "
+                          "Something went wrong with execution. "
+                          "Please report this error.")
+
+    def cancel(self):
+        """Submit a request to cancel the container/script/run.
+
+        .. note:: If this object represents a prediction run,
+                  ``cancel`` will only cancel the parent job.
+                  Child jobs will remain active.
+
+        Returns
+        -------
+        bool
+            Whether or not the run is in a cancelled state.
+        """
+        with self._condition:
+            if self.cancelled():
+                return True
+            elif not self.done():
+                # Cancel the job and store the result of the cancellation in
+                # the "finished result" attribute, `_result`.
+                self._result = self.client.scripts.post_cancel(self.job_id)
+                for waiter in self._waiters:
+                    waiter.add_cancelled(self)
+                self._condition.notify_all()
+                self._invoke_callbacks()
+                self.cleanup()
+                return self.cancelled()
+            return False
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        del state['_polling_thread']
+        del state['client']
+        del state['poller']
+        del state['_condition']
+        if '_pubnub' in state:
+            state['_pubnub'] = True  # Replace with a boolean flag
+        state['_done_callbacks'] = []
+        state['_self_polling_executor'] = None
+
+        return state
+
+    def __setstate__(self, state: dict):
+        self.__dict__ = state
+        self.client = APIClient(resources='all')
+        if getattr(self, '_pubnub', None) is True:
+            # Re-subscribe to notifications channel
+            self._pubnub = self._subscribe(*self._pubnub_config())
+        self._polling_thread = _ResultPollingThread(self._check_result, (),
+                                                    self.polling_interval)
+        self.poller = self.client.scripts.get_containers_runs
+        self._condition = threading.Condition()
+        self.add_done_callback(self._set_model_exception)
+
+    @property
+    def state(self) -> str:
+        state = self._civis_state
+        if state == 'succeeded':
+            state = self.metadata['run']['status']
+        return state
+
+    @property
+    def table_fname(self) -> str:
+        return 'predictions.csv'
+
+    @property
+    def metadata_fname(self) -> str:
+        return 'model_info.json'
+
+    @property
+    def train_data_fname(self) -> str:
+        if self._train_data_fname is None:
+            self._train_data_fname = os.path.basename(self.training_metadata
+                                                      .get('run')
+                                                      .get('configuration')
+                                                      .get('data')
+                                                      .get('location'))
+        return self._train_data_fname
+
+    @property
+    def train_data(self) -> 'pandas.DataFrame':
+        if self._train_data is None:
+            try:
+                self._train_data = load_table_from_outputs(
+                    self.train_job_id,
+                    self.train_run_id,
+                    self.train_data_fname,
+                    client=self.client)
+            except CivisAPIError as err:
+                if err.status_code == 404:
+                    raise ValueError('There is no training data stored for '
+                                     'this job!') from err
+                else:
+                    raise
+
+        return self._train_data
+
+    @property
+    def table(self) -> 'pandas.DataFrame':
+        self.result()  # Block and raise errors if any
+        if self._table is None:
+            if self.is_training:
+                # Training jobs only have one output table, the OOS scores
+                self._table = load_table_from_outputs(self.job_id,
+                                                      self.run_id,
+                                                      self.table_fname,
+                                                      index_col=0,
+                                                      client=self.client)
+            else:
+                # Prediction jobs may have many output tables.
+                output_ids = self.metadata['output_file_ids']
+                if len(output_ids) > 1:
+                    print('This job output {} files. Retrieving only the '
+                          'first. Find the full list at `metadata'
+                          '["output_file_ids"]`.'.format(len(output_ids)))
+                self._table = load_table(output_ids[0],
+                                         client=self.client,
+                                         index_col=0)
+        return self._table
+
+    @property
+    @_block_and_handle_missing
+    def metadata(self) -> dict:
+        if self._metadata is None:
+            self._metadata = load_dict(self.job_id,
+                                       self.run_id,
+                                       self.metadata_fname,
+                                       client=self.client)
+        return self._metadata
+
+    @property
+    @_block_and_handle_missing
+    def estimator(self) -> 'sklearn.pipeline.Pipeline':
+        if self._estimator is None:
+            self._estimator = load_estimator(self.train_job_id,
+                                             self.train_run_id,
+                                             client=self.client)
+        return self._estimator
+
+    @property
+    @_block_and_handle_missing
+    def validation_metadata(self) -> dict:
+        if self._val_metadata is None:
+            self._val_metadata = load_dict(self.train_job_id,
+                                           self.train_run_id,
+                                           'metrics.json',
+                                           client=self.client)
+        return self._val_metadata
+
+    @property
+    def metrics(self) -> dict:
+        return self.validation_metadata['metrics']
+
+    @property
+    @_block_and_handle_missing
+    def training_metadata(self) -> dict:
+        if self._train_metadata is None:
+            self._train_metadata = load_dict(self.train_job_id,
+                                             self.train_run_id,
+                                             'model_info.json',
+                                             client=self.client)
+        return self._train_metadata

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1,0 +1,387 @@
+
+from collections import namedtuple
+from io import BytesIO
+import json
+import os
+import pickle
+import tempfile
+from unittest import mock
+
+import joblib
+import numpy as np
+
+from civis import APIClient
+from civis.base import CivisAPIError, CivisJobFailure
+from civis import futures
+from civis.response import Response
+import pandas as pd
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+from civis.ml import _model
+
+def setup_client_mock(script_id=-10, run_id=100):
+    """Return a Mock set up for use in testing container scripts
+
+    Parameters
+    ----------
+    script_id: int
+        Mock-create containers with this ID when calling `post_containers`
+        or `post_containers_runs`.
+    run_id: int
+        Mock-create runs with this ID when calling `post_containers_runs`.
+
+    Returns
+    -------
+    `unittest.mock.Mock`
+        With scripts endpoints `post_containers`, `post_containers_runs`,
+        `post_cancel`, and `get_containers_runs` set up.
+    """
+    c = mock.Mock()
+    c.__class__ = APIClient
+
+    mock_container = Response({'id': script_id})
+    c.scripts.post_containers.return_value = mock_container
+    mock_container_run_start = Response({'id': run_id,
+                                         'container_id': script_id,
+                                         'state': 'queued'})
+    mock_container_run = Response({'id': run_id,
+                                   'container_id': script_id,
+                                   'state': 'succeeded'})
+    c.scripts.post_containers_runs.return_value = mock_container_run_start
+    c.scripts.get_containers_runs.return_value = mock_container_run
+
+    def change_state_to_cancelled(script_id):
+        mock_container_run.state = "cancelled"
+        return mock_container_run
+
+    c.scripts.post_cancel.side_effect = change_state_to_cancelled
+
+    # No channels endpoint available
+    del c.channels
+
+    return c
+
+
+def test_check_is_fit_exception():
+    mock_pipe = mock.MagicMock()
+    mock_pipe.train_result_ = None
+
+    @_model.check_is_fit
+    def foo(arg):
+        return 7
+
+    with pytest.raises(ValueError):
+        foo(mock_pipe)
+
+
+def test_check_is_fit():
+    mock_pipe = mock.MagicMock()
+    mock_pipe.train_result_ = True
+
+    @_model.check_is_fit
+    def foo(arg):
+        return 7
+
+    assert foo(mock_pipe) == 7
+
+
+@mock.patch.object(_model, "futures")
+def test_block_and_handle_missing_exception(mock_fut):
+    @_model._block_and_handle_missing
+    def foo(arg):
+        raise FileNotFoundError
+
+    mock_super = mock.Mock()
+    mock_super.exception.return_value = Exception
+
+    with pytest.raises(Exception):
+        foo(mock_super)
+
+    mock_super.exception.return_value = None
+    with pytest.raises(FileNotFoundError):
+        foo(mock_super)
+
+
+@mock.patch.object(_model, "futures")
+def test_block_and_handle_missing(mock_fut):
+    @_model._block_and_handle_missing
+    def foo(arg):
+        return 7
+    assert foo('bar') == 7
+
+
+@mock.patch.object(_model, 'open', new_callable=mock.mock_open)
+@mock.patch.object(_model, 'file_to_civis', return_value=-11)
+def test_stash_local_data_from_file(mock_file, mock_open):
+    assert _model._stash_local_data('airspeed_velocity.csv') == -11
+    mock_open.assert_called_once_with('airspeed_velocity.csv')
+    mock_file.assert_called_once_with(mock_open.return_value,
+                                      name='modelpipeline_data.csv',
+                                      client=mock.ANY)
+
+
+@mock.patch.object(_model, 'file_to_civis', return_value=-11)
+def test_stash_local_data_from_dataframe(mock_file):
+    df = pd.DataFrame({'a': [1], 'b': [2]})
+    assert _model._stash_local_data(df) == -11
+    mock_file.assert_called_once_with(mock.ANY, name='modelpipeline_data.csv',
+                                      client=mock.ANY)
+    assert isinstance(mock_file.call_args[0][0], BytesIO)
+
+
+@mock.patch.object(_model, 'retrieve_file', autospec=True)
+def test_load_estimator(mock_retrieve):
+    obj = {'spam': 'eggs'}
+
+    def _retrieve_json(fname, job_id, run_id, local_dir, client=None):
+        full_name = os.path.join(local_dir, fname)
+        joblib.dump(obj, full_name)
+        return full_name
+
+    mock_retrieve.side_effect = _retrieve_json
+    out = _model.load_estimator(13, 17, 'fname')
+    assert out == obj
+
+
+###################################
+# Tests of ModelFuture below here #
+###################################
+@mock.patch.object(_model.ModelFuture, "_set_model_exception", autospec=True)
+@mock.patch.object(_model.ModelFuture, "add_done_callback", autospec=True)
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, 'APIClient')
+def test_modelfuture_constructor(m_api, m_f_api, mock_adc, mock_spe):
+    c = setup_client_mock(7, 17)
+    m_api.return_value = m_f_api.return_value = c
+
+    mf = _model.ModelFuture(job_id=7, run_id=17)
+    assert mf.is_training is True
+    assert mf.train_run_id == 17
+    assert mf.train_job_id == 7
+
+    mf = _model.ModelFuture(job_id=7, run_id=17,
+                            train_job_id=23, train_run_id=29)
+    assert mf.is_training is False
+    assert mf.train_run_id == 29
+    assert mf.train_job_id == 23
+
+
+@mock.patch.object(_model, "load_dict",
+                   mock.Mock(return_value={'spam': 'eggs'}))
+@mock.patch.object(_model, 'APIClient', setup_client_mock())
+def test_modelfuture_pickle_smoke():
+    mf = _model.ModelFuture(job_id=7, run_id=13, client=setup_client_mock())
+    mf.result()
+    mf_pickle = pickle.dumps(mf)
+    pickle.loads(mf_pickle)
+
+
+def test_set_model_exception_metadata_exception():
+    """Tests cases where accessing metadata throws exceptions
+    """
+    class ModelFutureRaiseExc:
+        def __init__(self, exc):
+            self.exc = exc
+
+        @property
+        def metadata(self):
+            raise self.exc('What a spectacular failure, you say!')
+
+    # exception types get caught!
+    for exc in [FileNotFoundError, CivisJobFailure, KeyError]:
+        fut = ModelFutureRaiseExc(exc)
+        _model.ModelFuture._set_model_exception(fut)
+
+    fut = ModelFutureRaiseExc(RuntimeError)
+    with pytest.raises(RuntimeError):
+        _model.ModelFuture._set_model_exception(fut)
+
+
+class ModelFutureStub:
+
+    def __init__(self, exc, trn, val):
+        self._exception = exc
+        self.metadata = trn
+        self.validation_metadata = val
+        self.is_training = True
+
+    def set_exception(self, exc):
+        self._exception = exc
+
+
+def _test_set_model_exc(trn, val, exc):
+    fut = ModelFutureStub(exc, trn, val)
+
+    assert isinstance(fut._exception, type(exc))
+    _model.ModelFuture._set_model_exception(fut)
+    assert isinstance(fut._exception, _model.ModelError)
+    assert 'this is a trace' in str(fut._exception)
+
+    # don't change attribute if it's already a ModelError
+    fut._exception = _model.ModelError('undecipherable message')
+    _model.ModelFuture._set_model_exception(fut)
+    assert isinstance(fut._exception, _model.ModelError)
+    assert 'undecipherable message' in str(fut._exception)
+
+
+def test_set_model_exception_training_metadata():
+    trn = {'run': {'status': 'exception', 'stack_trace': 'this is a trace'}}
+    val = None
+    exc = FileNotFoundError('Look, no mocks!')
+
+    _test_set_model_exc(trn, val, exc)
+
+
+def test_set_model_exception_validation_metadata():
+    trn = {'run': {'status': 'succeeded'}}
+    val = {'run': {'status': 'exception', 'stack_trace': 'this is a trace'}}
+    exc = FileNotFoundError('Hahaha, zero mocks here!')
+
+    _test_set_model_exc(trn, val, exc)
+
+
+@mock.patch.object(_model, "load_dict", mock.Mock(return_value='bar'))
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, 'APIClient')
+@mock.patch.object(api.ModelFuture, "_set_model_exception", lambda *args: None)
+def test_getstate(m_api, m_f_api):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+
+    mf = _model.ModelFuture(3, 7)
+    ret = mf.__getstate__()
+    assert ret['_done_callbacks'] == []
+    assert not ret['_self_polling_executor']
+    assert 'client' not in ret
+    assert 'poller' not in ret
+    assert '_condition' not in ret
+
+
+@mock.patch.object(_model, 'load_dict', autospec=True,
+                   return_value={'run': {'status': 'foo'}})
+def test_state(mock_load_dict):
+    c = setup_client_mock(3, 7)
+
+    mf = _model.ModelFuture(3, 7, client=c)
+    ret = mf.state
+    assert ret == 'foo'
+
+    c.scripts.get_containers_runs.return_value = Response({'id': 7,
+                                                           'container_id': 3,
+                                                           'state': 'failed'})
+    mf = _model.ModelFuture(3, 7, client=c)
+    assert mf.state == 'failed'
+
+
+@mock.patch.object(futures, "APIClient")
+@mock.patch.object(_model, "APIClient")
+@mock.patch.object(_model, "load_table_from_outputs", return_value='bar')
+@mock.patch.object(_model.ModelFuture, "result")
+@mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
+def test_table(mock_res, mock_lt, m_api, m_f_api):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+    mf = api.ModelFuture(3, 7)
+    assert mf.table == 'bar'
+    mock_lt.assert_called_once_with(3, 7, 'predictions.csv',
+                                    index_col=0, client=mock.ANY)
+
+
+@mock.patch.object(_model, "load_dict", return_value='bar')
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, "APIClient")
+@mock.patch.object(_model.ModelFuture, "_set_model_exception")
+def test_metadata(mock_spe, m_api, m_f_api, mock_ld):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+    mf = _model.ModelFuture(3, 7)
+    assert mf.metadata == 'bar'
+    mock_ld.assert_called_once_with(3, 7, 'model_info.json', client=mock.ANY)
+
+
+def test_train_data_fname():
+    # swap out the poller with a simple function that accepts *args, **kwargs
+    # and returns a simple successful Response object
+    def poller(*args, **kwargs):
+        return Response({'state': 'succeeded'})
+    mock_client = mock.MagicMock()
+    mock_client.scripts.get_containers_runs = poller
+    mf = _model.ModelFuture(job_id=1, run_id=2, client=mock_client)
+
+    path = '/green/eggs/and/ham'
+    training_meta = {'run': {'configuration': {'data': {'location': path}}}}
+    mf._train_metadata = training_meta
+    assert mf.train_data_fname == 'ham'
+
+
+@mock.patch.object(_model, "load_table_from_outputs", autospec=True)
+def test_train_data(mock_load_table):
+    def poller(*args, **kwargs):
+        return Response({'state': 'succeeded'})
+    mock_client = mock.MagicMock()
+    mock_client.scripts.get_containers_runs = poller
+    mf = _model.ModelFuture(job_id=1, run_id=2, client=mock_client)
+    mf._train_data_fname = 'placeholder.csv'
+
+    miscallaneous_string = 'one two three'
+    mock_load_table.return_value = miscallaneous_string
+    assert mf.train_data == miscallaneous_string
+
+
+@mock.patch.object(_model, "load_table_from_outputs", autospec=True)
+def test_train_data_exc_handling(mock_load_table):
+    def poller(*args, **kwargs):
+        return Response({'state': 'succeeded'})
+    mock_client = mock.MagicMock()
+    mock_client.scripts.get_containers_runs = poller
+    mf = _model.ModelFuture(job_id=1, run_id=2, client=mock_client)
+    mf._train_data_fname = 'placeholder.csv'
+
+    # check we catch 404 error and raise some intelligible
+    r = Response({'content': None, 'status_code': 404, 'reason': None})
+    mock_load_table.side_effect = CivisAPIError(r)
+    with pytest.raises(ValueError):
+        mf.train_data
+
+
+@mock.patch.object(_model, "load_estimator", return_value='spam')
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, "APIClient")
+@mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
+def test_estimator(m_api, m_f_api, mock_le):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+
+    mf = _model.ModelFuture(3, 7)
+    assert mock_le.call_count == 0, "Estimator retrieval is lazy."
+    assert mf.estimator == 'spam'
+    assert mock_le.call_count == 1
+
+    assert mf.estimator == 'spam'
+    assert mock_le.call_count == 1,\
+        "The Estimator is only downloaded once and cached."
+
+
+@mock.patch.object(_model, "load_dict", return_value='foo')
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, "APIClient")
+@mock.patch.object(api.ModelFuture, "_set_model_exception")
+def test_validation_metadata(mock_spe, m_api, m_f_api, mock_ld):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+    mf = _model.ModelFuture(3, 7)
+    assert mf.validation_metadata == 'foo'
+    mock_ld.assert_called_once_with(3, 7, 'metrics.json', client=mock.ANY)
+
+
+@mock.patch.object(_model, "load_dict",
+                   mock.MagicMock(return_value={'metrics': 'foo'}))
+@mock.patch.object(futures, 'APIClient')
+@mock.patch.object(_model, "APIClient")
+def test_metrics(m_api, m_f_api):
+    c = setup_client_mock(3, 7)
+    m_api.return_value = m_f_api.return_value = c
+    mf = _model.ModelFuture(3, 7)
+
+    assert mf.metrics == 'foo'


### PR DESCRIPTION
This is the next step in adding the new modeling interface. This PR adds the new `civis.ml` namespace, and populates it with `ModelFuture`, a subclass of `CivisFuture`. The `ModelFuture` object knows how to find and download results from a CivisML model. It also transports errors from Civis and re-raises them in the local environment to make debugging easier.