### PR TITLE
[CIVP-12029] ENH Retry uploads and downloads in joblib backend

### DIFF
--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -409,11 +409,33 @@ class JobSubmissionError(Exception):
     pass
 
 
-def _robust_pickle_download(output_file_id, client, n_retries=5, delay=0.0):
+def _robust_pickle_download(output_file_id, client=None,
+                            n_retries=5, delay=0.0):
     """Download and deserialize the result from output_file_id
 
     Retry network errors `n_retries` times with `delay` seconds between calls
+
+    Parameters
+    ----------
+    output_file_id : int
+        ID of the file to download
+    client : civis.APIClient, optional
+    n_retries : int, optional
+        Retry the upload this many times before raising an error.
+    delay : float, optional
+        If provided, wait this many seconds between retries.
+
+    Returns
+    -------
+    obj
+        Any Python object; the result of calling ``joblib.load`` on the
+        downloaded file
+
+    See Also
+    --------
+    joblib.load
     """
+    client = client or civis.APIClient(resources='all')
     retry_exc = (requests.HTTPError,
                  requests.ConnectionError,
                  requests.ConnectTimeout)
@@ -436,7 +458,7 @@ def _robust_pickle_download(output_file_id, client, n_retries=5, delay=0.0):
             return joblib.load(buffer)
 
 
-def _robust_file_to_civis(buf, name, client, n_retries=5,
+def _robust_file_to_civis(buf, name, client=None, n_retries=5,
                           delay=0.0, **kwargs):
     """Upload the contents of an input file-like buffer
 
@@ -472,6 +494,7 @@ def _robust_file_to_civis(buf, name, client, n_retries=5,
     --------
     civis.io.file_to_civis
     """
+    client = client or civis.APIClient(resources='all')
     retry_exc = (requests.HTTPError,
                  requests.ConnectionError,
                  requests.ConnectTimeout)

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -409,7 +409,7 @@ class JobSubmissionError(Exception):
     pass
 
 
-def _robust_result_download(output_file_id, client, n_retries=5, delay=0.0):
+def _robust_pickle_download(output_file_id, client, n_retries=5, delay=0.0):
     """Download and deserialize the result from output_file_id
 
     Retry network errors `n_retries` times with `delay` seconds between calls
@@ -434,6 +434,63 @@ def _robust_result_download(output_file_id, client, n_retries=5, delay=0.0):
         else:
             buffer.seek(0)
             return joblib.load(buffer)
+
+
+def _robust_file_to_civis(buf, name, client, n_retries=5,
+                          delay=0.0, **kwargs):
+    """Upload the contents of an input file-like buffer
+
+    Call :func:`~civis.io.file_to_civis`, and retry a specified
+    number of times before giving up. This will abandon
+    Civis files created for failed uploads. Thoase files may
+    be partially filled; it's necessary to create new files
+    to ensure that the contents are exactly as requested.
+
+    .. note:: This function starts by calling ``.seek(0)`` on the
+              buffer, and will do so before every retry.
+
+    Parameters
+    ----------
+    buf : File
+        File-like bytes object to send to a Civis File
+    name : str
+        Name of the new Civis File
+    client : civis.APIClient, optional
+    n_retries : int, optional
+        Retry the upload this many times before raising an error.
+    delay : float, optional
+        If provided, wait this many seconds between retries.
+    kwargs :
+        Extra keyword arguments will be passed to ``io.file_to_civis``
+
+    Returns
+    -------
+    int
+        ID of the new Civis File
+
+    See Also
+    --------
+    civis.io.file_to_civis
+    """
+    retry_exc = (requests.HTTPError,
+                 requests.ConnectionError,
+                 requests.ConnectTimeout)
+    n_failed = 0
+    while True:
+        buf.seek(0)
+        try:
+            file_id = civis.io.file_to_civis(buf, name=name,
+                                             client=client, **kwargs)
+        except retry_exc as exc:
+            if n_failed < n_retries:
+                n_failed += 1
+                log.debug("Upload failure %s due to %s; retrying.",
+                          n_failed, str(exc))
+                time.sleep(delay)
+            else:
+                raise
+        else:
+            return file_id
 
 
 class _CivisBackendResult:
@@ -521,7 +578,7 @@ class _CivisBackendResult:
                     fut.job_id, fut.run_id)
                 if run_outputs:
                     output_file_id = run_outputs[0]['object_id']
-                    res = _robust_result_download(output_file_id, client,
+                    res = _robust_pickle_download(output_file_id, client,
                                                   n_retries=5, delay=1.0)
                     fut.remote_func_output = res
                     log.debug("Downloaded and deserialized the result.")
@@ -640,10 +697,12 @@ class _CivisBackend(ParallelBackendBase):
             joblib.dump(func, temppath, compress=3)
             with open(temppath, "rb") as tmpfile:
                 func_file_id = \
-                    civis.io.file_to_civis(tmpfile,
-                                           "civis_joblib_backend_func",
-                                           expires_at=expires_at,
-                                           client=self._client)
+                    _robust_file_to_civis(tmpfile,
+                                          "civis_joblib_backend_func",
+                                          n_retries=5,
+                                          delay=0.5,
+                                          expires_at=expires_at,
+                                          client=self._client)
                 log.debug("uploaded serialized function to File: %d",
                           func_file_id)
 


### PR DESCRIPTION
Large-scale jobs sometimes encounter 500 errors from web communications with S3. We can greatly reduce the chance of these failures interrupting a job by retrying ``file_to_civis`` and ``civis_to_file`` operations.

Add a wrapper for ``civis.io.file_to_civis`` which retries on network errors. Rename ``_robust_result_download`` to ``_robust_pickle_download``, since we don't care that the contents of the file are a result. Use these functions for upload and download on both sides of the joblib backend.

There's no new changelog entry because this PR modifies unreleased code.

Closes #109 .