### PR TITLE
[CIVP-12117] TST Run pandas and scikit-learn tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
+    - pip install pandas scikit-learn scipy
     - pip install -e .
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Edited example for safer null value handling
 - Make ``pubnub`` and ``joblib`` hard dependencies instead of optional dependencies (#110).
+- Include ``pandas`` and ``sklearn``-dependent code in Travis CI tests.
 
 ### Added
 - Version 1.1 of CivisML, with custom dependency installation from remote git hosting services (i.e., Github, Bitbucket).

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest~=2.8.0
+pytest>=3,<4
 sphinx>=1.4.6,==1.*
 flake8>=3.0.4,==3.*
 mock==2.0.0 ; python_version == '2.7'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,5 @@ sphinx>=1.4.6,==1.*
 flake8>=3.0.4,==3.*
 mock==2.0.0 ; python_version == '2.7'
 pytest-cov>=2.4.0,==2.*
-vcrpy>=1.10.0,<=1.10.9
+vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = docs
 
 [flake8]


### PR DESCRIPTION
`pandas` and `scikit-learn` are optional dependencies for the Python API client. We have tests which exercise these code paths, but the libraries aren't installed in the Travis testing environment, so we don't test the functions. This adds `pandas` and `sklearn` to Travis so that we're no longer skipping tests.

Increase the required version of `vcrpy`; previously the `civis/tests/test_io.py::ImportTests.test_read_civis_pandas` test would error on Python 3.6 with
`TypeError: request() got an unexpected keyword argument 'encode_chunked'`. This was a `vcrpy` Python 3.6 incompatibility, fixed in their v1.11 release.

Also tweak the tests in test_model.py so that we're not raising uncaught warnings.

After this PR, no tests are skipped, and the test suite doesn't raise any warnings.