### PR TITLE
[CIVP-12119] BUG Expire the CLI's API spec cache after 24 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug where the version of a dependency for Python 2.7 usage was incorrectly specified.
 - Non-seekable file-like objects can now be provided to ``civis.io.file_to_civis``. Only seekable file-like objects will be streamed.
 - The ``civis.ml.ModelFuture`` no longer raises an exception if its model job is cancelled.
+- The CLI's API spec cache now expires after 24 hours instead of 10 seconds.
 
 ## 1.5.2 - 2017-05-17
 ### Fixed

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -201,7 +201,7 @@ def retrieve_spec_dict():
     try:
         # If the cached spec is from the last 24 hours, use it.
         modified_time = os.path.getmtime(_CACHED_SPEC_PATH)
-        if now_timestamp - modified_time < 10:
+        if now_timestamp - modified_time < 24 * 3600:
             refresh_spec = False
             with open(_CACHED_SPEC_PATH) as f:
                 spec_dict = json.load(f, object_pairs_hook=OrderedDict)


### PR DESCRIPTION
The comment in the code indicates that the cache should last 24 hours. The 10 second expiration is likely a holdover from debugging.