### PR TITLE
ENH Civis joblib backend now falls back to sequential at n_jobs=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- The Civis ``joblib`` backend will now fall back to a ``SequentialBackend``
+  (running jobs locally rather than on Civis Platform) when ``n_jobs=1``.
 
 
 ## 1.6.2 - 2017-09-08


### PR DESCRIPTION
Built-in `joblib` backends (multiprocessing and threading) replace themselves with a "sequential" backend (no parallel computation) when users set `n_jobs=1`. This change adds the same feature to the Civis `joblib` backend. Fallback behavior will allow for easier debugging / testing / local computation, and may be more intuitive to users familiar with the built-in `joblib` backends.

Todo:
- [ ] Add a test for the fallback behavior
- [ ] Mention fallback behavior in documentation