### PR TITLE
BUG Include joblib.load in wrapper function error handling

### DIFF
--- a/civis/run_joblib_func.py
+++ b/civis/run_joblib_func.py
@@ -30,14 +30,14 @@ def worker_func(func_file_id):
         raise RuntimeError("This function must be run inside a "
                            "Civis container job.")
 
-    func_buffer = BytesIO()
-    civis.io.civis_to_file(func_file_id, func_buffer)
-    func_buffer.seek(0)
-    func = joblib.load(func_buffer)
-
     # Run the function.
     result = None
     try:
+        func_buffer = BytesIO()
+        civis.io.civis_to_file(func_file_id, func_buffer)
+        func_buffer.seek(0)
+        func = joblib.load(func_buffer)
+
         result = func()
     except Exception:
         print("Error! Attempting to record exception.")


### PR DESCRIPTION
In the joblib backend remote runner script, the `joblib.load` call will fail if we try to load an object which refers to code that's not in our remote environment. That's an easy mistake to make, and we should make sure that users see an informative error from it. By moving the `load` call inside the try/finally block, we can record any exceptions from the `load` call and pass them back to the parent process.