### PR TITLE
BUG Add ml and parallel to civis namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed bug where instantiating a new model via ``ModelPipeline.from_existing`` from an existing model with empty "PARAMS" and "CV_PARAMS" boxes fails (#122).
+- Users can now access the ``ml`` and ``parallel`` namespaces from the base ``civis`` namespace.
 
 ## 1.6.0 - 2017-07-27
 ### Changed

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
-from civis import io
+from civis import io, ml, parallel
 
-__all__ = ["__version__", "APIClient", "find", "find_one", "io"]
+__all__ = ["__version__", "APIClient", "find", "find_one", "io",
+           "ml", "parallel"]


### PR DESCRIPTION
The `ml` and `parallel` namespaces weren't part of `civis.__init__.py`'s `__all__`, so users needed to use e.g. `from civis.ml import ModelPipeline` instead of `civis.ml.ModelPipeline`. This change makes `ml` and `parallel` part of the top-level namespace.