### PR TITLE
[CIVP-11087] Fix readme filename extension in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
-include README.md
+include README.rst
 include LICENSE.md
 include civis/_version.py


### PR DESCRIPTION
I missed this when converting the readme from Markdown to reStructuredText at #83. Probably no bugfix release is needed.