### PR TITLE
show expected types of arguments in the CLI

### DIFF
--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -323,8 +323,8 @@ def add_command_params(cmd, op_dict):
         description = p.get('description', '')
 
         if p['required']:
-            cmd.help += "\n\n{} - {}".format(p['name'].upper(),
-                                             description)
+            cmd.help += "\n\n{} ({}) - {}".format(
+                p['name'].upper(), param_type_spec, description)
             arg = click.Argument([p['name'].lower()],
                                  type=param_type)
             cmd.params.append(arg)


### PR DESCRIPTION
The CLI didn't indicate the types of required arguments, and this was confusing for cases like `civis scripts put-containers-archive`, where a "status" boolean is expected.

Note that YAML is 

Before:

```
» civis scripts put-containers-archive --help
Usage: civis scripts put-containers-archive [OPTIONS] ID STATUS

  Update the archive status of this object

  /scripts/containers/{id}/archive

  ID - The ID of the object.

  STATUS - The desired archived status of the object.
...
```

After:

```
» civis scripts put-containers-archive --help
Usage: civis scripts put-containers-archive [OPTIONS] ID STATUS

  Update the archive status of this object

  /scripts/containers/{id}/archive

  ID (integer) - The ID of the object.

  STATUS (boolean) - The desired archived status of the object.
...
```

Note that yaml is case-insensitive when parsing inputs as booleans.

```
In [6]: yaml.load("True")
Out[6]: True

In [7]: yaml.load("true")
Out[7]: True

In [8]: yaml.load("TRUE")
Out[8]: True

In [9]: yaml.load("FALSE")
Out[9]: False
```