### PR TITLE
[CIVP-11423] BUG get validation metadata from training job for prediction future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed a bug where ``ModelFuture.validation_metadata`` would not source training job metadata for a ``ModelFuture`` corresponding to prediction job (#90).
 
-## 1.5.1 - 2017-05-16
+## 1.5.1 - 2017-05-15
 ### Fixed
 - Fixed a bug which caused an exception to be set on all ``ModelFuture`` objects, regardless of job status (#86).
 - Fixed a bug which made the ``ModelPipeline`` unable to generate prediction jobs for models trained with v0.5 templates (#84).
 - Handle the case when inputs to ``ModelFuture`` are ``numpy.int64`` (or other non-``integer`` ints) (#85).
-- Fixed a bug where ``ModelFuture.validation_metadata`` would not source training job metadata for a ``ModelFuture`` corresponding to prediction job (#90).
 
 ### Changed
 - Convert `README.md` (Markdown) to `README.rst` (reStructuredText).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 1.5.1 - 2017-05-15
+## 1.5.1 - 2017-05-16
 ### Fixed
 - Fixed a bug which caused an exception to be set on all ``ModelFuture`` objects, regardless of job status (#86).
 - Fixed a bug which made the ``ModelPipeline`` unable to generate prediction jobs for models trained with v0.5 templates (#84).
 - Handle the case when inputs to ``ModelFuture`` are ``numpy.int64`` (or other non-``integer`` ints) (#85).
+- Fixed a bug where ``ModelFuture.validation_metadata`` would not source training job metadata for a ``ModelFuture`` corresponding to prediction job (#90).
 
 ### Changed
 - Convert `README.md` (Markdown) to `README.rst` (reStructuredText).

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -491,8 +491,10 @@ class ModelFuture(CivisFuture):
     @_block_and_handle_missing
     def validation_metadata(self):
         if self._val_metadata is None:
-            fid = cio.file_id_from_run_output('metrics.json', self.job_id,
-                                              self.run_id, client=self.client)
+            fid = cio.file_id_from_run_output('metrics.json',
+                                              self.train_job_id,
+                                              self.train_run_id,
+                                              client=self.client)
             self._val_metadata = cio.file_to_json(fid, client=self.client)
         return self._val_metadata
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -465,8 +465,9 @@ def test_estimator(mock_le):
         "The Estimator is only downloaded once and cached."
 
 
-@mock.patch.object(_model.cio, "file_id_from_run_output")
-@mock.patch.object(_model.cio, "file_to_json", return_value='foo')
+@mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
+@mock.patch.object(_model.cio, "file_to_json", return_value='foo',
+                   autospec=True)
 @mock.patch.object(_model.ModelFuture, "_set_model_exception")
 def test_validation_metadata_training(mock_spe, mock_f2f,
                                       mock_file_id_from_run_output):
@@ -480,8 +481,9 @@ def test_validation_metadata_training(mock_spe, mock_f2f,
                                                     client=mock.ANY)
 
 
-@mock.patch.object(_model.cio, "file_id_from_run_output")
-@mock.patch.object(_model.cio, "file_to_json", return_value='foo')
+@mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
+@mock.patch.object(_model.cio, "file_to_json", return_value='foo',
+                   autospec=True)
 @mock.patch.object(_model.ModelFuture, "_set_model_exception")
 def test_validation_metadata_prediction(mock_spe, mock_f2f,
                                         mock_file_id_from_run_output):

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -465,26 +465,60 @@ def test_estimator(mock_le):
         "The Estimator is only downloaded once and cached."
 
 
-@mock.patch.object(_model.cio, "file_id_from_run_output",
-                   mock.Mock(return_value=11, spec_set=True))
+@mock.patch.object(_model.cio, "file_id_from_run_output")
 @mock.patch.object(_model.cio, "file_to_json", return_value='foo')
 @mock.patch.object(_model.ModelFuture, "_set_model_exception")
-def test_validation_metadata(mock_spe, mock_f2f):
+def test_validation_metadata_training(mock_spe, mock_f2f,
+                                      mock_file_id_from_run_output):
+    mock_file_id_from_run_output.return_value = 11
     c = setup_client_mock(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
+
     assert mf.validation_metadata == 'foo'
     mock_f2f.assert_called_once_with(11, client=c)
+    mock_file_id_from_run_output.assert_called_with('metrics.json', 3, 7,
+                                                    client=mock.ANY)
 
 
-@mock.patch.object(_model.cio, "file_id_from_run_output",
-                   mock.Mock(return_value=11, spec_set=True))
+@mock.patch.object(_model.cio, "file_id_from_run_output")
+@mock.patch.object(_model.cio, "file_to_json", return_value='foo')
+@mock.patch.object(_model.ModelFuture, "_set_model_exception")
+def test_validation_metadata_prediction(mock_spe, mock_f2f,
+                                        mock_file_id_from_run_output):
+    mock_file_id_from_run_output.return_value = 11
+    c = setup_client_mock(3, 7)
+    mf = _model.ModelFuture(1, 2, 3, 7, client=c)
+
+    assert mf.validation_metadata == 'foo'
+    mock_f2f.assert_called_once_with(11, client=c)
+    mock_file_id_from_run_output.assert_called_with('metrics.json', 3, 7,
+                                                    client=mock.ANY)
+
+
+@mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
 @mock.patch.object(_model.cio, "file_to_json",
                    mock.MagicMock(return_value={'metrics': 'foo'}))
-def test_metrics():
+def test_metrics_training(mock_file_id_from_run_output):
+    mock_file_id_from_run_output.return_value = 11
     c = setup_client_mock(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
 
     assert mf.metrics == 'foo'
+    mock_file_id_from_run_output.assert_called_with('metrics.json', 3, 7,
+                                                    client=mock.ANY)
+
+
+@mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
+@mock.patch.object(_model.cio, "file_to_json",
+                   mock.MagicMock(return_value={'metrics': 'foo'}))
+def test_metrics_prediction(mock_file_id_from_run_output):
+    mock_file_id_from_run_output.return_value = 11
+    c = setup_client_mock(3, 7)
+    mf = _model.ModelFuture(1, 2, 3, 7, client=c)
+
+    assert mf.metrics == 'foo'
+    mock_file_id_from_run_output.assert_called_with('metrics.json', 3, 7,
+                                                    client=mock.ANY)
 
 
 #####################################


### PR DESCRIPTION
This was the only `@property` that wasn't tying the file ID lookups to the training job.

EDIT: now pointing at `release-1.5`.