### PR TITLE
ENH Bind optional arguments to endpoints by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Optional arguments to API endpoints now display in function signatures.
+  Function signatures show a default value of "DEFAULT"; arguments will still
+  only be transmitted to the Civis Platform API when explicitly provided. (#140)
 
 
 ## 1.6.2 - 2017-09-08

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from jsonref import JsonRef
 import requests
+import six
 
 from civis.base import Endpoint, get_base_url
 from civis.compat import lru_cache
@@ -145,7 +146,7 @@ def iterable_method(method, params):
     return (method.lower() == 'get' and params_present)
 
 
-def create_signature(args, kwargs):
+def create_signature(args, optional_args, kwargs=False):
     """ Dynamically create a signature for a function from strings.
 
     This function can be used to create a signature for a dynamically
@@ -156,8 +157,10 @@ def create_signature(args, kwargs):
     ----------
     args : list
         List of strings that name the required arguments of a function.
-    kwargs : list
+    optional_args : list
         List of strings that name the optional arguments of a function.
+    kwargs : bool, optional
+        If True, the function can also accept arbitrary keyword arguments
 
     Returns
     -------
@@ -166,6 +169,12 @@ def create_signature(args, kwargs):
         a dynamically created function.
     """
     p = [Parameter(x, Parameter.POSITIONAL_OR_KEYWORD) for x in args]
+    if six.PY3:
+        opt_par_type = Parameter.KEYWORD_ONLY
+    else:
+        opt_par_type = Parameter.POSITIONAL_OR_KEYWORD
+    p += [Parameter(x, opt_par_type, default='DEFAULT')
+          for x in optional_args]
     if kwargs:
         p.append(Parameter('kwargs', Parameter.VAR_KEYWORD))
     return Signature(p)
@@ -173,7 +182,7 @@ def create_signature(args, kwargs):
 
 def split_method_params(params):
     args = []
-    kwargs = []
+    optional_args = []
     body_params = []
     query_params = []
     path_params = []
@@ -182,14 +191,14 @@ def split_method_params(params):
         if param["required"]:
             args.append(name)
         else:
-            kwargs.append(name)
+            optional_args.append(name)
         if param["in"] == "body":
             body_params.append(name)
         elif param["in"] == "query":
             query_params.append(name)
         elif param["in"] == "path":
             path_params.append(name)
-    return args, kwargs, body_params, query_params, path_params
+    return args, optional_args, body_params, query_params, path_params
 
 
 def create_method(params, verb, method_name, path, doc):
@@ -222,16 +231,17 @@ def create_method(params, verb, method_name, path, doc):
         A function which will make an API call
     """
     elements = split_method_params(params)
-    sig_args, sig_kwargs, body_params, query_params, path_params = elements
-    sig = create_signature(sig_args, sig_kwargs)
+    sig_args, sig_opt_args, body_params, query_params, path_params = elements
+    sig = create_signature(sig_args, sig_opt_args)
     is_iterable = iterable_method(verb, query_params)
 
     def f(self, *args, **kwargs):
+        raise_for_unexpected_kwargs(method_name, kwargs, sig_args,
+                                    sig_opt_args, is_iterable)
+
         arguments = sig.bind(*args, **kwargs).arguments
         if arguments.get("kwargs"):
             arguments.update(arguments.pop("kwargs"))
-        raise_for_unexpected_kwargs(method_name, arguments, sig_args,
-                                    sig_kwargs, is_iterable)
         body = {x: arguments[x] for x in body_params if x in arguments}
         query = {x: arguments[x] for x in query_params if x in arguments}
         path_vals = {x: arguments[x] for x in path_params if x in arguments}
@@ -240,7 +250,7 @@ def create_method(params, verb, method_name, path, doc):
         return self._call_api(verb, url, query, body, iterator=iterator)
 
     # Add signature to function, including 'self' for class method
-    sig_self = create_signature(["self"] + sig_args, sig_kwargs)
+    sig_self = create_signature(["self"] + sig_args, sig_opt_args)
     f.__signature__ = sig_self
     f.__doc__ = doc
     f.__name__ = str(method_name)

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -146,7 +146,7 @@ def iterable_method(method, params):
     return (method.lower() == 'get' and params_present)
 
 
-def create_signature(args, optional_args, kwargs=False):
+def create_signature(args, optional_args):
     """ Dynamically create a signature for a function from strings.
 
     This function can be used to create a signature for a dynamically
@@ -159,8 +159,6 @@ def create_signature(args, optional_args, kwargs=False):
         List of strings that name the required arguments of a function.
     optional_args : list
         List of strings that name the optional arguments of a function.
-    kwargs : bool, optional
-        If True, the function can also accept arbitrary keyword arguments
 
     Returns
     -------
@@ -175,8 +173,6 @@ def create_signature(args, optional_args, kwargs=False):
         opt_par_type = Parameter.POSITIONAL_OR_KEYWORD
     p += [Parameter(x, opt_par_type, default='DEFAULT')
           for x in optional_args]
-    if kwargs:
-        p.append(Parameter('kwargs', Parameter.VAR_KEYWORD))
     return Signature(p)
 
 

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -239,6 +239,7 @@ def create_method(params, verb, method_name, path, doc):
         raise_for_unexpected_kwargs(method_name, kwargs, sig_args,
                                     sig_opt_args, is_iterable)
 
+        iterator = kwargs.pop('iterator', False)
         arguments = sig.bind(*args, **kwargs).arguments
         if arguments.get("kwargs"):
             arguments.update(arguments.pop("kwargs"))
@@ -246,7 +247,6 @@ def create_method(params, verb, method_name, path, doc):
         query = {x: arguments[x] for x in query_params if x in arguments}
         path_vals = {x: arguments[x] for x in path_params if x in arguments}
         url = path.format(**path_vals) if path_vals else path
-        iterator = arguments.get('iterator', False)
         return self._call_api(verb, url, query, body, iterator=iterator)
 
     # Add signature to function, including 'self' for class method

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -42,6 +42,20 @@ updated_at : string/time
     The last modification time for this credential.""")  # noqa: E122
 
 
+def test_create_method_iterator_kwarg():
+    args = [{"name": 'limit', "in": 'query', "required": False, "doc": ""},
+            {"name": 'page_num', "in": 'query', "required": False, "doc": ""},
+            {"name": 'order', "in": 'query', "required": False, "doc": ""},
+            {"name": 'order_by', "in": 'query', "required": False, "doc": ""}]
+    method = _resources.create_method(args, 'get', 'mock_name', '/objects',
+                                      'fake_doc')
+    mock_endpoint = mock.MagicMock()
+
+    method(mock_endpoint, iterator=True)
+    mock_endpoint._call_api.assert_called_once_with(
+        'get', '/objects', {}, {}, iterator=True)
+
+
 def test_create_method_no_iterator_kwarg():
 
     # Test that dynamically-created function errors when an


### PR DESCRIPTION
Previously, optional arguments were all absorbed in a `**kwargs` blob and pulled out later. This changes to set all of them explicitly in the function signature. Doing this improves the readability of the docstrings, and also allows other code (e.g. `mock`'s autospeccer) to read expected function signatures. Note that the actual function code, in `resources._resources.create_method` remains the same. It takes `*args, **kwargs` inputs. The function's signature gets patched after it's created. Because the code remains the same, we never actually transmit default values to the API.

I've set default values to the string "DEFAULT" in an attempt to indicate to users that the defaults in the function signature are different from the defaults in the API.

I'm running `raise_for_unexpected_kwargs` only on keyword arguments. `sig.bind` will only give one unexpected keyword argument even if many are present, so I've preserved our own error handling for that. `sig.bind` will take care of errors for positional arguments and collisions of positional arguments and keyword arguments.

In Python 2, optional arguments will now be able to be given positionally. The previous, keyword-only behavior, is preserved in Python 3.

I've deleted one test from `test_resources` which fails now; it doesn't seem like it should have ever passed. `iterator` wasn't in the spec, so trying to call it should have made an error.