### PR TITLE
[CIVP-12579] Update docstring of "civis_to_multifile_csv"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   This also makes the `iterator=True` parameter work in Python 2.
 - When using ``civis.io.civis_to_csv``, emit a warning on SQL queries which
   return no results instead of allowing a cryptic ``IndexError`` to surface (#135).
+- Fixed the example code snippet for ``civis.io.civis_to_multifile_csv``.
+  Also provided more details on its return dict in the docstring.
+- Pinned down `sphinx_rtd_theme` and `numpydoc` in `dev-requirements.txt`
+  for building the documentation.
 
 ### Added
 - Jupyter notebook with demonstrations of use patterns and abstractions in the Python API client (#127).

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -395,11 +395,11 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
             Each dict has the following keys:
 
             'id': int
-                File ID.
+                File ID
             'name': str
                 Filename
             'size': int
-                File size
+                File size in bytes
             'url': str
                 Unsigned S3 URL ('s3://...')
             'url_signed': str

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -384,7 +384,7 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     -------
     unload_manifest: dict
         A dictionary resembling an AWS manifest file. Has the following keys:
-        ``'header'``, ``'query'``, ``'entries'``, respresenting the columns
+        ``'header'``, ``'query'``, ``'entries'``, representing the columns
         from the query, the query itself, and a list of dictionaries for each
         unloaded CSV part, each containing its file ``'id'``, ``'name'``,
         ``'size'``, and unsigned and signed S3 urls, ``'url'`` and
@@ -395,8 +395,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     >>> sql = "SELECT * FROM schema.my_big_table"
     >>> database = "my_database"
     >>> delimiter = "|"
-    >>> manifest = civis_multipart_unload(sql, database, delimiter=delimiter)
-    >>> ids = [file['id'] for file in manifest['files']]
+    >>> manifest = civis_to_multifile_csv(sql, database, delimiter=delimiter)
+    >>> ids = [entry['id'] for entry in manifest['entries']]
     >>> buf = BytesIO()
     >>> civis_to_file(ids[0], buf)
     >>> buf.seek(0)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -384,11 +384,35 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     -------
     unload_manifest: dict
         A dictionary resembling an AWS manifest file. Has the following keys:
-        ``'header'``, ``'query'``, ``'entries'``, representing the columns
-        from the query, the query itself, and a list of dictionaries for each
-        unloaded CSV part, each containing its file ``'id'``, ``'name'``,
-        ``'size'``, and unsigned and signed S3 urls, ``'url'`` and
-        ``'url_signed'``, respectively.
+
+        'query': str
+            The query.
+
+        'header': list of str
+            The columns from the query.
+
+        'entries': list of dict
+            Each dict has the following keys:
+
+            'id': int
+                File ID.
+            'name': str
+                Filename
+            'size': int
+                File size
+            'url': str
+                Unsigned S3 URL ('s3://...')
+            'url_signed': str
+                Signed S3 URL ('https://...')
+
+        'unquoted': bool
+            Whether the cells are quoted.
+
+        'compression': str
+            Type of compression used.
+
+        'delimiter': str
+            Delimiter that separates the cells.
 
     Examples
     --------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ mock==2.0.0 ; python_version == '2.7'
 pytest-cov>=2.4.0,==2.*
 vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6
+sphinx_rtd_theme>=0.2.4,<=0.2.99

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pytest-cov>=2.4.0,==2.*
 vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6
 sphinx_rtd_theme>=0.2.4,<=0.2.99
+numpydoc>=0.7.0,<=0.7.99


### PR DESCRIPTION
This PR updates the docstring of `civis.io.civis_to_multifile_csv` by fixing the example code snippet as well as providing more details on the return dict. The updated docstring for the return dict looks like the following in the compiled Sphinx docs:

<img width="606" alt="screen shot 2017-09-07 at 11 14 20 am" src="https://user-images.githubusercontent.com/6993153/30173631-f31610ce-93bd-11e7-97b2-90f442b88cd6.png">

Also, while I was compiling the Sphinx docs locally to verify the changes, it's occurred to me that the packages `sphinx_rtd_theme` and `numpydoc` are needed, and so I've added them to `dev-requirements.txt`.