### PR TITLE
[CIVP-11103] ENH ModelFuture recognize and raies MemoryErrors

### DIFF
--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -313,20 +313,15 @@ class ModelFuture(CivisFuture):
             if fut.is_training and meta['run']['status'] == 'succeeded':
                 # if training job and job succeeded, check validation job
                 meta = fut.validation_metadata
-            if (meta['run']['status'] == 'exception' and
-                    not isinstance(fut._exception, ModelError)):
-                # `set_exception` invokes callbacks, so make sure
-                # we haven't already set a `ModelError` to avoid
-                # infinite recursion.
-                try:
-                    # This will fail if the user doesn't have joblib installed
-                    est = fut.estimator
-                except Exception:  # NOQA
-                    est = None
-                fut.set_exception(
-                      ModelError('Model run failed with stack trace:\n'
-                                 '{}'.format(meta['run']['stack_trace']),
-                                 est, meta))
+            try:
+                # This will fail if the user doesn't have joblib installed
+                est = fut.estimator
+            except Exception:  # NOQA
+                est = None
+            fut.set_exception(
+                  ModelError('Model run failed with stack trace:\n'
+                             '{}'.format(meta['run']['stack_trace']),
+                             est, meta))
         except (FileNotFoundError, CivisJobFailure) as exc:
             # If there's no metadata file
             # (we get FileNotFound or CivisJobFailure),


### PR DESCRIPTION
Modify the `ModelFuture` to notice when the jobs it's connected to failed because they ran out of memory. If that happened, re-raise an appropriate error so that the user can handle it. We can't do anything about this on the Platform side -- Python dies abruptly without being able to write any outputs.

Before:

![screen shot 2017-05-10 at 4 24 59 pm](https://cloud.githubusercontent.com/assets/8355977/25922030/43aae9d0-359d-11e7-82fd-862f68d7940b.png)

After:

![screen shot 2017-05-10 at 4 24 08 pm](https://cloud.githubusercontent.com/assets/8355977/25922035/4855f948-359d-11e7-9692-ed8def9c149b.png)
