### PR TITLE
[CIVP-12032] DEP Make joblib and pubnub hard dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
-    - pip install -e .[pubnub]
+    - pip install -e .
 env:
   global:
     - CIVIS_API_KEY=FOOBAR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Edited example for safer null value handling
+- Make ``pubnub`` and ``joblib`` hard dependencies instead of optional dependencies (#110).
 
 ### Added
 - Added email notifications option to ``ModelPipeline``.

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -14,11 +14,7 @@ import warnings
 from concurrent import futures
 from functools import wraps
 
-try:
-    import joblib
-    HAS_JOBLIB = True
-except ImportError:
-    HAS_JOBLIB = False
+import joblib
 try:
     from sklearn.base import BaseEstimator
     HAS_SKLEARN = True
@@ -155,9 +151,6 @@ def _load_table_from_outputs(job_id, run_id, filename, client=None,
 
 def _load_estimator(job_id, run_id, filename='estimator.pkl', client=None):
     """Load a joblib-serialized Estimator from run outputs"""
-    if not HAS_JOBLIB:
-        raise ImportError('Install joblib to download models '
-                          'from Civis Platform.')
     try:
         tempdir = tempfile.mkdtemp()
         path = _retrieve_file(filename, job_id, run_id, tempdir, client=client)
@@ -823,8 +816,7 @@ class ModelPipeline:
         if fit_params:
             train_args['FIT_PARAMS'] = json.dumps(fit_params)
 
-        if (HAS_SKLEARN and HAS_JOBLIB and
-                isinstance(self.model, BaseEstimator)):
+        if HAS_SKLEARN and isinstance(self.model, BaseEstimator):
             try:
                 tempdir = tempfile.mkdtemp()
                 fout = os.path.join(tempdir, 'estimator.pkl')

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -6,16 +6,12 @@ import os
 import pickle
 import tempfile
 
+import joblib
 try:
     import pandas as pd
     HAS_PANDAS = True
 except ImportError:
     HAS_PANDAS = False
-try:
-    import joblib
-    HAS_JOBLIB = True
-except ImportError:
-    HAS_JOBLIB = False
 try:
     from sklearn.linear_model import LogisticRegression
     HAS_SKLEARN = True
@@ -158,7 +154,6 @@ def test_stash_local_data_from_dataframe(mock_file):
     assert isinstance(mock_file.call_args[0][0], BytesIO)
 
 
-@pytest.mark.skipif(not HAS_JOBLIB, reason="joblib not installed")
 @mock.patch.object(_model, '_retrieve_file', autospec=True)
 def test_load_estimator(mock_retrieve):
     obj = {'spam': 'eggs'}

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -656,7 +656,6 @@ class _CivisBackend(ParallelBackendBase):
                    "if command -v {runner_remote_path} >/dev/null; "
                    "then exec {runner_remote_path} {func_file_id}; "
                    "else pip install civis=={civis_version} && "
-                   "pip install joblib=={jl_version} && "
                    "exec {runner_remote_path} {func_file_id}; fi"
                    .format(jl_version=joblib.__version__,
                            civis_version=civis.__version__,

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -12,14 +12,11 @@ from civis.futures import (ContainerFuture,
                            _ContainerShellExecutor,
                            CustomScriptExecutor,
                            _create_docker_command)
-try:
-    from civis.futures import (CivisFuture,
-                               has_pubnub,
-                               JobCompleteListener,
-                               _LONG_POLLING_INTERVAL)
-    from pubnub.enums import PNStatusCategory
-except ImportError:
-    has_pubnub = False
+
+from civis.futures import (CivisFuture,
+                           JobCompleteListener,
+                           _LONG_POLLING_INTERVAL)
+from pubnub.enums import PNStatusCategory
 
 from civis.tests.testcase import CivisVCRTestCase
 
@@ -59,7 +56,6 @@ class CivisFutureTests(CivisVCRTestCase):
     def tearDownClass(cls):
         clear_lru_cache()
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     def test_listener_calls_callback_when_message_matches(self):
         match = mock.Mock()
         match.return_value = True
@@ -72,7 +68,6 @@ class CivisFutureTests(CivisVCRTestCase):
         match.assert_called_with(message.message)
         self.assertEqual(callback.call_count, 1)
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     def test_listener_does_not_call_callback(self):
         match = mock.Mock()
         match.return_value = False
@@ -85,7 +80,6 @@ class CivisFutureTests(CivisVCRTestCase):
         match.assert_called_with(message.message)
         self.assertEqual(callback.call_count, 0)
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     def test_listener_calls_disconnect_callback_when_status_disconnect(self):
         disconnect_categories = [
             PNStatusCategory.PNTimeoutCategory,
@@ -98,7 +92,6 @@ class CivisFutureTests(CivisVCRTestCase):
             listener.status(None, status)
             assert disconnect.call_count == 1
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     def test_listener_does_note_call_disconnect_callback_on_other_status(self):
         nondisconnect_categories = [
             PNStatusCategory.PNAcknowledgmentCategory,
@@ -111,7 +104,6 @@ class CivisFutureTests(CivisVCRTestCase):
             listener.status(None, status)
             assert disconnect.call_count == 0
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_check_message(self, *mocks):
@@ -127,7 +119,6 @@ class CivisFutureTests(CivisVCRTestCase):
         }
         self.assertTrue(result._check_message(message))
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_check_message_with_different_run_id(self, *mocks):
@@ -143,7 +134,6 @@ class CivisFutureTests(CivisVCRTestCase):
         }
         self.assertFalse(result._check_message(message))
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_check_message_when_job_is_running(self, *mocks):
@@ -159,7 +149,6 @@ class CivisFutureTests(CivisVCRTestCase):
         }
         self.assertFalse(result._check_message(message))
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_set_api_result_result_succeeded(self, mock_subscribe, mock_api):
@@ -176,7 +165,6 @@ class CivisFutureTests(CivisVCRTestCase):
         assert mock_pubnub.unsubscribe_all.call_count == 1
         assert result._state == 'FINISHED'
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_set_api_result_failed(self, mock_subscribe, mock_api):
@@ -194,7 +182,6 @@ class CivisFutureTests(CivisVCRTestCase):
         with pytest.raises(CivisJobFailure):
             result.result()
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_channels(self, *mocks):
@@ -203,7 +190,6 @@ class CivisFutureTests(CivisVCRTestCase):
         future._pubnub.get_subscribed_channels.return_value = [1]
         assert future.subscribed is True
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_no_subscription(self, *mocks):
@@ -212,7 +198,6 @@ class CivisFutureTests(CivisVCRTestCase):
         future._pubnub.get_subscribed_channels.return_value = []
         assert future.subscribed is False
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_base)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_subscribed_with_no_channels(self, *mocks):
@@ -222,7 +207,6 @@ class CivisFutureTests(CivisVCRTestCase):
         assert future.subscribed is False
         clear_lru_cache()
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_overwrite_polling_interval_with_channels(self, *mocks):
@@ -230,7 +214,6 @@ class CivisFutureTests(CivisVCRTestCase):
         assert future.polling_interval == _LONG_POLLING_INTERVAL
         assert hasattr(future, '_pubnub')
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_explicit_polling_interval_with_channels(self, *mocks):
@@ -238,7 +221,6 @@ class CivisFutureTests(CivisVCRTestCase):
         assert future.polling_interval == 5
         assert hasattr(future, '_pubnub')
 
-    @pytest.mark.skipif(not has_pubnub, reason="pubnub not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec_base)
     @mock.patch.object(CivisFuture, '_subscribe')
     def test_polling_interval(self, *mocks):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ mock==2.0.0 ; python_version == '2.7'
 pytest-cov>=2.4.0,==2.*
 vcrpy>=1.10.0,<=1.10.9
 vcrpy-unittest==0.1.6
-joblib~=0.11

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,15 +37,14 @@ set ``use_pandas=True`` in functions that accept that parameter.  To install
    pip install pandas
 
 Machine learning features in the ``ml`` namespace have a soft dependency on
-``scikit-learn``, ``joblib``, and ``pandas``. Install ``scikit-learn`` and
-``joblib`` to export your trained models from the Civis Platform or to
+``scikit-learn`` and ``pandas``. Install ``scikit-learn`` to
+export your trained models from the Civis Platform or to
 provide your own custom models. Use ``pandas`` to download model predictions
 from the Civis Platform. Install these dependencies with
 
 .. code-block:: bash
 
    pip install scikit-learn
-   pip install joblib
    pip install pandas
 
 

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -150,9 +150,7 @@ the following pip-installable dependencies enhance the capabilities of the
 
 - pandas
 - scikit-learn
-- joblib
 - glmnet
-- pubnub
 
 Install :mod:`pandas` if you wish to download tables of predictions.
 You can also model on :class:`~pandas.DataFrame` objects in your interpreter.
@@ -160,15 +158,9 @@ You can also model on :class:`~pandas.DataFrame` objects in your interpreter.
 If you wish to use custom models or download trained models,
 you'll need scikit-learn installed.
 
-We use the ``joblib`` library to move scikit-learn models back and forth from Platform.
-Install it if you wish to use custom models or download trained models.
-
 The "sparse_logistic", "sparse_linear_regressor", and "sparse_ridge_regressor" models
 all use the public Civis Analytics ``glmnet`` library. Install it if you wish to download
 a model created from one of these pre-defined models.
-
-If you install ``pubnub``, the Civis Platform API client can use the notifications endpoint instead of
-polling for job completion. This gives faster results and uses fewer API calls.
 
 Object reference
 ================

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ requests>=2.12.0,==2.*
 jsonschema>=2.5.1,==2.*
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
+joblib~=0.11
+pubnub~=4

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import re
-import os
 import setuptools
 from setuptools import find_packages, setup
 
@@ -50,6 +49,8 @@ def main():
             'requests>=2.12.0,==2.*',
             'jsonschema>=2.5.1,==2.*',
             'six>=1.10,<=1.99',
+            'joblib>=0.11,<=0.11.99',
+            'pubnub>=4.0,<=4.99',
         ],
         extras_require={
             ':python_version=="2.7"': [
@@ -58,8 +59,6 @@ def main():
                 'futures==3.1.1',
                 'functools32>=3.2,<=3.99'
             ],
-            'pubnub': ['pubnub>=4.0.0,<=4.99'],
-            'joblib': ['joblib>=0.11.0,<=0.11.99'],
         },
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
Both the `joblib` and `pubnub` external libraries provide valuable functionality for users of the Python API client, and they are light, fast to install packages. Make them hard dependencies. Remove code paths which allowed those libraries to be absent, and modify the documentation to reflect the fact that all users will have those two libraries installed.