### PR TITLE
[CIVP-11103] COMPAT Fix test in test_model for Python 2

### DIFF
--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1,3 +1,4 @@
+from builtins import super
 from collections import namedtuple
 from six import BytesIO
 import json


### PR DESCRIPTION
PR #79 added test code in the `test_model` module which is not Python 2-compatible. This fixes it.