### PR TITLE
BUG ModelPipeline.from_existing handle future training templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `ResourceWarning` for Python 2.7 (#128).
 - Added `TypeError` for multi-indexed dataframes when used as input to
   CivisML (#131).
+- ``ModelPipeline.from_existing`` will warn if users attempt to recreate
+  a model trained with a newer version of CivisML, and fall back on the
+  most recent prediction template it knows of.
 
 ### Added
 - Jupyter notebook with demonstrations of use patterns and abstractions in the Python API client (#127).

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     HAS_SKLEARN = False
 
-from civis import APIClient, find, find_one
+from civis import APIClient, find, find_one, __version__
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.compat import FileNotFoundError
@@ -743,7 +743,17 @@ class ModelPipeline:
 
         # Set prediction template corresponding to training template
         template_id = int(container['from_template_id'])
-        klass.predict_template_id = _PRED_TEMPLATES.get(template_id)
+        p_id = _PRED_TEMPLATES.get(template_id)
+        if p_id is None:
+            warnings.warn('Model %s was trained with a newer version of '
+                          'CivisML than is available in the API client '
+                          'version %s. Please update your API client version .'
+                          'Attempting to use an older version of the '
+                          'prediction code. Prediction will either fail '
+                          'immediately or succeed.'
+                          % (train_job_id, __version__), RuntimeWarning)
+            p_id = max(_PRED_TEMPLATES.values())
+        klass.predict_template_id = p_id
 
         return klass
 


### PR DESCRIPTION
If users called `ModelPipeline.from_existing` on a model training job which used a version of CivisML newer than what the client is aware of, we got errors because the prediction template ID was set to `None`. Let's warn and default to the newest known prediction template. At the very least, this should generate much clearer errors when the prediction job does a version check.