### PR TITLE
[CIVP-11405] BLD: Fix functools32 installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix issue with Python 2/3 dependency management (#89).
+
 ## 1.5.1 - 2017-05-15
 ### Fixed
 - Fixed a bug which caused an exception to be set on all ``ModelFuture`` objects, regardless of job status (#86).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyyaml>=3.0,<=3.99
 click>=6.0,<=6.99
 funcsigs==1.0.2 ; python_version == '2.7'
-future>-0.16,<=0.99 ; python_version == '2.7'
+future>=0.16,<=0.99 ; python_version == '2.7'
 futures==3.1.1 ; python_version == '2.7'
 jsonref>=0.1.0,<=0.1.99
 requests>=2.12.0,==2.*

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import re
 import os
+import setuptools
 from setuptools import find_packages, setup
 
 CLASSIFIERS = [
@@ -9,6 +10,10 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
 ]
+
+
+if int(setuptools.__version__.split(".", 1)[0]) < 18:
+    raise AssertionError("setuptools >= 18 must be installed")
 
 
 def get_version():
@@ -24,14 +29,9 @@ def get_version():
     return ".".join([MAJOR, MINOR, MICRO])
 
 
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as _in:
-        return _in.read()
-
-
 def main():
-    with open('requirements.txt') as f:
-        required = f.read().splitlines()
+    with open('README.rst') as README_FILE:
+        README = README_FILE.read()
 
     setup(
         classifiers=CLASSIFIERS,
@@ -42,9 +42,22 @@ def main():
         url="https://www.civisanalytics.com",
         description="Access the Civis Platform API",
         packages=find_packages(),
-        long_description=read('README.rst'),
-        install_requires=required,
+        long_description=README,
+        install_requires=[
+            'pyyaml>=3.0,<=3.99',
+            'click>=6.0,<=6.99',
+            'jsonref>=0.1.0,<=0.1.99',
+            'requests>=2.12.0,==2.*',
+            'jsonschema>=2.5.1,==2.*',
+            'six>=1.10,<=1.99',
+        ],
         extras_require={
+            ':python_version=="2.7"': [
+                'funcsigs==1.0.2',
+                'future>=0.16,<=0.99',
+                'futures==3.1.1',
+                'functools32>=3.2<=3.99'
+            ],
             'pubnub': ['pubnub>=4.0.0,<=4.99']
         },
         entry_points={
@@ -53,6 +66,7 @@ def main():
             ]
         }
     )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hopefully fixes the following error on Python 3, but I haven't been able to replicate not installing from PyPI.

```
Using cached functools32-3.2.3-2.zip
Complete output from command python setup.py egg_info:
This backport is for Python 2.7 only.
```

Issue is described in the following

https://github.com/inveniosoftware/invenio-oaiserver/issues/112
https://github.com/Julian/jsonschema/issues/228
https://hynek.me/articles/conditional-python-dependencies/
https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies

And the differing usage of install_requires vs requirements.txt here

https://packaging.python.org/requirements/