### PR TITLE
BUG Avoid IndexError on empty civis_to_csv queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   CivisML (#131).
 - Make the `PaginatedResponse` returned by LIST endpoints a full iterator.
   This also makes the `iterator=True` parameter work in Python 2.
+- When using ``civis.io.civis_to_csv``, emit a warning on SQL queries which
+  return no results instead of allowing a cryptic ``IndexError`` to surface (#135).
 
 ### Added
 - Jupyter notebook with demonstrations of use patterns and abstractions in the Python API client (#127).


### PR DESCRIPTION
The `_download_callback` used by `civis.io.civis_to_csv` assumed that the future it's attached to returned some output. If that weren't the case (either the query errored or succeeded with no results), then the user would see an `IndexError` display on the screen, but not halt program execution. This is confusing. Intercept the error and replace it with a warning.