### PR TITLE
[CIVP-12068] ENH Serialize with cloudpickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added email notifications option to ``ModelPipeline``.
-- Added custom ``joblib`` backend for multiprocessing in the Civis Platform. Public-facing functions are ``make_backend_factory``, ``make_backend_template_factory``, and ``infer_backend_factory``.
+- Added custom ``joblib`` backend for multiprocessing in the Civis Platform. Public-facing functions are ``make_backend_factory``, ``make_backend_template_factory``, and ``infer_backend_factory``. Includes a new hard dependency on ``cloudpickle`` to facilitate code transport.
 
 ### Fixed
 - Fixed a bug where the version of a dependency for Python 2.7 usage was incorrectly specified.

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -52,6 +52,11 @@ so it will run ``pre_dispatch`` jobs at once. The default value of
 at once in the Civis Platform. Set ``pre_dispatch="n_jobs"`` in your
 :class:`~joblib.Parallel` call to run at most ``n_jobs`` jobs.
 
+The Civis joblib backend uses `cloudpickle <https://github.com/cloudpipe/cloudpickle>`_
+to transport code and data from the parent environment to the Civis Platform.
+This means that you may parallelize dynamically-defined functions and classes,
+including lambda functions.
+
 Infer backend parameters
 ------------------------
 If you're writing code which will run inside a Civis Container Script, then
@@ -143,21 +148,19 @@ prints information to either stdout or stderr.
 
 Mismatches between your local environment and the environment in the
 Civis container script jobs are a common source of errors.
-To run a function in the Civis platform, that function must be 
-importable from a Python interpreter running in the container script.
-For example, if you define a function::
+To run a function in the Civis platform, any modules called by 
+that function must be importable from a Python interpreter running 
+in the container script. For example, if you use :class:`joblib.Parallel`
+with :func:`numpy.sqrt`, the joblib backend must be set to run
+your function in a container which has :mod:`numpy` installed.
+If you see an error such as::
 
-    def my_func(x):
-        return 2*x
-        
-and run this with :class:`joblib.Parallel`, you'll get an error like::
-
-    AttributeError: module '__main__' has no attribute 'my_func'
+    ModuleNotFoundError: No module named 'numpy'
     
-which signifies that the function you're trying to run doesn't exist
-in the remote environment. Install it in your remote environment by
-putting it into a GitHub repository and using the ``repo_http_uri``
-parameter of :func:`~civis.parallel.make_backend_factory`.
+this signifies that the function you're trying to run doesn't exist
+in the remote environment. Select a Docker container with the module installed,
+or install it in your remote environment by using the ``repo_http_uri``
+parameter of :func:`~civis.parallel.make_backend_factory` to install it from GitHub.
 
 Object Reference
 ================

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib~=0.11
 pubnub~=4
+cloudpickle~=0.2

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ def main():
             'six>=1.10,<=1.99',
             'joblib>=0.11,<=0.11.99',
             'pubnub>=4.0,<=4.99',
+            'cloudpickle>=0.2.0,<=0.3.99',
         ],
         extras_require={
             ':python_version=="2.7"': [


### PR DESCRIPTION
Switch from serializing with `joblib` to using `cloudpickle`. `joblib` is more efficient than pickle protocol 2 for storing numpy arrays, but pickle protocols 3 and 4 (available in Python 3) are just as good as `joblib` for array data. `cloudpickle` adds the ability to transport dynamically defined functions and classes, so that users don't need to create installable Python modules to run a single custom function in the Civis Platform.

Using protocol `pickle.HIGHEST_PROTOCOL` guarantees that we get the best protocol for our version of Python. This does assume that users have the same Python version on both ends of the `joblib.Parallel` call.

TODO:
- [x] Modify `parallel` documentation to reflect the ability to use dynamically-defined classes and functions.