### PR TITLE
[CIVP-12088] BUG Stop ModelFuture cancellation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed a bug where the version of a dependency for Python 2.7 usage was incorrectly specified.
 - Non-seekable file-like objects can now be provided to ``civis.io.file_to_civis``. Only seekable file-like objects will be streamed.
+- The ``civis.ml.ModelFuture`` no longer raises an exception if its model job is cancelled.
 
 ## 1.5.2 - 2017-05-17
 ### Fixed

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -328,6 +328,9 @@ class ModelFuture(ContainerFuture):
             # check the tail of the log for a clearer exception.
             exc = _exception_from_logs(exc, fut.job_id, fut.run_id, fut.client)
             fut.set_exception(exc)
+        except futures.CancelledError:
+            # We don't need to change the exception if the run was cancelled
+            pass
         except KeyError:
             # KeyErrors always represent a bug in the modeling code,
             # but showing the resulting KeyError can be confusing and

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1,5 +1,6 @@
 from builtins import super
 from collections import namedtuple
+from concurrent.futures import CancelledError
 from six import BytesIO
 import json
 import os
@@ -225,7 +226,7 @@ def test_set_model_exception_metadata_exception():
             raise self.__exc('What a spectacular failure, you say!')
 
     # exception types get caught!
-    for exc in [FileNotFoundError, CivisJobFailure, KeyError]:
+    for exc in [FileNotFoundError, CivisJobFailure, KeyError, CancelledError]:
         fut = ModelFutureRaiseExc(exc, 1, 2, client=mock_client)
         _model.ModelFuture._set_model_exception(fut)
 


### PR DESCRIPTION
If a modelling job is cancelled, then `fut.metadata` raises a `concurrent.future.CancelledError`. The `ModelFuture._set_model_exception` callback needs to allow for this -- if the job is cancelled, there's no new error to set, and we don't want to raise anything.