### PR TITLE
Pandas IO Typing

### DIFF
--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -3,6 +3,7 @@ import csv
 import io
 import six
 import warnings
+import numpy as np
 
 from civis import APIClient
 from civis.io import civis_to_file
@@ -10,8 +11,6 @@ from civis._utils import maybe_get_random_name
 from civis.base import EmptyResultError
 from civis.futures import CivisFuture
 from civis.utils._deprecation import deprecate_param
-import numpy as np
-from pprint import pprint
 
 import requests
 

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -67,8 +67,7 @@ DATE_TYPES = ['date', 'timestamp',
 @deprecate_param('v2.0.0', 'api_key')
 def read_civis(table, database, columns=None, use_pandas=False,
                job_name=None, api_key=None, client=None, credential_id=None,
-               polling_interval=None, archive=False, hidden=True,
-               pandas_kwargs=None, **kwargs):
+               polling_interval=None, archive=False, hidden=True, **kwargs):
     """Read data from a Civis table.
 
     Parameters

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -147,9 +147,7 @@ def read_civis(table, database, columns=None, use_pandas=False,
         # Instantiate client here in case users provide a (deprecated) api_key
         client = APIClient(api_key=api_key, resources='all')
 
-
     table_id = client.get_table_id(table=table, database=database)
-
     sql = _get_sql_select(table, columns)
     data = read_civis_sql(sql=sql, database=database, use_pandas=use_pandas,
                           job_name=job_name, client=client, 
@@ -260,7 +258,6 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
                                .format(script_id))
     url = outputs[0]["path"]
     if use_pandas:
-
         sortkeys, py_types, date_cols = _redshift_to_py(client, table_id)
         # Not sure about the best way to handle null fields
         data = pd.read_csv(url, parse_dates=date_cols,

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -159,14 +159,16 @@ class ImportTests(CivisVCRTestCase):
                   'char': np.str,
                   'character varying': np.str
                   }
-        expected = pd.DataFrame([[1., 2., 3, 4, 5, 6., 7., 8., True, 'f', 'bar', '05/07/1995']], 
-                                 columns=['numeric', 'real', 'smallint', 
+        expected = pd.DataFrame(data=[[1., 2., 3, 4, 5, 6., 7., 8.,
+                                  True, 'f', 'bar', '05/07/1995']], 
+                                columns=['numeric', 'real', 'smallint', 
                                  'integer', 'bigint', 'deicmal', 'real', 
                                  'double', 'boolean', 'char', 
                                  'character varying', 'date'
                                  ],
-                     parse_dates=['date'],
-                     converters=col_types)
+                                parse_dates=['date'],
+                                converters=col_types)
+        
         df = civis.io.read_civis('scratch.api_client_test_fixture',
                                  'redshift-general', use_pandas=True,
                                  polling_interval=POLL_INTERVAL)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -146,7 +146,27 @@ class ImportTests(CivisVCRTestCase):
     @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_read_civis_pandas(self, *mocks):
-        expected = pd.DataFrame([[1, 2, 3]], columns=['a', 'b', 'c'])
+        col_types = {
+                  'numeric' : np.float,
+                  'real': np.float,
+                  'smallint': np.int, 
+                  'integer' : np.int,
+                  'bigint' : np.int,
+                  'deicmal':np.float,
+                  'real':np.float,
+                  'double':np.float,
+                  'boolean' : np.bool,
+                  'char': np.str,
+                  'character varying': np.str
+                  }
+        expected = pd.DataFrame([[1., 2., 3, 4, 5, 6., 7., 8., True, 'f', 'bar', '05/07/1995']], 
+                                 columns=['numeric', 'real', 'smallint', 
+                                 'integer', 'bigint', 'deicmal', 'real', 
+                                 'double', 'boolean', 'char', 
+                                 'character varying', 'date'
+                                 ],
+                     parse_dates=['date'],
+                     converters=col_types)
         df = civis.io.read_civis('scratch.api_client_test_fixture',
                                  'redshift-general', use_pandas=True,
                                  polling_interval=POLL_INTERVAL)


### PR DESCRIPTION
The new code provides a typed Pandas Dataframe based on the Redshift analogue when `use_pandas=True ` with `civis.io.read_civis` based on #143. The last remaining component is to verify the testing tools. This entails updating the sql table on platform with columns with the types we would like to test.