### PR TITLE
[PARO-436] BUG raise more informative error when multi-indexed dataframe is passed in

### DIFF
--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -83,6 +83,9 @@ def _block_and_handle_missing(method):
 
 def _stash_local_dataframe(df, client=None):
     """Store data in a temporary Civis File and return the file ID"""
+    # Standard dataframe indexes do not have a "levels" attribute,
+    # but multiindexes do. Checking for this attribute means we don't
+    # need to import pandas to do error handling here.
     if getattr(getattr(df, "index", None), "levels", None) is not None:
         raise TypeError("CivisML does not currently support "
                         "multi-indexed data frames.")

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -87,8 +87,9 @@ def _stash_local_dataframe(df, client=None):
     # but multiindexes do. Checking for this attribute means we don't
     # need to import pandas to do error handling here.
     if getattr(getattr(df, "index", None), "levels", None) is not None:
-        raise TypeError("CivisML does not currently support "
-                        "multi-indexed data frames.")
+        raise TypeError("CivisML does not support multi-indexed data frames. "
+                        "Try calling `.reset_index` on your data to convert "
+                        "it into a CivisML-friendly format.")
     civis_fname = 'modelpipeline_data.csv'
     buf = six.BytesIO()
     if six.PY3:

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -83,6 +83,9 @@ def _block_and_handle_missing(method):
 
 def _stash_local_dataframe(df, client=None):
     """Store data in a temporary Civis File and return the file ID"""
+    if getattr(getattr(df, "index", None), "levels", None) is not None:
+        raise TypeError("CivisML does not currently support "
+                        "multi-indexed data frames.")
     civis_fname = 'modelpipeline_data.csv'
     buf = six.BytesIO()
     if six.PY3:

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -146,6 +146,18 @@ def test_stash_local_data_from_file(mock_file):
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+@pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
+def test_stash_local_dataframe_multiindex_err():
+    arrays = [np.array(['bar', 'bar', 'baz', 'baz',
+                        'foo', 'foo', 'qux', 'qux']),
+              np.array(['one', 'two', 'one', 'two',
+                        'one', 'two', 'one', 'two'])]
+    df = pd.DataFrame(np.random.randn(8, 4), index=arrays)
+    with pytest.raises(TypeError):
+        _model._stash_local_dataframe(df)
+
+
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 @mock.patch.object(_model.cio, 'file_to_civis', return_value=-11)
 def test_stash_local_data_from_dataframe(mock_file):
     df = pd.DataFrame({'a': [1], 'b': [2]})


### PR DESCRIPTION
Currently, multi-indexed dataframes get read in, and the job fails down the line, throwing an uninformative error. This PR checks for multi-indexed dataframes directly, and throws an informative error to let the user know they are not supported.