### PR TITLE
[CIVP-12028] ENH Allow arbitrary keyword arguments to joblib backend

### DIFF
--- a/civis/futures.py
+++ b/civis/futures.py
@@ -455,9 +455,8 @@ class _ContainerShellExecutor(_CivisExecutor):
     Parameters
     ----------
     docker_image_name: str, optional
-        The name of the Docker image to be used by Civis.
-    docker_image_tag: str, optional
-        The name of the tag for the Docker image.
+        The name of the Docker image to be used by Civis. You may also
+        wish to specify a ``docker_image_tag`` in the keyword arguments.
     script_name: str, optional
         The name for containers in Civis.
         Defaults to "ContainerShellExecutorScript" followed by the date.
@@ -495,7 +494,6 @@ class _ContainerShellExecutor(_CivisExecutor):
     civis.APIClient.scripts.post_containers
     """
     def __init__(self, docker_image_name="civisanalytics/datascience-python",
-                 docker_image_tag="latest",
                  script_name=None,
                  required_resources=None,
                  hidden=True,
@@ -505,7 +503,6 @@ class _ContainerShellExecutor(_CivisExecutor):
                  inc_script_names=False,
                  **kwargs):
         self.docker_image_name = docker_image_name
-        self.docker_image_tag = docker_image_tag
         self.container_kwargs = kwargs
 
         if required_resources is None:
@@ -541,7 +538,6 @@ class _ContainerShellExecutor(_CivisExecutor):
             required_resources=self.required_resources,
             docker_command=cmd,
             docker_image_name=self.docker_image_name,
-            docker_image_tag=self.docker_image_tag,
             hidden=self.hidden,
             **self.container_kwargs
         )

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -454,15 +454,17 @@ class _ContainerShellExecutor(_CivisExecutor):
 
     Parameters
     ----------
-    docker_image_name: str
+    docker_image_name: str, optional
         The name of the Docker image to be used by Civis.
-    docker_image_tag: str
+    docker_image_tag: str, optional
         The name of the tag for the Docker image.
-    script_name: str
+    script_name: str, optional
         The name for containers in Civis.
-    required_resources: dict
+        Defaults to "ContainerShellExecutorScript" followed by the date.
+    required_resources: dict, optional
         A dictionary specifying what resources the job needs.
         See :func:`~APIClient.scripts.post_containers` for details.
+        Defaults to 1 CPU and 1 GiB of RAM.
     hidden: bool, optional
         The hidden status of the object. Setting this to ``True`` hides it
         from most API endpoints. The object can still be queried
@@ -486,7 +488,7 @@ class _ContainerShellExecutor(_CivisExecutor):
         the script names for each submission.
     **kwargs:
         Additional keyword arguments will be passed
-        directly to ``scripts.post_containers``.
+        directly to :func:`~civis.APIClient.scripts.post_containers`.
 
     See Also
     --------
@@ -510,6 +512,9 @@ class _ContainerShellExecutor(_CivisExecutor):
             required_resources = {'cpu': 1024, 'memory': 1024}
         self.required_resources = required_resources
 
+        if kwargs.get('name'):
+            # The argument in `post_containers` is named "name"
+            script_name = kwargs.pop('name')
         if script_name is None:
             date_str = datetime.datetime.today().strftime("%Y-%m-%d")
             script_name = ("ContainerShellExecutorScript "

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -111,9 +111,9 @@ def infer_backend_factory(required_resources=None,
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
     **kwargs:
-        Additional keyword arguments will be passed
-        directly to ``scripts.post_containers``, potentially overriding
-        the values of those arguments in the parent environment.
+        Additional keyword arguments will be passed directly to
+        :func:`~civis.APIClient.scripts.post_containers`, potentially
+        overriding the values of those arguments in the parent environment.
 
     Raises
     ------

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -186,7 +186,6 @@ def infer_backend_factory(required_resources=None,
 
 
 def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
-                         docker_image_tag="latest",
                          client=None,
                          polling_interval=None,
                          setup_cmd=None,
@@ -203,9 +202,8 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     Parameters
     ----------
     docker_image_name : str, optional
-        The image for the container script.
-    docker_image_tag : str, optional
-        The tag for the Docker image.
+        The image for the container script. You may also wish to specify
+        a ``docker_image_tag`` in the keyword arguments.
     client : `civis.APIClient` instance or None, optional
         An API Client object to use.
     polling_interval : int, optional
@@ -321,7 +319,6 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
 
     def backend_factory():
         return _CivisBackend(docker_image_name=docker_image_name,
-                             docker_image_tag=docker_image_tag,
                              client=client,
                              polling_interval=polling_interval,
                              setup_cmd=setup_cmd,

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -26,6 +26,12 @@ _DEFAULT_SETUP_CMD = ":"  # An sh command that does nothing.
 _DEFAULT_REPO_SETUP_CMD = "cd /app; python setup.py install; cd /"
 _ALL_JOBS = 50  # Give the user this many jobs if they request "all of them"
 
+# When creating a remote execution environment from an existing
+# Container Script, read these keys.
+KEYS_TO_INFER = ['docker_image_name', 'docker_image_tag', 'repo_http_uri',
+                 'repo_ref', 'remote_host_credential_id', 'git_credential_id',
+                 'cancel_timeout', 'time_zone']
+
 
 def infer_backend_factory(required_resources=None,
                           params=None,
@@ -49,6 +55,9 @@ def infer_backend_factory(required_resources=None,
     user has modified the container job since the run started
     (e.g. by changing the GitHub branch in the container's GUI),
     this function may infer incorrect settings for the child jobs.
+
+    Keyword arguments inferred from the existing script's state are
+    %s
 
     Parameters
     ----------
@@ -168,9 +177,7 @@ def infer_backend_factory(required_resources=None,
 
     # Set defaults on other keyword arguments with
     # values from the current script
-    for key in ['docker_image_name', 'docker_image_tag', 'repo_http_uri',
-                'repo_ref', 'remote_host_credential_id', 'git_credential_id',
-                'cancel_timeout', 'time_zone']:
+    for key in KEYS_TO_INFER:
         kwargs.setdefault(key, state[key])
 
     return make_backend_factory(required_resources=state.required_resources,
@@ -183,6 +190,9 @@ def infer_backend_factory(required_resources=None,
                                 max_job_retries=max_job_retries,
                                 hidden=hidden,
                                 **kwargs)
+
+
+infer_backend_factory.__doc__ = infer_backend_factory.__doc__ % KEYS_TO_INFER
 
 
 def make_backend_factory(docker_image_name="civisanalytics/datascience-python",

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -35,7 +35,8 @@ def infer_backend_factory(required_resources=None,
                           setup_cmd=None,
                           max_submit_retries=0,
                           max_job_retries=0,
-                          hidden=True):
+                          hidden=True,
+                          **kwargs):
     """Infer the container environment and return a backend factory.
 
     This function helps you run additional jobs from code which executes
@@ -109,6 +110,10 @@ def infer_backend_factory(required_resources=None,
         The hidden status of the object. Setting this to true
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
+    **kwargs:
+        Additional keyword arguments will be passed
+        directly to ``scripts.post_containers``, potentially overriding
+        the values of those arguments in the parent environment.
 
     Raises
     ------
@@ -161,11 +166,14 @@ def infer_backend_factory(required_resources=None,
     # Update arguments with input
     state.arguments.update(arguments or {})
 
-    return make_backend_factory(docker_image_name=state.docker_image_name,
-                                docker_image_tag=state.docker_image_tag,
-                                repo_http_uri=state.repo_http_uri,
-                                repo_ref=state.repo_ref,
-                                required_resources=state.required_resources,
+    # Set defaults on other keyword arguments with
+    # values from the current script
+    for key in ['docker_image_name', 'docker_image_tag', 'repo_http_uri',
+                'repo_ref', 'remote_host_credential_id', 'git_credential_id',
+                'cancel_timeout', 'time_zone']:
+        kwargs.setdefault(key, state[key])
+
+    return make_backend_factory(required_resources=state.required_resources,
                                 params=state.params,
                                 arguments=state.arguments,
                                 client=client,
@@ -173,22 +181,19 @@ def infer_backend_factory(required_resources=None,
                                 setup_cmd=setup_cmd,
                                 max_submit_retries=max_submit_retries,
                                 max_job_retries=max_job_retries,
-                                hidden=hidden)
+                                hidden=hidden,
+                                **kwargs)
 
 
 def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
                          docker_image_tag="latest",
-                         repo_http_uri=None,
-                         repo_ref=None,
-                         required_resources=None,
-                         params=None,
-                         arguments=None,
                          client=None,
                          polling_interval=None,
                          setup_cmd=None,
                          max_submit_retries=0,
                          max_job_retries=0,
-                         hidden=True):
+                         hidden=True,
+                         **kwargs):
     """Create a joblib backend factory that uses Civis Container Scripts
 
     .. note:: The total size of function parameters in `Parallel()`
@@ -201,27 +206,6 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
         The image for the container script.
     docker_image_tag : str, optional
         The tag for the Docker image.
-    repo_http_uri : str, optional
-        The GitHub repo to check out to /app
-        (e.g., github.com/my-user/my-repo.git)
-    repo_ref : str, optional
-        The GitHub repo reference to check out (e.g., "master")
-    required_resources : dict or None, optional
-        The resources needed by the container. See the
-        `container scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
-        for details.
-    params : list or None, optional
-        A definition of the parameters this script accepts in the
-        arguments field. See the `container scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
-        for details.
-    arguments : dict or None, optional
-        Dictionary of name/value pairs to use to run this script.
-        Only settable if this script has defined params. See the `container
-        scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
-        for details.
     client : `civis.APIClient` instance or None, optional
         An API Client object to use.
     polling_interval : int, optional
@@ -257,6 +241,9 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
         The hidden status of the object. Setting this to true
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
+    **kwargs:
+        Additional keyword arguments will be passed
+        directly to :func:`~civis.APIClient.scripts.post_containers`.
 
     Examples
     --------
@@ -321,9 +308,13 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     necessary Python objects (e.g., if you pass a Pandas data frame, the image
     must have Pandas installed). In particular, the function that is called by
     ``joblib`` must be available in the specified environment.
+
+    See Also
+    --------
+    civis.APIClient.scripts.post_containers
     """
     if setup_cmd is None:
-        if repo_http_uri is not None:
+        if kwargs.get('repo_http_uri'):
             setup_cmd = _DEFAULT_REPO_SETUP_CMD
         else:
             setup_cmd = _DEFAULT_SETUP_CMD
@@ -331,17 +322,13 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     def backend_factory():
         return _CivisBackend(docker_image_name=docker_image_name,
                              docker_image_tag=docker_image_tag,
-                             repo_http_uri=repo_http_uri,
-                             repo_ref=repo_ref,
-                             required_resources=required_resources,
-                             params=params,
-                             arguments=arguments,
                              client=client,
                              polling_interval=polling_interval,
                              setup_cmd=setup_cmd,
                              max_submit_retries=max_submit_retries,
                              max_n_retries=max_job_retries,
-                             hidden=hidden)
+                             hidden=hidden,
+                             **kwargs)
 
     return backend_factory
 

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -311,9 +311,7 @@ def test_infer_from_custom_job(mock_make_factory):
                        'max_submit_retries': mock.ANY,
                        'max_job_retries': mock.ANY,
                        'hidden': True}
-    for key in ['docker_image_name', 'docker_image_tag', 'repo_http_uri',
-                'repo_ref', 'remote_host_credential_id', 'git_credential_id',
-                'cancel_timeout', 'time_zone']:
+    for key in civis.parallel.KEYS_TO_INFER:
         expected_kwargs[key] = mock_script[key]
     mock_make_factory.assert_called_once_with(**expected_kwargs)
 


### PR DESCRIPTION
Allow users to pass keyword arguments to ``_ContainerShellExecutor`` and ``make_backend_factory`` and ``infer_backend_factory``. These keyword arguments will be passed directly to ``APIClient.scripts.post_containers``. An example of a new argument which users might want to pass is "cancel_timeout".

There's no modification to the changelog since this PR changes only unreleased code.

Closes #108 .

TODO
- [x] Update `infer_joblib_backend` to infer arbitrary arguments.