### PR TITLE
[CIVP-11787] Add joblib backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added email notifications option to ``ModelPipeline``.
+- Added custom ``joblib`` backend for multiprocessing in the Civis Platform. Public-facing functions are ``make_backend_factory``, ``make_backend_template_factory``, and ``infer_backend_factory``.
 
 ### Fixed
 - Fixed a bug where the version of a dependency for Python 2.7 usage was incorrectly specified.

--- a/civis/compat.py
+++ b/civis/compat.py
@@ -36,6 +36,10 @@ else:
 
         Upon exiting the context, the directory and everything contained
         in it are removed.
+
+        This is a port of the Python 3.2+ TemporaryDirectory object,
+        modified slightly to work with Python 2.7. Python 3 docs are at
+        https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
         """
 
         def __init__(self, suffix='', prefix='tmp', dir=None):

--- a/civis/compat.py
+++ b/civis/compat.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from __future__ import print_function
 
 import six
 
@@ -15,3 +16,62 @@ else:
     from functools32 import lru_cache
     from funcsigs import signature
     FileNotFoundError = IOError
+
+if six.PY3:
+    from tempfile import TemporaryDirectory
+else:
+    # Backport TemporaryDirectory; this was introduced in Python 3.2
+    from tempfile import mkdtemp
+    import shutil as _shutil
+    import sys as _sys
+    import warnings as _warnings
+
+    class TemporaryDirectory(object):
+        """Create and return a temporary directory.  This has the same
+        behavior as mkdtemp but can be used as a context manager.  For
+        example:
+
+            with TemporaryDirectory() as tmpdir:
+                ...
+
+        Upon exiting the context, the directory and everything contained
+        in it are removed.
+        """
+
+        def __init__(self, suffix='', prefix='tmp', dir=None):
+            self._closed = False
+            self.name = None  # Handle mkdtemp raising an exception
+            self.name = mkdtemp(suffix, prefix, dir)
+
+        def __repr__(self):
+            return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+        def __enter__(self):
+            return self.name
+
+        def __exit__(self, exc, value, tb):
+            self.cleanup()
+
+        def __del__(self):
+            # Issue a ResourceWarning if implicit cleanup needed
+            self.cleanup(_warn=True)
+
+        def cleanup(self, _warn=False):
+            if self.name and not self._closed:
+                try:
+                    _shutil.rmtree(self.name)
+                except (TypeError, AttributeError) as ex:
+                    # Issue #10188: Emit a warning on stderr
+                    # if the directory could not be cleaned
+                    # up due to missing globals
+                    if "None" not in str(ex):
+                        raise
+                    print("ERROR: {!r} while cleaning up "
+                          "{!r}".format(ex, self,),
+                          file=_sys.stderr)
+                    return
+                self._closed = True
+                if _warn:
+                    _warnings.warn("Implicitly cleaning up {!r}".format(self),
+                                   ResourceWarning)
+

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -1,0 +1,732 @@
+"""
+A module that facilitates the use of Civis's container scripts for
+parallelizing Python workflows.
+"""
+from concurrent.futures import wait
+from datetime import datetime, timedelta
+from io import BytesIO
+import logging
+import os
+from tempfile import TemporaryDirectory
+import time
+
+import joblib
+from joblib._parallel_backends import ParallelBackendBase
+from joblib.my_exceptions import TransportableException
+import civis
+from civis.base import CivisAPIError
+import requests
+
+from civisjobs.containers import ContainerPoolExecutor, CustomPoolExecutor
+
+_LOGGER = logging.getLogger(__name__)
+_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+_DEFAULT_SETUP_CMD = ":"  # An sh command that does nothing.
+_DEFAULT_REPO_SETUP_CMD = "cd /app; python setup.py install; cd /"
+_ALL_JOBS = 50  # Give the user this many jobs if they request "all of them"
+
+
+def infer_backend_factory(required_resources=None,
+                          params=None,
+                          arguments=None,
+                          client=None,
+                          polling_interval=None,
+                          setup_cmd=None,
+                          max_submit_retries=0,
+                          max_job_retries=0,
+                          hidden=True):
+    """Infer the container environment and return a backend factory.
+
+    This function helps you run additional jobs from code which executes
+    inside a Civis container job. The function reads settings for
+    relevant parameters (e.g. the Docker image) of the container
+    it's running inside of.
+
+    .. note:: This function will read the state of the parent
+    container job at the time this function executes. If the
+    user has modified the container job since the run started
+    (e.g. by changing the GitHub branch in the container's GUI),
+    this function may infer incorrect settings for the child jobs.
+
+    Parameters
+    ----------
+    required_resources : dict or None, optional
+        The resources needed by the container. See the
+        `container scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details. Resource requirements not specified will
+        default to the requirements of the current job.
+    params : list or None, optional
+        A definition of the parameters this script accepts in the
+        arguments field. See the `container scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+            Parameters of the child jobs will default to the parameters
+        of the current job. Any parameters provided here will override
+        parameters of the same name from the current job.
+    arguments : dict or None, optional
+        Dictionary of name/value pairs to use to run this script.
+        Only settable if this script has defined params. See the `container
+        scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+            Arguments will default to the arguments of the current job.
+        Anything provided here will override portions of the current job's
+        arguments.
+    client : `civis.APIClient` instance or None, optional
+        An API Client object to use.
+    polling_interval : int, optional
+        The polling interval, in seconds, for checking container script status.
+        If you have many jobs, you may want to set this higher (e.g., 300) to
+        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        You should only set this if you aren't using ``pubnub`` notifications.
+    setup_cmd : str, optional
+        A shell command or sequence of commands for setting up the environment.
+        These will precede the commands used to run functions in joblib.
+        This is primarily for installing dependencies that are not available
+        in the dockerhub repo (e.g., "cd /app && python setup.py install"
+        or "pip install gensim").
+            With no GitHub repo input, the setup command will
+        default to a command that does nothing. If a `repo_http_uri`
+        is provided, the default setup command will attempt to run
+        "python setup.py install". If this command fails, execution
+        will still continue.
+    max_submit_retries : int, optional
+        The maximum number of retries for submitting each job. This is to help
+        avoid a large set of jobs failing because of a single 5xx error. A
+        value higher than zero should only be used for jobs that are idempotent
+        (i.e., jobs whose result and side effects are the same regardless of
+        whether they are run once or many times).
+    max_job_retries : int, optional
+        Retry failed jobs this number of times before giving up.
+        Even more than with `max_submit_retries`, this should only
+        be used for jobs which are idempotent, as the job may have
+        caused side effects (if any) before failing.
+        These retries assist with jobs which may have failed because
+        of network or worker failures.
+    hidden: bool, optional
+        The hidden status of the object. Setting this to true
+        hides it from most API endpoints. The object can still
+        be queried directly by ID. Defaults to True.
+
+    Raises
+    ------
+    RuntimeError
+        If this function is not running inside a Civis container job.
+
+    See Also
+    --------
+    make_backend_factory
+    """
+    if client is None:
+        client = civis.APIClient(resources='all')
+
+    if not os.environ.get('CIVIS_JOB_ID'):
+        raise RuntimeError('This function must be run '
+                           'inside a container job.')
+    state = client.scripts.get_containers(os.environ['CIVIS_JOB_ID'])
+    if state.from_template_id:
+        # If this is a Custom Script from a template, we need the
+        # backing script. Make sure to save the arguments from
+        # the Custom Script: those are the only user-settable parts.
+        template = client.templates.get_scripts(state.from_template_id)
+        try:
+            custom_args = state.arguments
+            state = client.scripts.get_containers(template.script_id)
+            state.arguments = custom_args
+        except civis.base.CivisAPIError as err:
+            if err.status_code == 404:
+                raise RuntimeError('Unable to introspect environment from '
+                                   'your template\'s backing script. '
+                                   'You may not have permission to view '
+                                   'script ID {}.'.format(template.script_id))
+            else:
+                raise
+
+    # Default to this container's resource requests, but
+    # allow users to override it.
+    state.required_resources.update(required_resources or {})
+
+    # Update parameters with user input
+    params = params or []
+    for input_param in params:
+        for param in state.params:
+            if param['name'] == input_param['name']:
+                param.update(input_param)
+                break
+        else:
+            state.params.append(input_param)
+
+    # Update arguments with input
+    state.arguments.update(arguments or {})
+
+    return make_backend_factory(docker_image_name=state.docker_image_name,
+                                docker_image_tag=state.docker_image_tag,
+                                repo_http_uri=state.repo_http_uri,
+                                repo_ref=state.repo_ref,
+                                required_resources=state.required_resources,
+                                params=state.params,
+                                arguments=state.arguments,
+                                client=client,
+                                polling_interval=polling_interval,
+                                setup_cmd=setup_cmd,
+                                max_submit_retries=max_submit_retries,
+                                max_job_retries=max_job_retries,
+                                hidden=hidden)
+
+
+def make_backend_factory(docker_image_name="civisanalytics/datascience-base",
+                         docker_image_tag="latest",
+                         repo_http_uri=None,
+                         repo_ref=None,
+                         required_resources=None,
+                         params=None,
+                         arguments=None,
+                         client=None,
+                         polling_interval=None,
+                         setup_cmd=None,
+                         max_submit_retries=0,
+                         max_job_retries=0,
+                         hidden=True):
+    """Create a joblib backend factory that uses Civis container scripts.
+
+    Parameters
+    ----------
+    docker_image_name : str, optional
+        The image for the container script.
+    docker_image_tag : str, optional
+        The tag for the Docker image.
+    repo_http_uri : str, optional
+        The GitHub repo to check out to /app
+        (e.g., github.com/my-user/my-repo.git)
+    repo_ref : str, optional
+        The GitHub repo reference to check out (e.g., "master")
+    required_resources : dict or None, optional
+        The resources needed by the container. See the
+        `container scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+    params : list or None, optional
+        A definition of the parameters this script accepts in the
+        arguments field. See the `container scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+    arguments : dict or None, optional
+        Dictionary of name/value pairs to use to run this script.
+        Only settable if this script has defined params. See the `container
+        scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+    client : `civis.APIClient` instance or None, optional
+        An API Client object to use.
+    polling_interval : int, optional
+        The polling interval, in seconds, for checking container script status.
+        If you have many jobs, you may want to set this higher (e.g., 300) to
+        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        You should only set this if you aren't using ``pubnub`` notifications.
+    setup_cmd : str, optional
+        A shell command or sequence of commands for setting up the environment.
+        These will precede the commands used to run functions in joblib.
+        This is primarily for installing dependencies that are not available
+        in the dockerhub repo (e.g., "cd /app && python setup.py install"
+        or "pip install gensim").
+            With no GitHub repo input, the setup command will
+        default to a command that does nothing. If a `repo_http_uri`
+        is provided, the default setup command will attempt to run
+        "python setup.py install". If this command fails, execution
+        will still continue.
+    max_submit_retries : int, optional
+        The maximum number of retries for submitting each job. This is to help
+        avoid a large set of jobs failing because of a single 5xx error. A
+        value higher than zero should only be used for jobs that are idempotent
+        (i.e., jobs whose result and side effects are the same regardless of
+        whether they are run once or many times).
+    max_job_retries : int, optional
+        Retry failed jobs this number of times before giving up.
+        Even more than with `max_submit_retries`, this should only
+        be used for jobs which are idempotent, as the job may have
+        caused side effects (if any) before failing.
+        These retries assist with jobs which may have failed because
+        of network or worker failures.
+    hidden: bool, optional
+        The hidden status of the object. Setting this to true
+        hides it from most API endpoints. The object can still
+        be queried directly by ID. Defaults to True.
+
+    Examples
+    --------
+    >>> # Without joblib:
+    >>> from math import sqrt
+    >>> print([sqrt(i ** 2) for i in range(10)])
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+    >>> # Using the default joblib backend:
+    >>> from joblib import delayed, Parallel
+    >>> parallel = Parallel(n_jobs=5)
+    >>> print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+    >>> # Using the Civis backend:
+    >>> from joblib import parallel_backend, register_parallel_backend
+    >>> from civisjobs import make_backend_factory
+    >>> register_parallel_backend('civis', make_backend_factory(
+    ...     required_resources={"cpu": 512, "memory": 256}))
+    >>> with parallel_backend('civis'):
+    ...    parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
+    ...    print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+    >>> # Using scikit-learn with the Civis backend:
+    >>> from sklearn.externals.joblib import \
+    ...     register_parallel_backend as sklearn_register_parallel_backend
+    >>> from sklearn.externals.joblib import \
+    ...     parallel_backend as sklearn_parallel_backend
+    >>> from sklearn.grid_search import GridSearchCV
+    >>> from sklearn.ensemble import GradientBoostingClassifier
+    >>> from sklearn.datasets import load_digits
+    >>> digits = load_digits()
+    >>> param_grid = {
+    ...     "max_depth": [1, 3, 5, None],
+    ...     "max_features": ["sqrt", "log2", None],
+    ...     "learning_rate": [0.1, 0.01, 0.001]
+    ... }
+    >>> # Note: n_jobs and predispatch specify the maximum number of
+    >>> # concurrent jobs.
+    >>> gs = GridSearchCV(GradientBoostingClassifier(n_estimators=1000,
+    ...                                              random_state=42),
+    ...                   param_grid=param_grid,
+    ...                   n_jobs=5, pre_dispatch="n_jobs")
+    >>> sklearn_register_parallel_backend('civis', make_backend_factory(
+    ...     required_resources={"cpu": 512, "memory": 256}))
+    >>> with sklearn_parallel_backend('civis'):
+    ...     gs.fit(digits.data, digits.target)
+
+    Notes
+    -----
+    Joblib's ``register_parallel_backend`` (see example above) expects a
+    callable that returns a ``ParallelBackendBase`` instance. This function
+    allows the user to specify the Civis container script setting that will be
+    used when that backend creates container scripts to run jobs.
+
+    The specified Docker image (optionally, with a GitHub repo and setup
+    command) must have basically the same environment as the one in which this
+    module is used to submit jobs. The worker jobs need to be able to
+    deserialize the jobs they are given, including the data and all the
+    necessary Python objects (e.g., if you pass a Pandas data frame, the image
+    must have Pandas installed). In particular, the function that is called by
+    joblib must be available in the specified environment.
+    """
+    if setup_cmd is None:
+        if repo_http_uri is not None:
+            setup_cmd = _DEFAULT_REPO_SETUP_CMD
+        else:
+            setup_cmd = _DEFAULT_SETUP_CMD
+
+    def backend_factory():
+        return _CivisBackend(docker_image_name=docker_image_name,
+                             docker_image_tag=docker_image_tag,
+                             repo_http_uri=repo_http_uri,
+                             repo_ref=repo_ref,
+                             required_resources=required_resources,
+                             params=params,
+                             arguments=arguments,
+                             client=client,
+                             polling_interval=polling_interval,
+                             setup_cmd=setup_cmd,
+                             max_submit_retries=max_submit_retries,
+                             max_n_retries=max_job_retries,
+                             hidden=hidden)
+
+    return backend_factory
+
+
+def make_backend_template_factory(from_template_id,
+                                  arguments=None,
+                                  client=None,
+                                  polling_interval=None,
+                                  max_submit_retries=0,
+                                  max_job_retries=0,
+                                  hidden=True):
+    """Create a joblib backend factory that uses Civis Custom Scripts.
+
+    Parameters
+    ----------
+    from_template_id: int
+        Create jobs as Custom Scripts from the given template ID.
+        When using the joblib backend with templates,
+        the template must have a very specific form. Refer
+        to the README for details.
+    arguments : dict or None, optional
+        Dictionary of name/value pairs to use to run this script.
+        Only settable if this script has defined params. See the `container
+        scripts API documentation
+        <https://platform.civisanalytics.com/api#resources-scripts>`
+        for details.
+    client : `civis.APIClient` instance or None, optional
+        An API Client object to use.
+    polling_interval : int, optional
+        The polling interval, in seconds, for checking container script status.
+        If you have many jobs, you may want to set this higher (e.g., 300) to
+        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        You should only set this if you aren't using ``pubnub`` notifications.
+    max_submit_retries : int, optional
+        The maximum number of retries for submitting each job. This is to help
+        avoid a large set of jobs failing because of a single 5xx error. A
+        value higher than zero should only be used for jobs that are idempotent
+        (i.e., jobs whose result and side effects are the same regardless of
+        whether they are run once or many times).
+    max_job_retries : int, optional
+        Retry failed jobs this number of times before giving up.
+        Even more than with `max_submit_retries`, this should only
+        be used for jobs which are idempotent, as the job may have
+        caused side effects (if any) before failing.
+        These retries assist with jobs which may have failed because
+        of network or worker failures.
+    hidden: bool, optional
+        The hidden status of the object. Setting this to true
+        hides it from most API endpoints. The object can still
+        be queried directly by ID. Defaults to True.
+    """
+    def backend_factory():
+        return _CivisBackend(from_template_id=from_template_id,
+                             arguments=arguments,
+                             client=client,
+                             polling_interval=polling_interval,
+                             max_submit_retries=max_submit_retries,
+                             max_n_retries=max_job_retries,
+                             hidden=hidden)
+
+    return backend_factory
+
+
+class JobSubmissionError(Exception):
+    pass
+
+
+def _robust_result_download(output_file_id, client, n_retries=5, delay=0.0):
+    """Download and deserialize the result from output_file_id
+
+    Retry network errors `n_retries` times with `delay` seconds between calls
+    """
+    retry_exc = (requests.HTTPError,
+                 requests.ConnectionError,
+                 requests.ConnectTimeout)
+    n_failed = 0
+    while True:
+        buffer = BytesIO()
+        try:
+            civis.io.civis_to_file(output_file_id, buffer, client=client)
+        except retry_exc as exc:
+            buffer.close()
+            if n_failed < n_retries:
+                n_failed += 1
+                _LOGGER.debug("Download failure %s due to %s; retrying.",
+                              n_failed, str(exc))
+                time.sleep(delay)
+            else:
+                raise
+        else:
+            buffer.seek(0)
+            return joblib.load(buffer)
+
+
+class _CivisBackendResult:
+    """
+    A wrapper for results that looks like the results from multiprocessing
+    pools that joblib expects.  This retrieves the results for a completed
+    job (i.e., container script) from Civis.
+
+    Parameters
+    ----------
+    future : :class:`~civisjobs.containers.ContainerFuture`
+        A Future which represents a Civis job. Created by a
+        :class:`~ContainerPoolExecutor`.
+    callback : callable
+        A `joblib`-provided callback function which should be
+        called on successful job completion. It will launch the
+        next job in line. See `joblib.parallel.Parallel._dispatch`
+        for the creation of this callback function.
+        It takes a single input, the output of the remote function call.
+
+    Notes
+    -----
+    * This is similar to a Future object except with ``get`` instead of
+      ``result``, and with a callback specified.
+    * This is only intended to work within joblib and with the Civis backend.
+    * Joblib calls ``get`` on one result at a time, in order of submission.
+    * Exceptions should only be raised inside ``get`` so that joblib can
+        handle them properly.
+    """
+    def __init__(self, future, callback):
+        self._future = future
+        self._callback = callback
+        self.result = None
+        if hasattr(future, 'client'):
+            self._client = future.client
+        else:
+            self._client = civis.APIClient(resources='all')
+
+        # Download results and trigger the next job as a callback
+        # so that we don't have to wait for `get` to be called.
+        # Note that the callback of a `concurrent.futures.Future`
+        # (which self._future is a subclass of) is called with a
+        # single argument, the Future itself.
+        self._future.remote_func_output = None  # `get` reads results from here
+        self._future.result_fetched = False  # Did we get the result?
+        self._future.add_done_callback(
+            self._make_fetch_callback(self._callback, self._client))
+
+    @staticmethod
+    def _make_fetch_callback(joblib_callback, client):
+        """Create a closure for use as a callback on the ContainerFuture"""
+        def _fetch_result(fut):
+            """Retrieve outputs from the remote function.
+            Run the joblib callback only if there were no errors.
+
+            Parameters
+            ----------
+            fut : :class:`~civisjobs.containers.ContainerFuture`
+                A Future which represents a Civis job. Created by a
+                :class:`~ContainerPoolExecutor`.
+
+            Note
+            ----
+            We can't return data from a callback, so the remote
+            function output is attached to the Future object
+            as a new attribute ``remote_func_output``.
+            """
+            if fut.succeeded():
+                _LOGGER.debug(
+                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    " job succeeded!", fut.script_id, fut.run_id)
+            elif fut.cancelled():
+                _LOGGER.debug(
+                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    " job cancelled!", fut.script_id, fut.run_id)
+            else:
+                _LOGGER.error(
+                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    " job failure!", fut.script_id, fut.run_id)
+
+            try:
+                # Find the output file ID from the run outputs.
+                run_outputs = client.scripts.list_containers_runs_outputs(
+                    fut.script_id, fut.run_id)
+                if run_outputs:
+                    output_file_id = run_outputs[0]['object_id']
+                    res = _robust_result_download(output_file_id, client,
+                                                  n_retries=5, delay=1.0)
+                    fut.remote_func_output = res
+                    _LOGGER.debug("Downloaded and deserialized the result.")
+            except BaseException as exc:
+                # If something went wrong when fetching outputs, record the
+                # exception so we can re-raise it in the parent process.
+                # Catch BaseException so we can also re-raise a
+                # KeyboardInterrupt where it can be properly handled.
+                _LOGGER.debug('Exception during result download: %s', str(exc))
+                fut.remote_func_output = exc
+            else:
+                fut.result_fetched = True
+                if not fut.cancelled() and not fut.exception():
+                    # The next job will start when this callback is called.
+                    # Only run it if the job was a success.
+                    joblib_callback(fut.remote_func_output)
+
+        return _fetch_result
+
+    def get(self):
+        """
+        Return the result of the job (i.e., the deserialized python object
+        produced by the job).
+
+        Returns
+        -------
+        The output of the function which `joblib` ran via Civis
+        NB: `joblib` expects that `get` will always return an iterable.
+        The remote function(s) should always be wrapped in
+        `joblib.parallel.BatchedCalls`, which does always return a list.
+
+        Raises
+        ------
+        TransportableException
+            Any error in the remote job will result in a
+            `TransportableException`, to be handled by `Parallel.retrieve`.
+        futures.CancelledError
+            If the remote job was cancelled before completion
+        """
+        if self.result is None:
+            # Wait for the script to complete.
+            wait([self._future])
+            self.result = self._future.remote_func_output
+
+        if self._future.exception() or not self._future.result_fetched:
+            # If the job errored, we may have been able to return
+            # an exception via the run outputs. If not, fall back
+            # to the API exception.
+            # Note that a successful job may still have an exception
+            # result if job output retrieval failed.
+            if self.result is not None:
+                raise self.result
+            else:
+                # Use repr for the message because the API exception
+                # typically has str(exc)==None.
+                exc = self._future.exception()
+                raise TransportableException(repr(exc), type(exc))
+
+        return self.result
+
+
+class _CivisBackend(ParallelBackendBase):
+    """
+    The backend class that tells joblib how to use Civis to run jobs.
+    Users should interact with this through ``make_backend_factory``.
+
+    .. note:: If we're polling to monitor job status, then
+              the `ContainerFuture` returned by the `ContainerPoolExecutor`
+              doesn't start polling until someone requests status
+              (to minimize the number of API calls used).
+              If it doesn't poll, it can't retry a failed run.
+              `joblib` is careful to keep results in order, which means
+              that it submits all jobs at once, then queries them for
+              results one at a time, in order.
+                  This behavior matters for retrying failed jobs.
+              If polling hasn't started, then the `ContainerFuture`
+              can't notice and retry failures.
+    """
+    def __init__(self, setup_cmd=_DEFAULT_SETUP_CMD,
+                 from_template_id=None,
+                 max_submit_retries=0,
+                 client=None,
+                 **executor_kwargs):
+        if max_submit_retries < 0:
+            raise ValueError(
+                "max_submit_retries cannot be negative (value = %d)" %
+                max_submit_retries)
+
+        if client is None:
+            client = civis.APIClient(resources='all')
+        self._client = client
+        if from_template_id:
+            self.executor = CustomPoolExecutor(from_template_id, client=client,
+                                               **executor_kwargs)
+        else:
+            self.executor = ContainerPoolExecutor(client=client,
+                                                  **executor_kwargs)
+        self.setup_cmd = setup_cmd
+        self.max_submit_retries = max_submit_retries
+        self.run_file_id = None
+        self.using_template = (from_template_id is not None)
+
+    def effective_n_jobs(self, n_jobs):
+        if n_jobs == -1:
+            n_jobs = _ALL_JOBS
+        if n_jobs <= 0:
+            raise ValueError("Please request a positive number of jobs, "
+                             "or use \"-1\" to request a default "
+                             "of {} jobs.".format(_ALL_JOBS))
+        return n_jobs
+
+    def abort_everything(self, ensure_ready=True):
+        # This method is called when a job has raised an exception.
+        # In that case, we're not going to finish computations, so
+        # we should free up Platform resources in any remaining jobs.
+        self.executor.cancel_all()
+        if not ensure_ready:
+            self.executor.shutdown(wait=False)
+
+    def apply_async(self, func, callback=None):
+        """Schedule func to be run
+
+        Note that if the `executor` is set to retry job failures
+        (`max_n_retries` set, via `max_job_retries` on the
+        `make_backend_factory`), then run polling will begin
+        immediately. Otherwise, runs will be polled sequentially,
+        with later runs not polled until earlier runs have finished.
+        """
+        # Upload the job runner script if needed.
+        if self.run_file_id is None and not self.using_template:
+            runfunc_name = "run_joblib_func.py"
+            runner_local_path = os.path.join(_THIS_DIR, runfunc_name)
+            with open(runner_local_path) as f:
+                self.run_file_id = civis.io.file_to_civis(f, runfunc_name,
+                                                          client=self._client)
+                _LOGGER.debug("Uploaded job runner script to File %d",
+                              self.run_file_id)
+
+        # Serialize func to a temporary file and upload it to a Civis File.
+        # Make the temporary files expire in a week.
+        expires_at = (datetime.now() + timedelta(days=7)).isoformat()
+        with TemporaryDirectory() as tempdir:
+            temppath = os.path.join(tempdir, "civis_joblib_backend_func")
+            # compress=3 is a compromise between space and read/write times
+            # (https://github.com/joblib/joblib/blob/18f9b4ce95e8788cc0e9b5106fc22573d768c44b/joblib/numpy_pickle.py#L358).
+            joblib.dump(func, temppath, compress=3)
+            with open(temppath, "rb") as tmpfile:
+                func_file_id = \
+                    civis.io.file_to_civis(tmpfile,
+                                           "civis_joblib_backend_func",
+                                           expires_at=expires_at,
+                                           client=self._client)
+                _LOGGER.debug("uploaded serialized function to File: %d",
+                              func_file_id)
+
+            # Use the Civis CLI client to download the job runner script into
+            # the container, and then run it on the uploaded job.
+            # Only download the runner script if it doesn't already
+            # exist in the destination environment.
+            runner_remote_path = "joblib_remote_worker"
+            cmd = ("{setup_cmd} && "
+                   "if command -v {runner_remote_path} >/dev/null; "
+                   "then {runner_remote_path} {func_file_id}; "
+                   "else pip install joblib=={jl_version} && "
+                   "civis files download {run_file_id} {runner_remote_path} "
+                   "&& python {runner_remote_path} {func_file_id}; fi"
+                   .format(run_file_id=self.run_file_id,
+                           jl_version=joblib.__version__,
+                           runner_remote_path=runner_remote_path,
+                           func_file_id=func_file_id,
+                           setup_cmd=self.setup_cmd))
+
+            # Try to submit the command, with optional retrying for certain
+            # error types.
+            for n_retries in range(1 + self.max_submit_retries):
+                try:
+                    if self.using_template:
+                        args = {'JOBLIB_FUNC_FILE_ID': func_file_id}
+                        future = self.executor.submit(**args)
+                        _LOGGER.debug("Started custom script from template "
+                                      "%s with arguments %s",
+                                      self.executor.from_template_id, args)
+                    else:
+                        future = self.executor.submit(fn=cmd)
+                        _LOGGER.debug("started container script with "
+                                      "command: %s", cmd)
+                    # Stop retrying if submissions was successful.
+                    break
+                except CivisAPIError as e:
+                    # If we've retried the maximum number of times already,
+                    # then raise an exception.
+                    retries_left = self.max_submit_retries - n_retries - 1
+                    if retries_left < 1:
+                        raise JobSubmissionError(e)
+
+                    _LOGGER.debug("Retrying submission. %d retries left",
+                                  retries_left)
+
+                    # Sleep with exponentially increasing intervals in case
+                    # the issue persists for a while.
+                    time.sleep(2 ** n_retries)
+
+            if self.executor.max_n_retries:
+                # Start the ContainerFuture polling.
+                # This will use more API calls, but will
+                # allow the ContainerFuture to launch
+                # retries if necessary.
+                # (This is only relevant if we're not using the
+                # notifications endpoint.)
+                future.done()
+
+            # Wait for the job to finish.
+            result = _CivisBackendResult(future, callback)
+
+        return result

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -504,15 +504,15 @@ class _CivisBackendResult:
             """
             if fut.succeeded():
                 log.debug(
-                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    "Ran job through Civis. Job ID: %d, run ID: %d;"
                     " job succeeded!", fut.job_id, fut.run_id)
             elif fut.cancelled():
                 log.debug(
-                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    "Ran job through Civis. Job ID: %d, run ID: %d;"
                     " job cancelled!", fut.job_id, fut.run_id)
             else:
                 log.error(
-                    "Ran job through Civis. script ID: %d, run ID: %d;"
+                    "Ran job through Civis. Job ID: %d, run ID: %d;"
                     " job failure!", fut.job_id, fut.run_id)
 
             try:
@@ -662,7 +662,7 @@ class _CivisBackend(ParallelBackendBase):
             # the container, and then run it on the uploaded job.
             # Only download the runner script if it doesn't already
             # exist in the destination environment.
-            runner_remote_path = "joblib_remote_worker"
+            runner_remote_path = "civis_joblib_worker"
             cmd = ("{setup_cmd} && "
                    "if command -v {runner_remote_path} >/dev/null; "
                    "then {runner_remote_path} {func_file_id}; "

--- a/civis/run_joblib_func.py
+++ b/civis/run_joblib_func.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 This is an executable intended for use with a joblib backend
 for the Civis platform. It takes a Civis File ID representing
@@ -8,6 +6,7 @@ deserializes it, calls the callable, serializes the result,
 and uploads the result to another Civis File. The output file's ID
 will be set as an output on this run.
 """
+from __future__ import absolute_import, print_function
 
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -40,7 +39,7 @@ def worker_func(func_file_id):
     result = None
     try:
         result = func()
-    except Exception as exc:
+    except Exception:
         print("Error! Attempting to record exception.")
         # Wrap the exception in joblib's TransportableException
         # so that joblib can properly display the results.

--- a/civis/run_joblib_func.py
+++ b/civis/run_joblib_func.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""
+This is an executable intended for use with a joblib backend
+for the Civis platform. It takes a Civis File ID representing
+a joblib-serialized callable as an argument, downloads the file,
+deserializes it, calls the callable, serializes the result,
+and uploads the result to another Civis File. The output file's ID
+will be set as an output on this run.
+"""
+
+from datetime import datetime, timedelta
+from io import BytesIO
+import os
+import sys
+
+import civis
+import joblib
+from joblib.my_exceptions import TransportableException
+from joblib.format_stack import format_exc
+
+
+def worker_func(func_file_id):
+    # Have the output File expire in 7 days.
+    expires_at = (datetime.now() + timedelta(days=7)).isoformat()
+
+    client = civis.APIClient()
+    job_id = os.environ.get('CIVIS_JOB_ID')
+    run_id = os.environ.get('CIVIS_RUN_ID')
+    if not job_id or not run_id:
+        raise RuntimeError("This function must be run inside a "
+                           "Civis container job.")
+
+    func_buffer = BytesIO()
+    civis.io.civis_to_file(func_file_id, func_buffer)
+    func_buffer.seek(0)
+    func = joblib.load(func_buffer)
+
+    # Run the function.
+    result = None
+    try:
+        result = func()
+    except Exception as exc:
+        print("Error! Attempting to record exception.")
+        # Wrap the exception in joblib's TransportableException
+        # so that joblib can properly display the results.
+        e_type, e_value, e_tb = sys.exc_info()
+        text = format_exc(e_type, e_value, e_tb, context=10, tb_offset=1)
+        result = TransportableException(text, e_type)
+        raise
+    finally:
+        # Serialize the result and upload it to the Files API.
+        # Note that if compress is 0, joblib will output multiple files.
+        # compress=3 is a good compromise between space and read/write times
+        # (https://github.com/joblib/joblib/blob/18f9b4ce95e8788cc0e9b5106fc22573d768c44b/joblib/numpy_pickle.py#L358).
+        if result is not None:
+            # If the function exits without erroring, we may not have a result.
+            result_buffer = BytesIO()
+            joblib.dump(result, result_buffer, compress=3)
+            result_buffer.seek(0)
+            output_name = "Results from Joblib job {} / run {}".format(job_id,
+                                                                       run_id)
+            output_file_id = civis.io.file_to_civis(result_buffer, output_name,
+                                                    expires_at=expires_at)
+            client.scripts.post_containers_runs_outputs(job_id, run_id,
+                                                        'File', output_file_id)
+            print("Results output to file ID: {}".format(output_name,
+                                                         output_file_id))
+
+
+def main():
+    if len(sys.argv) > 1:
+        func_file_id = sys.argv[1]
+    else:
+        # If the file ID to download isn't given as a command-line
+        # argument, assume that it's in an environment variable.
+        func_file_id = os.environ['JOBLIB_FUNC_FILE_ID']
+    worker_func(func_file_id=func_file_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -1,0 +1,439 @@
+from math import sqrt
+import pickle
+from unittest.mock import ANY, call, MagicMock, Mock, patch
+
+import pytest
+from joblib import delayed, Parallel
+from joblib import parallel_backend, register_parallel_backend
+from joblib.my_exceptions import TransportableException
+from civis.base import CivisAPIError
+from civis.response import Response
+import requests
+
+import civisjobs.joblib
+from civisjobs.containers import ContainerFuture
+
+
+@pytest.fixture
+def mock_job():
+    return Response(dict(from_template_id=None, id='42',
+                         required_resources={'cpu': 11},
+                         params=[{'name': 'spam'}], arguments={'spam': 'eggs'},
+                         docker_image_name='image_name',
+                         docker_image_tag='tag',
+                         repo_http_uri='cabbage', repo_ref='servant'))
+
+
+def test_retries():
+    """Make sure that job submission retry behavior works."""
+
+    # Test that submission doesn't fail when there are no mock API errors.
+    _test_retries_helper(0, 0, False, None)
+    _test_retries_helper(0, 5, False, None)
+
+    # Test that submission fails when there are API errors and too few retries.
+    _test_retries_helper(2, 0, True, None)
+    _test_retries_helper(2, 1, True, None)
+    _test_retries_helper(2, 2, True, None)
+
+    # Test that submission doesn't fail when there are mock API errors and
+    # sufficient retries.
+    _test_retries_helper(2, 3, False, None)
+    _test_retries_helper(2, 4, False, None)
+
+
+def test_from_template_id():
+    _test_retries_helper(0, 5, False, 13)
+    _test_retries_helper(1, 5, False, 13)
+    _test_retries_helper(1, 0, True, 13)
+
+
+@patch.object(civisjobs.joblib, 'ContainerPoolExecutor')
+@patch.object(civisjobs.joblib, 'CustomPoolExecutor')
+@patch.object(civisjobs.joblib, '_CivisBackendResult')
+@patch.object(civisjobs.joblib.civis.io, 'file_to_civis', autospec=True)
+def _test_retries_helper(num_failures, max_submit_retries,
+                         should_fail, from_template_id,
+                         mock_file_to_civis, mock_result_cls,
+                         mock_custom_exec_cls, mock_executor_cls):
+
+    mock_file_to_civis.return_value = 0
+    mock_result_cls.get.return_value = 123
+
+    # A function to raise fake API errors the first num_failures times it is
+    # called.
+    def mock_submit(fn='', *args, arguments=None, **kwargs):
+        nonlocal failure_ct
+        if failure_ct < num_failures:
+            failure_ct += 1
+            raise CivisAPIError(MagicMock())
+        else:
+            return MagicMock(spec=ContainerFuture)
+
+    failure_ct = 0
+
+    mock_custom_exec_cls.return_value.submit.side_effect = mock_submit
+    mock_executor_cls.return_value.submit.side_effect = mock_submit
+
+    if from_template_id:
+        factory = civisjobs.joblib.make_backend_template_factory(
+            from_template_id=from_template_id,
+            max_submit_retries=max_submit_retries,
+            client=Mock())
+    else:
+        factory = civisjobs.joblib.make_backend_factory(
+            max_submit_retries=max_submit_retries, client=Mock())
+    register_parallel_backend('civis', factory)
+    with parallel_backend('civis'):
+        parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
+        if should_fail:
+            with pytest.raises(civisjobs.joblib.JobSubmissionError):
+                parallel(delayed(sqrt)(i ** 2) for i in range(3))
+        else:
+            parallel(delayed(sqrt)(i ** 2) for i in range(3))
+
+
+@patch.object(civisjobs.joblib, 'CustomPoolExecutor')
+@patch.object(civisjobs.joblib, '_CivisBackendResult')
+@patch.object(civisjobs.joblib.civis.io, 'file_to_civis', autospec=True)
+def test_template_submit(mock_file, mock_result, mock_pool):
+    # Verify that creating child jobs from a template looks like we expect
+    file_id = 17
+    mock_client = Mock()
+    mock_file.return_value = file_id
+
+    factory = civisjobs.joblib.make_backend_template_factory(
+        from_template_id=1234, client=mock_client)
+
+    n_calls = 3
+    register_parallel_backend('civis', factory)
+    with parallel_backend('civis'):
+        parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
+        parallel(delayed(sqrt)(i ** 2) for i in range(n_calls))
+
+    assert mock_file.call_count == 3, "Upload 3 functions to run"
+    assert mock_pool().submit.call_count == n_calls, "Run 3 functions"
+    for this_call in mock_pool().submit.call_args_list:
+        assert this_call == call(JOBLIB_FUNC_FILE_ID=file_id)
+    assert mock_result.call_count == 3, "Create 3 results"
+
+
+@patch.object(civisjobs.joblib, '_CivisBackend')
+def test_make_template(mock_backend):
+    # Verify that the input setup command is recognized
+    func = civisjobs.joblib.make_backend_template_factory(1234)
+
+    assert mock_backend.call_count == 0
+    func()
+    assert mock_backend.call_count == 1
+    assert mock_backend.call_args_list[0][1].get('from_template_id') == 1234
+
+
+@patch.object(civisjobs.joblib, '_CivisBackend')
+def test_setup_cmd(mock_backend):
+    # Verify that the input setup command is recognized
+    func = civisjobs.joblib.make_backend_factory(setup_cmd='sample')
+
+    assert mock_backend.call_count == 0
+    func()
+    assert mock_backend.call_count == 1
+    assert mock_backend.call_args_list[0][1].get('setup_cmd') == 'sample'
+
+
+@patch.object(civisjobs.joblib, '_CivisBackend')
+def test_default_setup_cmd_no_repo(mock_backend):
+    # Check that the setup command has the expected
+    # default when the user does not input a GitHub repo
+    func = civisjobs.joblib.make_backend_factory()
+
+    func()
+    assert mock_backend.call_count == 1
+    assert mock_backend.call_args_list[0][1].get('setup_cmd') == ":"
+
+
+@patch.object(civisjobs.joblib, '_CivisBackend')
+def test_default_setup_cmd_with_repo(mock_backend):
+    # Check that the default setup command will attempt to install
+    # a supplied GitHub repo.
+    func = civisjobs.joblib.make_backend_factory(repo_http_uri='potato')
+
+    func()
+    assert mock_backend.call_count == 1
+    assert mock_backend.call_args_list[0][1].get('setup_cmd') == \
+        "cd /app; python setup.py install; cd /"
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_no_job_id_error(mock_make_factory, mock_job):
+    # The `infer_backend_factory` should give a RuntimeError
+    # if there's no CIVIS_JOB_ID in the environment.
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    with patch.dict('os.environ', {}, clear=True):
+        with pytest.raises(RuntimeError):
+            civisjobs.joblib.infer_backend_factory(client=mock_client)
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer(mock_make_factory, mock_job):
+    # Verify that `infer_backend_factory` passes through
+    # the expected arguments to `make_backend_factory`.
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(client=mock_client)
+
+    expected = dict(mock_job)
+    del expected['from_template_id']
+    del expected['id']
+    mock_make_factory.assert_called_once_with(
+        client=mock_client,
+        setup_cmd=None,
+        polling_interval=None,
+        max_submit_retries=0,
+        max_job_retries=0,
+        hidden=True,
+        **expected)
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_new_params(mock_make_factory, mock_job):
+    # Test overwriting existing job parameters with new parameters
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    new_params = [{'name': 'spam', 'type': 'fun'},
+                  {'name': 'foo', 'type': 'bar'}]
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(
+            client=mock_client, params=new_params)
+
+    assert mock_make_factory.call_args[1]['params'] == new_params
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_extra_param(mock_make_factory, mock_job):
+    # Test adding a new parameter and keeping
+    # the existing parameter unchanged.
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    new_params = [{'name': 'foo', 'type': 'bar'}]
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(
+            client=mock_client, params=new_params)
+
+    assert mock_make_factory.call_args[1]['params'] == \
+        [{'name': 'spam'}, {'name': 'foo', 'type': 'bar'}]
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_update_resources(mock_make_factory, mock_job):
+    # Verify that users can modify requested resources for jobs.
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(
+            client=mock_client, required_resources={'cpu': -11})
+
+    assert mock_make_factory.call_args[1]['required_resources'] == \
+        {'cpu': -11}
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_update_args(mock_make_factory, mock_job):
+    # Verify that users can modify the existing job's
+    # arguments for sub-processes.
+    mock_client = MagicMock()
+    mock_client.scripts.get_containers.return_value = mock_job
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(
+            client=mock_client, arguments={'foo': 'bar'})
+
+    assert mock_make_factory.call_args[1]['arguments'] == \
+        {'spam': 'eggs', 'foo': 'bar'}
+
+
+@patch.object(civisjobs.joblib, 'make_backend_factory')
+def test_infer_from_custom_job(mock_make_factory):
+    # Test that `infer_backend_factory` can find needed
+    # parameters if it's run inside a custom job created
+    # from a template.
+    mock_client = MagicMock()
+    mock_custom = Response(dict(from_template_id=999, id=42,
+                                required_resources=None,
+                                params=[{'name': 'spam'}],
+                                arguments={'spam': 'eggs'},
+                                docker_image_name='image_name',
+                                docker_image_tag='tag',
+                                repo_http_uri='cabbage', repo_ref='servant'))
+    mock_script = Response(dict(from_template_id=None,
+                                id=171, required_resources={'cpu': 11},
+                                params=[{'name': 'spam'}], arguments={},
+                                docker_image_name='image_name',
+                                docker_image_tag='tag',
+                                repo_http_uri='cabbage', repo_ref='servant'))
+    mock_template = Response(dict(id=999, script_id=171))
+
+    def _get_container(job_id):
+        if int(job_id) == 42:
+            return mock_custom
+        elif int(job_id) == 171:
+            return mock_script
+        else:
+            raise ValueError("Got job_id {}".format(job_id))
+
+    mock_client.scripts.get_containers.side_effect = _get_container
+    mock_client.templates.get_scripts.return_value = mock_template
+    with patch.dict('os.environ', {'CIVIS_JOB_ID': "42",
+                                   'CIVIS_RUN_ID': "test_run"}):
+        civisjobs.joblib.infer_backend_factory(
+            client=mock_client)
+
+    # We should have called `get_containers` twice now -- once for
+    # the container we're running in, and a second time for the
+    # container which backs the template this job was created from.
+    # The backing script has settings which aren't visible from
+    # the container which was created from it.
+    assert mock_client.scripts.get_containers.call_count == 2
+    mock_client.templates.get_scripts.assert_called_once_with(999)
+    expected_kwargs = {'docker_image_name': 'image_name',
+                       'docker_image_tag': 'tag',
+                       'repo_http_uri': 'cabbage',
+                       'repo_ref': 'servant',
+                       'required_resources': {'cpu': 11},
+                       'params': [{'name': 'spam'}],
+                       'arguments': {'spam': 'eggs'},
+                       'client': ANY,
+                       'polling_interval': ANY,
+                       'setup_cmd': None,
+                       'max_submit_retries': ANY,
+                       'max_job_retries': ANY,
+                       'hidden': True}
+    mock_make_factory.assert_called_once_with(**expected_kwargs)
+
+
+def make_to_file_mock(result, max_n_err=0, exc=None):
+    cnt = {'err': 0}
+
+    def mock_civis_to_file(file_id, buf, client=None):
+        if cnt['err'] < max_n_err:
+            cnt['err'] += 1
+            raise exc
+        else:
+            buf.write(pickle.dumps(result))
+    return mock_civis_to_file
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_success(mock_civis):
+    # Test that we can get a result back from a succeeded job.
+    callback = MagicMock()
+    mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
+    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut.set_result(Response({'state': 'success'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    assert res.get() == 'spam'
+    assert callback.call_count == 1
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_callback_no_get(mock_civis):
+    # Test that the completed callback happens even if we don't call `get`
+    callback = MagicMock()
+    mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
+    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut.set_result(Response({'state': 'success'}))
+
+    civisjobs.joblib._CivisBackendResult(fut, callback)
+    assert callback.call_count == 1
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_exception(mock_civis):
+    # An error in the job should be raised by the result
+    callback = MagicMock()
+    exc = ZeroDivisionError()
+    mock_civis.io.civis_to_file.side_effect = make_to_file_mock(exc)
+    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut._set_api_exception(Response({'state': 'failed'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    with pytest.raises(ZeroDivisionError):
+        res.get()
+    assert callback.call_count == 0
+
+
+def test_result_exception_no_result():
+    # If the job errored but didn't write an output, we should get
+    # a generic TransportableException back.
+    callback = MagicMock()
+
+    # Passing the client mock as an argument instead of globally
+    # patching the client tests that the _CivisBackendResult
+    # uses the client object on the input CivisFuture.
+    mock_client = MagicMock().APIClient()
+    mock_client.scripts.list_containers_runs_outputs.return_value = []
+    fut = ContainerFuture(1, 2, client=mock_client)
+    fut._set_api_exception(Response({'state': 'failed'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    with pytest.raises(TransportableException) as exc:
+        res.get()
+    assert "{'state': 'failed'}" in str(exc.value)
+    assert callback.call_count == 0
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_callback_exception(mock_civis):
+    # An error in the result retrieval should be raised by .get
+    callback = MagicMock()
+    exc = ZeroDivisionError()
+    mock_civis.io.civis_to_file.side_effect = exc
+    fut = ContainerFuture(1, 2, client=MagicMock())
+
+    # We're simulating a job which succeeded but generated an
+    # exception when we try to download the outputs.
+    fut._set_api_exception(Response({'state': 'succeeded'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    with pytest.raises(ZeroDivisionError):
+        res.get()
+    assert callback.call_count == 0
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_eventual_success(mock_civis):
+    # Test that we can get a result back from a succeeded job,
+    # even if we need to retry a few times to succeed with the download.
+    callback = MagicMock()
+    exc = requests.ConnectionError()
+    se = make_to_file_mock('spam', max_n_err=2, exc=exc)
+    mock_civis.io.civis_to_file.side_effect = se
+    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut.set_result(Response({'state': 'success'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    assert res.get() == 'spam'
+    assert callback.call_count == 1
+
+
+@patch.object(civisjobs.joblib, 'civis')
+def test_result_eventual_failure(mock_civis):
+    # We will retry a connection error up to 5 times. Make sure
+    # that we will get an error if it persists forever.
+    callback = MagicMock()
+    exc = requests.ConnectionError()
+    se = make_to_file_mock('spam', max_n_err=10, exc=exc)
+    mock_civis.io.civis_to_file.side_effect = se
+    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut.set_result(Response({'state': 'success'}))
+    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+
+    with pytest.raises(requests.ConnectionError):
+        res.get()
+    assert callback.call_count == 0

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -1,6 +1,6 @@
 from math import sqrt
 import pickle
-from unittest.mock import ANY, call, MagicMock, Mock, patch
+from civis.compat import mock
 
 import pytest
 from joblib import delayed, Parallel
@@ -10,8 +10,8 @@ from civis.base import CivisAPIError
 from civis.response import Response
 import requests
 
-import civisjobs.joblib
-from civisjobs.containers import ContainerFuture
+import civis.parallel
+from civis.futures import ContainerFuture
 
 
 @pytest.fixture
@@ -48,10 +48,10 @@ def test_from_template_id():
     _test_retries_helper(1, 0, True, 13)
 
 
-@patch.object(civisjobs.joblib, 'ContainerPoolExecutor')
-@patch.object(civisjobs.joblib, 'CustomPoolExecutor')
-@patch.object(civisjobs.joblib, '_CivisBackendResult')
-@patch.object(civisjobs.joblib.civis.io, 'file_to_civis', autospec=True)
+@mock.patch.object(civis.parallel, '_ContainerShellExecutor')
+@mock.patch.object(civis.parallel, 'CustomScriptExecutor')
+@mock.patch.object(civis.parallel, '_CivisBackendResult')
+@mock.patch.object(civis.parallel.civis.io, 'file_to_civis', autospec=True)
 def _test_retries_helper(num_failures, max_submit_retries,
                          should_fail, from_template_id,
                          mock_file_to_civis, mock_result_cls,
@@ -62,47 +62,46 @@ def _test_retries_helper(num_failures, max_submit_retries,
 
     # A function to raise fake API errors the first num_failures times it is
     # called.
-    def mock_submit(fn='', *args, arguments=None, **kwargs):
-        nonlocal failure_ct
-        if failure_ct < num_failures:
-            failure_ct += 1
-            raise CivisAPIError(MagicMock())
-        else:
-            return MagicMock(spec=ContainerFuture)
+    counter = {'n_failed': 0}
 
-    failure_ct = 0
+    def mock_submit(fn='', *args, **kwargs):
+        if counter['n_failed'] < num_failures:
+            counter['n_failed'] += 1
+            raise CivisAPIError(mock.MagicMock())
+        else:
+            return mock.MagicMock(spec=ContainerFuture)
 
     mock_custom_exec_cls.return_value.submit.side_effect = mock_submit
     mock_executor_cls.return_value.submit.side_effect = mock_submit
 
     if from_template_id:
-        factory = civisjobs.joblib.make_backend_template_factory(
+        factory = civis.parallel.make_backend_template_factory(
             from_template_id=from_template_id,
             max_submit_retries=max_submit_retries,
-            client=Mock())
+            client=mock.Mock())
     else:
-        factory = civisjobs.joblib.make_backend_factory(
-            max_submit_retries=max_submit_retries, client=Mock())
+        factory = civis.parallel.make_backend_factory(
+            max_submit_retries=max_submit_retries, client=mock.Mock())
     register_parallel_backend('civis', factory)
     with parallel_backend('civis'):
         parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
         if should_fail:
-            with pytest.raises(civisjobs.joblib.JobSubmissionError):
+            with pytest.raises(civis.parallel.JobSubmissionError):
                 parallel(delayed(sqrt)(i ** 2) for i in range(3))
         else:
             parallel(delayed(sqrt)(i ** 2) for i in range(3))
 
 
-@patch.object(civisjobs.joblib, 'CustomPoolExecutor')
-@patch.object(civisjobs.joblib, '_CivisBackendResult')
-@patch.object(civisjobs.joblib.civis.io, 'file_to_civis', autospec=True)
+@mock.patch.object(civis.parallel, 'CustomScriptExecutor')
+@mock.patch.object(civis.parallel, '_CivisBackendResult')
+@mock.patch.object(civis.parallel.civis.io, 'file_to_civis', autospec=True)
 def test_template_submit(mock_file, mock_result, mock_pool):
     # Verify that creating child jobs from a template looks like we expect
     file_id = 17
-    mock_client = Mock()
+    mock_client = mock.Mock()
     mock_file.return_value = file_id
 
-    factory = civisjobs.joblib.make_backend_template_factory(
+    factory = civis.parallel.make_backend_template_factory(
         from_template_id=1234, client=mock_client)
 
     n_calls = 3
@@ -114,14 +113,14 @@ def test_template_submit(mock_file, mock_result, mock_pool):
     assert mock_file.call_count == 3, "Upload 3 functions to run"
     assert mock_pool().submit.call_count == n_calls, "Run 3 functions"
     for this_call in mock_pool().submit.call_args_list:
-        assert this_call == call(JOBLIB_FUNC_FILE_ID=file_id)
+        assert this_call == mock.call(JOBLIB_FUNC_FILE_ID=file_id)
     assert mock_result.call_count == 3, "Create 3 results"
 
 
-@patch.object(civisjobs.joblib, '_CivisBackend')
+@mock.patch.object(civis.parallel, '_CivisBackend')
 def test_make_template(mock_backend):
     # Verify that the input setup command is recognized
-    func = civisjobs.joblib.make_backend_template_factory(1234)
+    func = civis.parallel.make_backend_template_factory(1234)
 
     assert mock_backend.call_count == 0
     func()
@@ -129,10 +128,10 @@ def test_make_template(mock_backend):
     assert mock_backend.call_args_list[0][1].get('from_template_id') == 1234
 
 
-@patch.object(civisjobs.joblib, '_CivisBackend')
+@mock.patch.object(civis.parallel, '_CivisBackend')
 def test_setup_cmd(mock_backend):
     # Verify that the input setup command is recognized
-    func = civisjobs.joblib.make_backend_factory(setup_cmd='sample')
+    func = civis.parallel.make_backend_factory(setup_cmd='sample')
 
     assert mock_backend.call_count == 0
     func()
@@ -140,22 +139,22 @@ def test_setup_cmd(mock_backend):
     assert mock_backend.call_args_list[0][1].get('setup_cmd') == 'sample'
 
 
-@patch.object(civisjobs.joblib, '_CivisBackend')
+@mock.patch.object(civis.parallel, '_CivisBackend')
 def test_default_setup_cmd_no_repo(mock_backend):
     # Check that the setup command has the expected
     # default when the user does not input a GitHub repo
-    func = civisjobs.joblib.make_backend_factory()
+    func = civis.parallel.make_backend_factory()
 
     func()
     assert mock_backend.call_count == 1
     assert mock_backend.call_args_list[0][1].get('setup_cmd') == ":"
 
 
-@patch.object(civisjobs.joblib, '_CivisBackend')
+@mock.patch.object(civis.parallel, '_CivisBackend')
 def test_default_setup_cmd_with_repo(mock_backend):
     # Check that the default setup command will attempt to install
     # a supplied GitHub repo.
-    func = civisjobs.joblib.make_backend_factory(repo_http_uri='potato')
+    func = civis.parallel.make_backend_factory(repo_http_uri='potato')
 
     func()
     assert mock_backend.call_count == 1
@@ -163,26 +162,26 @@ def test_default_setup_cmd_with_repo(mock_backend):
         "cd /app; python setup.py install; cd /"
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_no_job_id_error(mock_make_factory, mock_job):
     # The `infer_backend_factory` should give a RuntimeError
     # if there's no CIVIS_JOB_ID in the environment.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
-    with patch.dict('os.environ', {}, clear=True):
+    with mock.patch.dict('os.environ', {}, clear=True):
         with pytest.raises(RuntimeError):
-            civisjobs.joblib.infer_backend_factory(client=mock_client)
+            civis.parallel.infer_backend_factory(client=mock_client)
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer(mock_make_factory, mock_job):
     # Verify that `infer_backend_factory` passes through
     # the expected arguments to `make_backend_factory`.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(client=mock_client)
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(client=mock_client)
 
     expected = dict(mock_job)
     del expected['from_template_id']
@@ -197,72 +196,72 @@ def test_infer(mock_make_factory, mock_job):
         **expected)
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_new_params(mock_make_factory, mock_job):
     # Test overwriting existing job parameters with new parameters
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
     new_params = [{'name': 'spam', 'type': 'fun'},
                   {'name': 'foo', 'type': 'bar'}]
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(
             client=mock_client, params=new_params)
 
     assert mock_make_factory.call_args[1]['params'] == new_params
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_extra_param(mock_make_factory, mock_job):
     # Test adding a new parameter and keeping
     # the existing parameter unchanged.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
     new_params = [{'name': 'foo', 'type': 'bar'}]
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(
             client=mock_client, params=new_params)
 
     assert mock_make_factory.call_args[1]['params'] == \
         [{'name': 'spam'}, {'name': 'foo', 'type': 'bar'}]
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_update_resources(mock_make_factory, mock_job):
     # Verify that users can modify requested resources for jobs.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(
             client=mock_client, required_resources={'cpu': -11})
 
     assert mock_make_factory.call_args[1]['required_resources'] == \
         {'cpu': -11}
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_update_args(mock_make_factory, mock_job):
     # Verify that users can modify the existing job's
     # arguments for sub-processes.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_client.scripts.get_containers.return_value = mock_job
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(
             client=mock_client, arguments={'foo': 'bar'})
 
     assert mock_make_factory.call_args[1]['arguments'] == \
         {'spam': 'eggs', 'foo': 'bar'}
 
 
-@patch.object(civisjobs.joblib, 'make_backend_factory')
+@mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_from_custom_job(mock_make_factory):
     # Test that `infer_backend_factory` can find needed
     # parameters if it's run inside a custom job created
     # from a template.
-    mock_client = MagicMock()
+    mock_client = mock.MagicMock()
     mock_custom = Response(dict(from_template_id=999, id=42,
                                 required_resources=None,
                                 params=[{'name': 'spam'}],
@@ -288,9 +287,9 @@ def test_infer_from_custom_job(mock_make_factory):
 
     mock_client.scripts.get_containers.side_effect = _get_container
     mock_client.templates.get_scripts.return_value = mock_template
-    with patch.dict('os.environ', {'CIVIS_JOB_ID': "42",
-                                   'CIVIS_RUN_ID': "test_run"}):
-        civisjobs.joblib.infer_backend_factory(
+    with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "42",
+                                        'CIVIS_RUN_ID': "test_run"}):
+        civis.parallel.infer_backend_factory(
             client=mock_client)
 
     # We should have called `get_containers` twice now -- once for
@@ -307,11 +306,11 @@ def test_infer_from_custom_job(mock_make_factory):
                        'required_resources': {'cpu': 11},
                        'params': [{'name': 'spam'}],
                        'arguments': {'spam': 'eggs'},
-                       'client': ANY,
-                       'polling_interval': ANY,
+                       'client': mock.ANY,
+                       'polling_interval': mock.ANY,
                        'setup_cmd': None,
-                       'max_submit_retries': ANY,
-                       'max_job_retries': ANY,
+                       'max_submit_retries': mock.ANY,
+                       'max_job_retries': mock.ANY,
                        'hidden': True}
     mock_make_factory.assert_called_once_with(**expected_kwargs)
 
@@ -328,40 +327,40 @@ def make_to_file_mock(result, max_n_err=0, exc=None):
     return mock_civis_to_file
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_success(mock_civis):
     # Test that we can get a result back from a succeeded job.
-    callback = MagicMock()
+    callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
     fut.set_result(Response({'state': 'success'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     assert res.get() == 'spam'
     assert callback.call_count == 1
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_callback_no_get(mock_civis):
     # Test that the completed callback happens even if we don't call `get`
-    callback = MagicMock()
+    callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
     fut.set_result(Response({'state': 'success'}))
 
-    civisjobs.joblib._CivisBackendResult(fut, callback)
+    civis.parallel._CivisBackendResult(fut, callback)
     assert callback.call_count == 1
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_exception(mock_civis):
     # An error in the job should be raised by the result
-    callback = MagicMock()
+    callback = mock.MagicMock()
     exc = ZeroDivisionError()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock(exc)
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
     fut._set_api_exception(Response({'state': 'failed'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(ZeroDivisionError):
         res.get()
@@ -371,16 +370,16 @@ def test_result_exception(mock_civis):
 def test_result_exception_no_result():
     # If the job errored but didn't write an output, we should get
     # a generic TransportableException back.
-    callback = MagicMock()
+    callback = mock.MagicMock()
 
     # Passing the client mock as an argument instead of globally
     # patching the client tests that the _CivisBackendResult
     # uses the client object on the input CivisFuture.
-    mock_client = MagicMock().APIClient()
+    mock_client = mock.MagicMock().APIClient()
     mock_client.scripts.list_containers_runs_outputs.return_value = []
     fut = ContainerFuture(1, 2, client=mock_client)
     fut._set_api_exception(Response({'state': 'failed'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(TransportableException) as exc:
         res.get()
@@ -388,51 +387,51 @@ def test_result_exception_no_result():
     assert callback.call_count == 0
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_callback_exception(mock_civis):
     # An error in the result retrieval should be raised by .get
-    callback = MagicMock()
+    callback = mock.MagicMock()
     exc = ZeroDivisionError()
     mock_civis.io.civis_to_file.side_effect = exc
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
 
     # We're simulating a job which succeeded but generated an
     # exception when we try to download the outputs.
     fut._set_api_exception(Response({'state': 'succeeded'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(ZeroDivisionError):
         res.get()
     assert callback.call_count == 0
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_eventual_success(mock_civis):
     # Test that we can get a result back from a succeeded job,
     # even if we need to retry a few times to succeed with the download.
-    callback = MagicMock()
+    callback = mock.MagicMock()
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=2, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
     fut.set_result(Response({'state': 'success'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     assert res.get() == 'spam'
     assert callback.call_count == 1
 
 
-@patch.object(civisjobs.joblib, 'civis')
+@mock.patch.object(civis.parallel, 'civis')
 def test_result_eventual_failure(mock_civis):
     # We will retry a connection error up to 5 times. Make sure
     # that we will get an error if it persists forever.
-    callback = MagicMock()
+    callback = mock.MagicMock()
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=10, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    fut = ContainerFuture(1, 2, client=MagicMock())
+    fut = ContainerFuture(1, 2, client=mock.MagicMock())
     fut.set_result(Response({'state': 'success'}))
-    res = civisjobs.joblib._CivisBackendResult(fut, callback)
+    res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(requests.ConnectionError):
         res.get()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ mock==2.0.0 ; python_version == '2.7'
 pytest-cov>=2.4.0,==2.*
 vcrpy>=1.10.0,<=1.10.9
 vcrpy-unittest==0.1.6
+joblib~=0.11

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,13 @@ def main():
                 'futures==3.1.1',
                 'functools32>=3.2,<=3.99'
             ],
-            'pubnub': ['pubnub>=4.0.0,<=4.99']
+            'pubnub': ['pubnub>=4.0.0,<=4.99'],
+            'joblib': ['joblib>=0.11.0,<=0.11.99'],
         },
         entry_points={
             'console_scripts': [
-                'civis = civis.cli.__main__:main'
+                'civis = civis.cli.__main__:main',
+                'joblib_remote_worker = civis.run_joblib_func:main',
             ]
         }
     )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def main():
         entry_points={
             'console_scripts': [
                 'civis = civis.cli.__main__:main',
-                'joblib_remote_worker = civis.run_joblib_func:main',
+                'civis_joblib_worker = civis.run_joblib_func:main',
             ]
         }
     )


### PR DESCRIPTION
Add a new `civis.parallel` module which contains tools to register a custom backend for the `joblib` library. This will let users leverage the Civis Platform infrastructure for parallel computing, and makes it easy to distribute parallel scikit-learn computations over the Civis infrastructure.

Most of this code was developed in a separate repo and has been in Civis internal use. This PR copies over that code, adapts it to work in the civis-python repo, and makes small modifications for Python 2 compatibility.