### PR TITLE
[CIVP-10806] DOC Documentation for civis.ml namespace

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ intersphinx_mapping = {
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable', None),
     'python': ('https://docs.python.org/3.4', None),
     'requests': ('https://requests.readthedocs.org/en/latest/', None),
+    'sklearn': ('http://scikit-learn.org/stable', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,18 @@ set ``use_pandas=True`` in functions that accept that parameter.  To install
 
    pip install pandas
 
+Machine learning features in the ``ml`` namespace have a soft dependency on
+``scikit-learn``, ``joblib``, and ``pandas``. Install ``scikit-learn`` and
+``joblib`` to export your trained models from the Civis Platform or to
+provide your own custom models. Use ``pandas`` to download model predictions
+from the Civis Platform. Install these dependencies with
+
+.. code-block:: bash
+
+   pip install scikit-learn
+   pip install joblib
+   pip install pandas
+
 
 Authentication
 --------------
@@ -90,6 +102,7 @@ Client API Reference
 
    user_guide
    io
+   ml
    client
    cli
 

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -68,7 +68,7 @@ recognizes. You can use code from
 - `scikit-learn <http://scikit-learn.org>`_ v0.18.1
 - `glmnet <https://github.com/civisanalytics/python-glmnet>`_ v2.0.0
 - `xgboost <http://xgboost.readthedocs.io>`_ v0.6a2
-- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.0.0
+- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.1.1
 
 When you're assembling your own model, remember that you'll have to make certain that
 either you add a missing value imputation step or that your data doesn't have any

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -1,0 +1,180 @@
+****************
+Machine Learning
+****************
+
+CivisML uses the Civis Platform to train machine learning models
+and parallelize their predictions over large datasets.
+It contains best-practice models for general-purpose classification
+and regression modeling as well as model quality evaluations and
+visualizations. All CivisML models use `scikit-learn <http://scikit-learn.org/>`_
+for interoperability with other platforms and to allow you to leverage
+resources in the open-source software community when creating machine learning models.
+
+
+Define Your Model
+=================
+
+Start the modeling process by defining your model. Do this by creating an instance
+of the :class:`~ModelPipeline` class. Each :class:`~ModelPipeline` corresponds to a
+scikit-learn :class:`~sklearn.pipeline.Pipeline` which will run in Civis Platform.
+A :class:`~sklearn.pipeline.Pipeline` allows you to combine multiple
+modeling steps (such as missing value imputation and feature selection) into a
+single model. The :class:`~sklearn.pipeline.Pipeline` is treated as a unit -- for example,
+cross-validation happens over all steps together.
+ 
+You can define your model in two ways, either by selecting a pre-defined algorithm
+or by providing your own scikit-learn
+:class:`~sklearn.pipeline.Pipeline` or :class:`~sklearn.base.Estimator` object.
+Note that whichever option you chose, CivisML will pre-process your data to
+one-hot-encode categorical features (the non-numerical columns) to binary indicator columns
+before sending the features to the :class:`~sklearn.pipeline.Pipeline`.
+
+       
+Pre-Defined Models
+------------------
+
+You can use the following pre-defined models with CivisML.
+All models start by imputing missing values with the mean of non-null
+values in a column. The "sparse_*" models include a LASSO regression step
+(using the `glmnet <https://github.com/civisanalytics/python-glmnet>`_ package)
+to do feature selection before passing data to the final model.
+In some models, CivisML uses default parameters different from those in scikit-learn,
+as indicated in the "Altered Defaults" column. All models also have ``random_state=42``.
+
+=============================  ================    ==================================================================================================================================   ==================================
+Name                           Model Type          Algorithm                                                                                                                            Altered Defaults
+=============================  ================    ==================================================================================================================================   ==================================
+sparse_logistic                classification      `LogisticRegression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_                ``C=499999950, tol=1e-08``
+gradient_boosting_classifier   classification      `GradientBoostingClassifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html>`_    ``n_estimators=500, max_depth=2``
+random_forest_classifier       classification      `RandomForestClassifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_            ``n_estimators=500``
+
+extra_trees_classifier         classification      `ExtraTreesClassifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html>`_                ``n_estimators=500``
+sparse_linear_regressor        regression          `LinearRegression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html>`_ 
+sparse_ridge_regressor         regression          `Ridge <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_ 
+gradient_boosting_regressor    regression          `GradientBoostingRegressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingRegressor.html>`_      ``n_estimators=500, max_depth=2``
+random_forest_regressor        regression          `RandomForestRegressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html>`_              ``n_estimators=500``
+extra_trees_regressor          regression          `ExtraTreesRegressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html>`_                  ``n_estimators=500``
+=============================  ================    ==================================================================================================================================   ==================================
+
+
+Custom Models
+-------------
+
+You can create your own :class:`~sklearn.pipeline.Pipeline` instead of using one of
+the pre-defined ones. Create the object and pass it as the ``model`` parameter
+of the :class:`ModelPipeline`. Your model must be built from libraries which CivisML
+recognizes. You can use code from
+
+- `scikit-learn <http://scikit-learn.org>`_ v0.18.1
+- `glmnet <https://github.com/civisanalytics/python-glmnet>`_ v2.0.0
+- `xgboost <http://xgboost.readthedocs.io>`_ v0.6a2
+- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.0.0
+
+When you're assembling your own model, remember that you'll have to make certain that
+either you add a missing value imputation step or that your data doesn't have any
+missing values. If you're making a classification model, the model must have a ``predict_proba``
+method. If the class you're using doesn't have a ``predict_proba`` method,
+you can add one by wrapping it in a :class:`~sklearn.calibration.CalibratedClassifierCV`.
+
+
+Asynchronous Execution
+======================
+
+All calls to a :class:`~ModelPipeline` object are non-blocking, i.e. they immediately
+provide a result without waiting for the job in the Civis Platform to complete.
+Calls to ``ModelPipeline.train`` and ``ModelPipeline.predict`` return
+a :class:`~ModelFuture` object, which is a subclass of
+:class:`~concurrent.futures.Future` from the Python standard library.
+This behavior lets you train multiple models at once, or generate predictions
+from models, while still doing other work while waiting for your jobs to complete.
+
+The :class:`~ModelFuture` can find and retrieve outputs from your CivisML jobs,
+such as trained :class:`~sklearn.pipeline.Pipeline` objects or out-of-sample predictions.
+The :class:`~ModelFuture` only downloads outputs when you request them.
+
+Model Persistence
+=================
+
+Civis Platform permanently stores all models, indexed by the job ID and the run ID
+(also called a "build") of the training job. If you wish to use an existing
+model, call :func:`ModelPipeline.from_existing` with the job ID of the training job.
+You can find the job ID with the ``train_job_id`` attribute of a :class:`~ModelFuture`,
+or by looking at the URL of your model on the
+`Civis Platform models page (https://platform.civisanalytics.com/#/models)`_.
+If the training job has multiple runs, you may also provide a run ID to select
+a run other than the most recent.
+You can list all model runs of a training job by calling
+``civis.APIClient().jobs.get(train_job_id)['runs']``.
+You may also store the :class:`~ModelPipeline` itself with the Python ``pickle`` module.
+
+
+Examples
+========
+
+:class:`concurrent.futures.Future` objects have the method ``add_done_callback``.
+This is called as soon as the run completes. It takes a single argument, the
+:class:`concurrent.futures.Future` for the completed job.
+You can use this method to chain jobs together::
+
+  from concurrent import futures
+  from civismodel import ModelPipeline
+  from civismodel.tests.datasets import load_iris
+  df = load_iris()
+  training, predictions = [], []
+  model = ModelPipeline('sparse_logistic', dependent_variable='type')
+  training.append(model.train(df))
+  training[-1].add_done_callback(lambda fut: predictions.append(model.predict(df)))
+  futures.wait(training)  # Blocks until all training jobs complete
+  futures.wait(predictions)  # Blocks until all prediction jobs complete
+
+You can create and train multiple models at once to find the best approach
+for solving a problem. For example::
+
+  algorithms = ['gradient_boosting_classifier', 'sparse_logistic', 'random_forest_classifier']
+  pkey = 'person_id'
+  depvar = 'likes_cats'
+  models = [ModelPipeline(alg, primary_key=pkey, dependent_variable=depvar) for alg in algorithms]
+  train = [model.train(table_name='schema.name', database_name='My DB') for model in models]
+  aucs = [tr.metrics['roc_auc'] for tr in train]  # Code blocks here
+
+Optional dependencies
+=====================
+
+You do not need any external libraries installed to use CivisML, but
+the following pip-installable dependencies enhance the capabilities of the
+:class:`~ModelPipeline`:
+
+- pandas
+- scikit-learn
+- joblib
+- glmnet
+- pubnub
+
+Install ``pandas`` if you wish to download tables of predictions.
+You can also model on :class:`~pandas.DataFrame` objects in your interpreter.
+
+If you wish to use custom models or download trained models,
+you'll need scikit-learn installed.
+
+We use the ``joblib`` library to move scikit-learn models back and forth from Platform.
+Install it if you wish to use custom models or download trained models.
+
+The "sparse_logistic", "sparse_linear_regressor", and "sparse_ridge_regressor" models
+all use the public Civis Analytics ``glmnet`` library. Install it if you wish to download
+a model created from one of these pre-defined models.
+
+If you install ``pubnub``, the Civis Platform API client can use the notifications endpoint instead of
+polling for job completion. This gives faster results and uses fewer API calls.
+
+
+Object reference
+================
+
+.. autoclass:: civismodel.api.ModelPipeline
+	       :members:
+
+.. autoclass:: civismodel.api.ModelFuture
+	       :members:
+	       :inherited-members:
+		  
+		 

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -15,7 +15,7 @@ Define Your Model
 =================
 
 Start the modeling process by defining your model. Do this by creating an instance
-of the :class:`~ModelPipeline` class. Each :class:`~ModelPipeline` corresponds to a
+of the :class:`~civis.ml.ModelPipeline` class. Each :class:`~civis.ml.ModelPipeline` corresponds to a
 scikit-learn :class:`~sklearn.pipeline.Pipeline` which will run in Civis Platform.
 A :class:`~sklearn.pipeline.Pipeline` allows you to combine multiple
 modeling steps (such as missing value imputation and feature selection) into a
@@ -24,7 +24,7 @@ cross-validation happens over all steps together.
  
 You can define your model in two ways, either by selecting a pre-defined algorithm
 or by providing your own scikit-learn
-:class:`~sklearn.pipeline.Pipeline` or :class:`~sklearn.base.Estimator` object.
+:class:`~sklearn.pipeline.Pipeline` or :class:`~sklearn.base.BaseEstimator` object.
 Note that whichever option you chose, CivisML will pre-process your data to
 one-hot-encode categorical features (the non-numerical columns) to binary indicator columns
 before sending the features to the :class:`~sklearn.pipeline.Pipeline`.
@@ -62,7 +62,7 @@ Custom Models
 
 You can create your own :class:`~sklearn.pipeline.Pipeline` instead of using one of
 the pre-defined ones. Create the object and pass it as the ``model`` parameter
-of the :class:`ModelPipeline`. Your model must be built from libraries which CivisML
+of the :class:`~civis.ml.ModelPipeline`. Your model must be built from libraries which CivisML
 recognizes. You can use code from
 
 - `scikit-learn <http://scikit-learn.org>`_ v0.18.1
@@ -80,46 +80,49 @@ you can add one by wrapping it in a :class:`~sklearn.calibration.CalibratedClass
 Asynchronous Execution
 ======================
 
-All calls to a :class:`~ModelPipeline` object are non-blocking, i.e. they immediately
+All calls to a :class:`~civis.ml.ModelPipeline` object are non-blocking, i.e. they immediately
 provide a result without waiting for the job in the Civis Platform to complete.
-Calls to ``ModelPipeline.train`` and ``ModelPipeline.predict`` return
-a :class:`~ModelFuture` object, which is a subclass of
+Calls to :meth:`civis.ml.ModelPipeline.train` and :meth:`civis.ml.ModelPipeline.predict` return
+a :class:`~civis.ml.ModelFuture` object, which is a subclass of
 :class:`~concurrent.futures.Future` from the Python standard library.
 This behavior lets you train multiple models at once, or generate predictions
 from models, while still doing other work while waiting for your jobs to complete.
 
-The :class:`~ModelFuture` can find and retrieve outputs from your CivisML jobs,
+The :class:`~civis.ml.ModelFuture` can find and retrieve outputs from your CivisML jobs,
 such as trained :class:`~sklearn.pipeline.Pipeline` objects or out-of-sample predictions.
-The :class:`~ModelFuture` only downloads outputs when you request them.
+The :class:`~civis.ml.ModelFuture` only downloads outputs when you request them.
+
 
 Model Persistence
 =================
 
 Civis Platform permanently stores all models, indexed by the job ID and the run ID
 (also called a "build") of the training job. If you wish to use an existing
-model, call :func:`ModelPipeline.from_existing` with the job ID of the training job.
-You can find the job ID with the ``train_job_id`` attribute of a :class:`~ModelFuture`,
+model, call :meth:`civis.ml.ModelPipeline.from_existing` with the job ID of the training job.
+You can find the job ID with the :attr:`~civis.ml.ModelFuture.train_job_id`
+attribute of a :class:`~civis.ml.ModelFuture`,
 or by looking at the URL of your model on the
-`Civis Platform models page (https://platform.civisanalytics.com/#/models)`_.
+`Civis Platform models page <https://platform.civisanalytics.com/#/models>`_.
 If the training job has multiple runs, you may also provide a run ID to select
 a run other than the most recent.
 You can list all model runs of a training job by calling
 ``civis.APIClient().jobs.get(train_job_id)['runs']``.
-You may also store the :class:`~ModelPipeline` itself with the Python ``pickle`` module.
+You may also store the :class:`~civis.ml.ModelPipeline` itself with the :mod:`pickle` module.
 
 
 Examples
 ========
 
-:class:`concurrent.futures.Future` objects have the method ``add_done_callback``.
+:class:`~concurrent.futures.Future` objects have the method
+:meth:`~concurrent.futures.Future.add_done_callback`.
 This is called as soon as the run completes. It takes a single argument, the
-:class:`concurrent.futures.Future` for the completed job.
+:class:`~concurrent.futures.Future` for the completed job.
 You can use this method to chain jobs together::
 
   from concurrent import futures
-  from civismodel import ModelPipeline
-  from civismodel.tests.datasets import load_iris
-  df = load_iris()
+  from civis.ml import ModelPipeline
+  import pandas as pd
+  df = pd.read_csv('data.csv')
   training, predictions = [], []
   model = ModelPipeline('sparse_logistic', dependent_variable='type')
   training.append(model.train(df))
@@ -130,6 +133,7 @@ You can use this method to chain jobs together::
 You can create and train multiple models at once to find the best approach
 for solving a problem. For example::
 
+  from civis.ml import ModelPipeline
   algorithms = ['gradient_boosting_classifier', 'sparse_logistic', 'random_forest_classifier']
   pkey = 'person_id'
   depvar = 'likes_cats'
@@ -142,7 +146,7 @@ Optional dependencies
 
 You do not need any external libraries installed to use CivisML, but
 the following pip-installable dependencies enhance the capabilities of the
-:class:`~ModelPipeline`:
+:class:`~civis.ml.ModelPipeline`:
 
 - pandas
 - scikit-learn
@@ -150,7 +154,7 @@ the following pip-installable dependencies enhance the capabilities of the
 - glmnet
 - pubnub
 
-Install ``pandas`` if you wish to download tables of predictions.
+Install :mod:`pandas` if you wish to download tables of predictions.
 You can also model on :class:`~pandas.DataFrame` objects in your interpreter.
 
 If you wish to use custom models or download trained models,
@@ -166,15 +170,13 @@ a model created from one of these pre-defined models.
 If you install ``pubnub``, the Civis Platform API client can use the notifications endpoint instead of
 polling for job completion. This gives faster results and uses fewer API calls.
 
-
 Object reference
 ================
 
-.. autoclass:: civismodel.api.ModelPipeline
+.. autoclass:: civis.ml.ModelPipeline
 	       :members:
 
-.. autoclass:: civismodel.api.ModelFuture
+
+.. autoclass:: civis.ml.ModelFuture
 	       :members:
 	       :inherited-members:
-		  
-		 


### PR DESCRIPTION
This adds Sphinx documentation for the new `civis.ml` namespace. This PR includes changes to the doc strings in `civis.ml` to make the formatting nicer on the autodoc'ed Sphinx page.