### PR TITLE
BUG Fully implement iterator protocol in PaginatedResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `ResourceWarning` for Python 2.7 (#128).
 - Added `TypeError` for multi-indexed dataframes when used as input to
   CivisML (#131).
+- Make the `PaginatedResponse` returned by LIST endpoints a full iterator.
 
 ### Added
 - Jupyter notebook with demonstrations of use patterns and abstractions in the Python API client (#127).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `TypeError` for multi-indexed dataframes when used as input to
   CivisML (#131).
 - Make the `PaginatedResponse` returned by LIST endpoints a full iterator.
+  This also makes the `iterator=True` parameter work in Python 2.
 
 ### Added
 - Jupyter notebook with demonstrations of use patterns and abstractions in the Python API client (#127).

--- a/civis/response.py
+++ b/civis/response.py
@@ -200,3 +200,5 @@ class PaginatedResponse:
         if self._iter is None:
             self._iter = self._get_iter()
         return next(self._iter)
+
+    next = __next__  # Python 2 compatibility

--- a/civis/response.py
+++ b/civis/response.py
@@ -137,7 +137,7 @@ class Response(dict):
 
 
 class PaginatedResponse:
-    """A response object that supports iteration.
+    """A response object which is an iterator
 
     Parameters
     ----------
@@ -172,7 +172,12 @@ class PaginatedResponse:
         self._params['page_num'] = 1
         self._params.pop('limit', None)
 
+        self._iter = None
+
     def __iter__(self):
+        return self
+
+    def _get_iter(self):
         while True:
             response = self._endpoint._make_request('GET',
                                                     self._path,
@@ -190,3 +195,8 @@ class PaginatedResponse:
                 yield converted_data
 
             self._params['page_num'] += 1
+
+    def __next__(self):
+        if self._iter is None:
+            self._iter = self._get_iter()
+        return next(self._iter)


### PR DESCRIPTION
The `PaginatedResponse` provided iteration support, but didn't implement the `__next__` method. This meant that the object itself was not an iterator. A small tweak can turn it into an iterator itself. Since the `PaginatedResponse` is returned when users provide an `iterator=True` argument to list endpoints, it seems reasonable for them to expect the returned object is an iterator.