### PR TITLE
[CIVP-12351] BUG make sure to pass proper defaults for PARAMS and CVPARAMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Catch unnecessary warning while importing xgboost in CivisML_parallel_training.ipynb (#121)
 
+### Fixed
+- Fixed bug where instantiating a ``ModelPipeline`` from a CivisML model built w/ the templated script breaks.
+
 ## 1.6.0 - 2017-07-27
 ### Changed
 - Edited example for safer null value handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Catch unnecessary warning while importing xgboost in CivisML_parallel_training.ipynb (#121)
 
 ### Fixed
-- Fixed bug where instantiating a ``ModelPipeline`` from a CivisML model built w/ the templated script breaks.
+- Fixed bug where instantiating a ``ModelPipeline`` from a CivisML model built w/ the templated script breaks (#122).
 
 ## 1.6.0 - 2017-07-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Catch unnecessary warning while importing xgboost in CivisML_parallel_training.ipynb (#121)
 
 ### Fixed
-- Fixed bug where instantiating a ``ModelPipeline`` from a CivisML model built w/ the templated script breaks (#122).
+- Fixed bug where instantiating a new model via ``ModelPipeline.from_existing`` from an existing model with empty "PARAMS" and "CV_PARAMS" boxes fails (#122).
 
 ## 1.6.0 - 2017-07-27
 ### Changed

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -694,8 +694,8 @@ class ModelPipeline:
         model = args.get('MODEL', args.get('WORKFLOW'))
         dependent_variable = args['TARGET_COLUMN'].split()
         primary_key = args.get('PRIMARY_KEY')
-        parameters = json.loads(args.get('PARAMS', {}))
-        cross_validation_parameters = json.loads(args.get('CVPARAMS', {}))
+        parameters = json.loads(args.get('PARAMS', "{}"))
+        cross_validation_parameters = json.loads(args.get('CVPARAMS', "{}"))
         calibration = args.get('CALIBRATION')
         excluded_columns = args.get('EXCLUDE_COLS', None)
         if excluded_columns:

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -627,13 +627,8 @@ def test_modelpipeline_classmethod_constructor_defaults(
     del container_response_stub.arguments['PARAMS']
     del container_response_stub.arguments['CVPARAMS']
     mock_client = mock.Mock()
-    mock_client.scripts.get_containers.return_value = \
-        container = container_response_stub
+    mock_client.scripts.get_containers.return_value = container_response_stub
     mock_client.credentials.get.return_value = Response({'name': 'Token'})
-
-    resources = {'REQUIRED_CPU': 1000,
-                 'REQUIRED_MEMORY': 9999,
-                 'REQUIRED_DISK_SPACE': -20}
 
     # test everything is working fine
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -621,6 +621,26 @@ def test_modelpipeline_classmethod_constructor(mock_future,
     assert mp.git_token_name == 'Token'
 
 
+@mock.patch.object(_model, 'ModelFuture')
+def test_modelpipeline_classmethod_constructor_defaults(
+        mock_future, container_response_stub):
+    del container_response_stub.arguments['PARAMS']
+    del container_response_stub.arguments['CVPARAMS']
+    mock_client = mock.Mock()
+    mock_client.scripts.get_containers.return_value = \
+        container = container_response_stub
+    mock_client.credentials.get.return_value = Response({'name': 'Token'})
+
+    resources = {'REQUIRED_CPU': 1000,
+                 'REQUIRED_MEMORY': 9999,
+                 'REQUIRED_DISK_SPACE': -20}
+
+    # test everything is working fine
+    mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
+    assert mp.cv_params == {}
+    assert mp.parameters == {}
+
+
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
 def test_modelpipeline_classmethod_constructor_nonint_id():
     # Verify that we can still JSON-serialize job and run IDs even


### PR DESCRIPTION
This PR fixes a bug where instantiating a `ModelPipeline` instance from a CivisML model run with a templated script fails due to improper defaults for the `PARAMS` and `CVPARAMS` keys.