### PR TITLE
[CIVP-11427] BUG Improve thread safety in PollableResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Added more locks to improve thread safety in the ``PollableResult`` and ``CivisFuture``.
+
 ## 1.5.1 - 2017-05-15
 ### Fixed
 - Fixed a bug which caused an exception to be set on all ``ModelFuture`` objects, regardless of job status (#86).

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -123,9 +123,10 @@ class CivisFuture(PollableResult):
                 len(self._pubnub.get_subscribed_channels()) > 0)
 
     def cleanup(self):
-        super().cleanup()
-        if hasattr(self, '_pubnub'):
-            self._pubnub.unsubscribe_all()
+        with self._condition:
+            super().cleanup()
+            if hasattr(self, '_pubnub'):
+                self._pubnub.unsubscribe_all()
 
     def _subscribe(self, pnconfig, channels):
         listener = JobCompleteListener(self._check_message,

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -393,6 +393,7 @@ class ModelFuture(CivisFuture):
 
     def __setstate__(self, state):
         self.__dict__ = state
+        self._condition = threading.Condition()
         self.client = APIClient(resources='all')
         if getattr(self, '_pubnub', None) is True:
             # Re-subscribe to notifications channel
@@ -400,7 +401,6 @@ class ModelFuture(CivisFuture):
         self._polling_thread = _ResultPollingThread(self._check_result, (),
                                                     self.polling_interval)
         self.poller = self.client.scripts.get_containers_runs
-        self._condition = threading.Condition()
         self.add_done_callback(self._set_model_exception)
 
     @property


### PR DESCRIPTION
We have at least once instance of a bug which looks to be caused by non-threadsafe code. The most likely culprit is in the `PollableResult` stack. Add some extra locks to avoid possibly double-destroying anything. `cleanup` looks like it was always called from inside a function holding the lock, so it's probably fine. It doesn't hurt to add an extra lock. `_reset_polling_thread` wasn't behind a lock, and it was being used as a callback from `pubnub` -- perhaps this could have been a problem?