### PR TITLE
[CIVP-10806] BUG Allow `from_existing` to handle v0 templates

### DIFF
--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -665,7 +665,9 @@ class ModelPipeline:
             raise
 
         args = container.arguments
-        model = args['MODEL']
+
+        # Older templates used "WORKFLOW" instead of "MODEL"
+        model = args.get('MODEL', args.get('WORKFLOW'))
         dependent_variable = args['TARGET_COLUMN'].split()
         primary_key = args.get('PRIMARY_KEY')
         parameters = json.loads(args.get('PARAMS', {}))


### PR DESCRIPTION
Older model templates used "WORKFLOW" where the new templates have "MODEL". When loading an old model, check first for "MODEL" and next for "WORKFLOW". It will have one of these if it's a CivisML job.