### PR TITLE
[CIVP-11088] Use correct job/run ID when fetching training metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     - "3.4"
 install:
+    - pip install --upgrade pip setuptools
     - pip install -r requirements.txt
     - pip install -r dev-requirements.txt
     - pip install -e .[pubnub]

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -460,8 +460,10 @@ class ModelFuture(CivisFuture):
     @_block_and_handle_missing
     def training_metadata(self):
         if self._train_metadata is None:
-            fid = cio.file_id_from_run_output('model_info.json', self.job_id,
-                                              self.run_id, client=self.client)
+            fid = cio.file_id_from_run_output('model_info.json',
+                                              self.train_job_id,
+                                              self.train_run_id,
+                                              client=self.client)
             self._train_metadata = cio.file_to_json(fid, client=self.client)
         return self._train_metadata
 


### PR DESCRIPTION
We had been using the associated job and run IDs, when we should have been using the job and run IDs of the connected training job.