### PR TITLE
[CIVP-10806] BUG Fix parameter bug in _load_table_from_outputs

### DIFF
--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -119,8 +119,8 @@ def _load_table_from_outputs(job_id, run_id, filename, client=None,
                              **table_kwargs):
     """Load a table from a run output directly into a ``DataFrame``"""
     client = APIClient(resources='all') if client is None else client
-    file_id = cio.file_id_from_run_output(filename, job_id, run_id, client,
-                                          regex=True)
+    file_id = cio.file_id_from_run_output(filename, job_id, run_id,
+                                          client=client, regex=True)
     return cio.file_to_dataframe(file_id, client=client, **table_kwargs)
 
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -152,6 +152,15 @@ def test_load_estimator(mock_retrieve):
     assert out == obj
 
 
+@mock.patch.object(_model.cio, 'file_to_dataframe', autospec=True)
+@mock.patch.object(_model.cio, 'file_id_from_run_output', autospec=True)
+def test_load_table_from_outputs(mock_fid, mock_f2df):
+    # Test that _load_table_from_outputs is calling functions
+    # correctly. Let `autospec` catch errors in arguments being passed.
+    mock_client = setup_client_mock()
+    _model._load_table_from_outputs(1, 2, 'fname', client=mock_client)
+
+
 ###################################
 # Tests of ModelFuture below here #
 ###################################


### PR DESCRIPTION
Use a keyword argument for `client`, since the fourth positional argument is `regex`. The new test fails with this error in place.