### PR TITLE
[CIVP-11787] DOC Document use of joblib backend

### DIFF
--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -44,10 +44,10 @@ def infer_backend_factory(required_resources=None,
     it's running inside of.
 
     .. note:: This function will read the state of the parent
-    container job at the time this function executes. If the
-    user has modified the container job since the run started
-    (e.g. by changing the GitHub branch in the container's GUI),
-    this function may infer incorrect settings for the child jobs.
+              container job at the time this function executes. If the
+              user has modified the container job since the run started
+              (e.g. by changing the GitHub branch in the container's GUI),
+              this function may infer incorrect settings for the child jobs.
 
     Parameters
     ----------
@@ -62,7 +62,8 @@ def infer_backend_factory(required_resources=None,
         arguments field. See the `container scripts API documentation
         <https://platform.civisanalytics.com/api#resources-scripts>`
         for details.
-            Parameters of the child jobs will default to the parameters
+
+        Parameters of the child jobs will default to the parameters
         of the current job. Any parameters provided here will override
         parameters of the same name from the current job.
     arguments : dict or None, optional
@@ -71,7 +72,8 @@ def infer_backend_factory(required_resources=None,
         scripts API documentation
         <https://platform.civisanalytics.com/api#resources-scripts>`
         for details.
-            Arguments will default to the arguments of the current job.
+
+        Arguments will default to the arguments of the current job.
         Anything provided here will override portions of the current job's
         arguments.
     client : `civis.APIClient` instance or None, optional
@@ -87,7 +89,8 @@ def infer_backend_factory(required_resources=None,
         This is primarily for installing dependencies that are not available
         in the dockerhub repo (e.g., "cd /app && python setup.py install"
         or "pip install gensim").
-            With no GitHub repo input, the setup command will
+
+        With no GitHub repo input, the setup command will
         default to a command that does nothing. If a ``repo_http_uri``
         is provided, the default setup command will attempt to run
         "python setup.py install". If this command fails, execution
@@ -195,6 +198,13 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
               calls on this backend must be less than 5 GB due to
               AWS file size limits.
 
+    .. note:: The maximum number of concurrent jobs in the Civis Platform
+              is controlled by both the ``n_jobs`` and ``pre_dispatch``
+              parameters of ``joblib.Parallel``.
+              Set ``pre_dispatch="n_jobs"`` to have a maximum of
+              ``n_jobs`` processes running at once.
+              (The default is ``pre_dispatch="2*n_jobs"``.)
+
     Parameters
     ----------
     docker_image_name : str, optional
@@ -235,7 +245,8 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
         This is primarily for installing dependencies that are not available
         in the dockerhub repo (e.g., "cd /app && python setup.py install"
         or "pip install gensim").
-            With no GitHub repo input, the setup command will
+
+        With no GitHub repo input, the setup command will
         default to a command that does nothing. If a `repo_http_uri`
         is provided, the default setup command will attempt to run
         "python setup.py install". If this command fails, execution
@@ -309,8 +320,9 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
 
     Notes
     -----
-    Joblib's ``register_parallel_backend`` (see example above) expects a
-    callable that returns a ``ParallelBackendBase`` instance. This function
+    Joblib's :func:`joblib.parallel.register_parallel_backend`
+    (see example above) expects a callable that returns a
+    :class:`joblib.parallel.ParallelBackendBase` instance. This function
     allows the user to specify the Civis container script setting that will be
     used when that backend creates container scripts to run jobs.
 
@@ -320,7 +332,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     deserialize the jobs they are given, including the data and all the
     necessary Python objects (e.g., if you pass a Pandas data frame, the image
     must have Pandas installed). In particular, the function that is called by
-    ``joblib`` must be available in the specified environment.
+    :mod:`joblib` must be available in the specified environment.
     """
     if setup_cmd is None:
         if repo_http_uri is not None:
@@ -361,7 +373,7 @@ def make_backend_template_factory(from_template_id,
         Create jobs as Custom Scripts from the given template ID.
         When using the joblib backend with templates,
         the template must have a very specific form. Refer
-        to the README for details.
+        to the documentation for details.
     arguments : dict or None, optional
         Dictionary of name/value pairs to use to run this script.
         Only settable if this script has defined params. See the `container

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3.4', None),
     'requests': ('https://requests.readthedocs.io/en/latest/', None),
     'sklearn': ('http://scikit-learn.org/stable', None),
+    'joblib': ('http://pythonhosted.org/joblib', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -108,6 +108,7 @@ Client API Reference
    user_guide
    io
    ml
+   parallel
    client
    cli
 

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -150,7 +150,7 @@ For example, if you define a function::
     def my_func(x):
         return 2*x
         
-and run this with :func:`joblib.Parallel`, you'll get an error like::
+and run this with :class:`joblib.Parallel`, you'll get an error like::
 
     AttributeError: module '__main__' has no attribute 'my_func'
     

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -1,0 +1,166 @@
+********************
+Parallel Computation
+********************
+
+The Civis Platform manages a pool of cloud computing resources.
+You can access these resources with the tools in the :mod:`civis.parallel`
+and :mod:`civis.futures` modules.
+
+Joblib backend
+==============
+`joblib <https://pythonhosted.org/joblib/index.html>`_ is a tool which facilitates
+parallel processing in Python. The :func:`~civis.parallel.make_backend_factory`,
+:func:`~civis.parallel.infer_backend_factory`, and 
+:func:`~civis.parallel.make_backend_template_factory` functions allow you
+to define a "civis" parallel computation backend which will transparently
+distribute computation in cloud resources managed by the Civis Platform.
+
+How to use
+----------
+Begin by defining the backend. The Civis joblib backend creates and runs 
+Container Scripts, and the :func:`~civis.parallel.make_backend_factory`
+function accepts several arguments which will be passed to
+:func:`~civis.resources._resources.Scripts.post_containers`.
+Use the ``docker_image_name``, ``docker_image_tag``, ``repo_http_uri``,
+and ``repo_ref`` parameters to define the environment in which your
+code will be run. Make sure that this environment includes all of the code
+which you're parallelizing.
+
+The :func:`~civis.parallel.make_backend_factory` function will return a
+backend factory which should be given to the :func:`joblib.register_parallel_backend`
+function. For example::
+
+    >>> from joblib import register_parallel_backend
+    >>> from civis.parallel import make_backend_factory
+    >>> be_factory = make_backend_factory()
+    >>> register_parallel_backend('civis', be_factory)
+    
+Direct ``joblib`` to use a custom backend by entering a :func:`joblib.parallel_backend`
+context::
+
+    >>> from joblib import parallel_backend
+    >>> with parallel_backend('civis'):
+    ...     # Do joblib parallel computation here.
+
+You can find more about custom joblib backends in the 
+`joblib documentation <http://pythonhosted.org/joblib/parallel.html#custom-backend-api-experimental>`_.
+
+Note that :class:`joblib.Parallel` takes both a ``n_jobs`` and ``pre_dispatch``
+parameter. The Civis joblib backend doesn't queue submitted jobs itself,
+so it will run ``pre_dispatch`` jobs at once. The default value of
+``pre_dispatch`` is "2*n_jobs", which will run a maximum of ``2 * n_jobs`` jobs
+at once in the Civis Platform. Set ``pre_dispatch="n_jobs"`` in your
+:class:`~joblib.Parallel` call to run at most ``n_jobs`` jobs.
+
+Infer backend parameters
+------------------------
+If you're writing code which will run inside a Civis Container Script, then
+the :func:`~civis.parallel.infer_backend_factory` function returns a backend
+factory with environment parameters pre-populated by inspecting the state of
+your container script at run time. Use :func:`~civis.parallel.infer_backend_factory`
+anywhere you would use :func:`~civis.parallel.make_backend_factory`,
+and you don't need to specify a Docker image or GitHub repository.
+
+Templated Scripts
+-----------------
+The :func:`~civis.parallel.make_backend_template_factory` is intended for
+developers who are writing code which may be run by users who don't have
+permissions to create new container scripts with the necessary environment.
+
+Instead of defining and creating new container scripts with
+:func:`~civis.parallel.make_backend_factory`, you can use
+:func:`~civis.parallel.make_backend_template_factory` to launch custom scripts from
+a templated script. To use the template factory, your backing container script must
+have the Civis Python client installed, and its run command must finish 
+by calling ``civis_joblib_worker`` with no arguments. The template must accept the
+parameter "JOBLIB_FUNC_FILE_ID". The Civis joblib backend will use this parameter
+to transport your remote work.
+
+Examples
+--------
+Parallel computation using the default joblib backend 
+(this uses processes on your local computer)::
+
+    >>> from joblib import delayed, Parallel
+    >>> parallel = Parallel(n_jobs=5)
+    >>> print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+You can do the the same parallel computation using the Civis backend
+by creating and registering a backend factory and entering a
+``with parallel_backend('civis')`` context::
+
+    >>> from joblib import parallel_backend, register_parallel_backend
+    >>> from civis.parallel import make_backend_factory
+    >>> register_parallel_backend('civis', make_backend_factory(
+    ...     required_resources={"cpu": 512, "memory": 256}))
+    >>> with parallel_backend('civis'):
+    ...    parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
+    ...    print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
+    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+You can use the Civis joblib backend to parallelize any code which
+uses joblib internally, such as scikit-learn::
+
+    >>> from joblib import parallel_backend, register_parallel_backend
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> from sklearn.ensemble import GradientBoostingClassifier
+    >>> from sklearn.datasets import load_digits
+    >>> digits = load_digits()
+    >>> param_grid = {
+    ...     "max_depth": [1, 3, 5, None],
+    ...     "max_features": ["sqrt", "log2", None],
+    ...     "learning_rate": [0.1, 0.01, 0.001]
+    ... }
+    >>> # Note: n_jobs and pre_dispatch specify the maximum number of
+    >>> # concurrent jobs.
+    >>> gs = GridSearchCV(GradientBoostingClassifier(n_estimators=1000,
+    ...                                              random_state=42),
+    ...                   param_grid=param_grid,
+    ...                   n_jobs=5, pre_dispatch="n_jobs")
+    >>> register_parallel_backend('civis', make_backend_factory(
+    ...     required_resources={"cpu": 512, "memory": 256}))
+    >>> with parallel_backend('civis'):
+    ...     gs.fit(digits.data, digits.target)
+
+Debugging
+---------
+Any (non-retried) errors in child jobs will cause the entire parallel call to
+fail. ``joblib`` will transport the first exception from a remote job and
+raise it in the parent process so that you can debug.
+
+If your remote jobs are failing because of network problems (e.g. occasional
+500 errors), you can make your parallel call more likely to succeed by using
+a ``max_job_retries`` value above 0 when creating your backend factory.
+This will automatically retry a job (potentially more than once) before giving
+up and keeping an exception.
+
+Logging: The Civis joblib backend uses the standard library 
+`logging module <https://docs.python.org/3/library/logging.html>`_, 
+with debug emits for events which might help you diagnose errors.
+See also the "verbose" argument to :class:`joblib.Parallel`, which
+prints information to either stdout or stderr.
+
+Mismatches between your local environment and the environment in the
+Civis container script jobs are a common source of errors.
+To run a function in the Civis platform, that function must be 
+importable from a Python interpreter running in the container script.
+For example, if you define a function::
+
+    def my_func(x):
+        return 2*x
+        
+and run this with :func:`joblib.Parallel`, you'll get an error like::
+
+    AttributeError: module '__main__' has no attribute 'my_func'
+    
+which signifies that the function you're trying to run doesn't exist
+in the remote environment. Install it in your remote environment by
+putting it into a GitHub repository and using the ``repo_http_uri``
+parameter of :func:`~civis.parallel.make_backend_factory`.
+
+Object Reference
+================
+
+.. automodule:: civis.parallel
+    :members:


### PR DESCRIPTION
Add RST documentation about how to use the new joblib backend. Includes some tweaks to docstrings for better formatting in web documentation.