### PR TITLE
[DE-15] Multipart uploads with Civis client

### DIFF
--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -5,11 +5,12 @@ import six
 import warnings
 
 from civis import APIClient
-from civis.io import civis_to_file
+from civis.io import civis_to_file, file_to_civis
 from civis._utils import maybe_get_random_name
 from civis.base import EmptyResultError
 from civis.futures import CivisFuture
 from civis.utils._deprecation import deprecate_param
+from civis.utils._jobs import run_job
 
 import requests
 
@@ -547,10 +548,15 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     txt.flush()
     buf.seek(0)
     delimiter = ','
-    return _import_bytes(buf, database, table, client, max_errors,
-                         existing_table_rows, distkey, sortkey1, sortkey2,
-                         delimiter, headers, credential_id, polling_interval,
-                         archive, hidden=hidden)
+    name = table.split('.')[-1]
+    file_id = file_to_civis(buf, name, api_key=api_key, client=client)
+    fut = civisfile_to_civis(file_id, database, table, api_key=api_key, client=client,
+                             max_errors=max_errors, existing_table_rows=existing_table_rows,
+                             distkey=distkey, sortkey1=sortkey1, sortkey2=sortkey2,
+                             delimiter=delimiter, headers=headers,
+                             credential_id=credential_id, archive=archive, hidden=hidden)
+
+    return fut
 
 
 @deprecate_param('v2.0.0', 'api_key')
@@ -629,11 +635,118 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     if archive:
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)
+
+    name = path.basename(filename)
     with open(filename, "rb") as data:
-        fut = _import_bytes(data, database, table, client, max_errors,
-                            existing_table_rows, distkey, sortkey1, sortkey2,
-                            delimiter, headers, credential_id,
-                            polling_interval, archive, hidden=hidden)
+        file_id = file_to_civis(data, name, api_key=api_key, client=client)
+        fut = civisfile_to_civis(file_id, database, table, api_key=api_key, client=client,
+                                 max_errors=max_errors, existing_table_rows=existing_table_rows,
+                                 distkey=distkey, sortkey1=sortkey1, sortkey2=sortkey2,
+                                 delimiter=delimiter, headers=headers,
+                                 credential_id=credential_id, archive=archive, hidden=hidden)
+    return fut
+
+
+@deprecate_param('v2.0.0', 'api_key')
+def civisfile_to_civis(file_id, database, table, api_key=None, client=None,
+                       max_errors=None, existing_table_rows="fail",
+                       distkey=None, sortkey1=None, sortkey2=None,
+                       delimiter=",", headers=None,
+                       credential_id=None, archive=False, hidden=True):
+    """Upload the contents of a Civis file to a Civis table.
+
+    Parameters
+    ----------
+    file_id : int
+        Civis file ID.
+    database : str or int
+        Upload data into this database. Can be the database name or ID.
+    table : str
+        The schema and table you want to upload to. E.g.,
+        ``'scratch.table'``.
+    api_key : DEPRECATED str, optional
+        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
+        environment variable will be used.
+    client : :class:`civis.APIClient`, optional
+        If not provided, an :class:`civis.APIClient` object will be
+        created from the :envvar:`CIVIS_API_KEY`.
+    max_errors : int, optional
+        The maximum number of rows with errors to remove from the import
+        before failing.
+    existing_table_rows : str, optional
+        The behaviour if a table with the requested name already exists.
+        One of ``'fail'``, ``'truncate'``, ``'append'`` or ``'drop'``.
+        Defaults to ``'fail'``.
+    distkey : str, optional
+        The column to use as the distkey for the table.
+    sortkey1 : str, optional
+        The column to use as the sortkey for the table.
+    sortkey2 : str, optional
+        The second column in a compound sortkey for the table.
+    delimiter : string, optional
+        The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
+    headers : bool, optional
+        Whether or not the first row of the file should be treated as
+        headers. The default, ``None``, attempts to autodetect whether
+        or not the first row contains headers.
+    credential_id : str or int, optional
+        The ID of the database credential.  If ``None``, the default
+        credential will be used.
+    archive : bool, optional (deprecated)
+        If ``True``, archive the import job as soon as it completes.
+    hidden : bool, optional
+        If ``True`` (the default), this job will not appear in the Civis UI.
+
+    Returns
+    -------
+    results : :class:`~civis.futures.CivisFuture`
+        A `CivisFuture` object.
+
+    Examples
+    --------
+    >>> with open('input_file.csv', 'w') as _input:
+    ...     _input.write('a,b,c\\n1,2,3')
+    >>> fut = civis.io.csv_to_civis('input_file.csv',
+    ...                             'my-database',
+    ...                             'scratch.my_data')
+    >>> fut.result()
+    """
+    if client is None:
+        client = APIClient(api_key=api_key, resources='all')
+    if archive:
+        warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
+                      "Use `hidden` instead.", FutureWarning)
+
+    schema, table = table.split(".", 1)
+    db_id = client.get_database_id(database)
+    cred_id = credential_id or client.default_credential
+    delimiter = DELIMITERS.get(delimiter)
+    assert delimiter, "delimiter must be one of {}".format(DELIMITERS.keys())
+
+    destination = dict(remote_host_id=db_id, credential_id=cred_id)
+    import_name = 'CSV import to {}.{}'.format(schema, table)
+    import_job = client.imports.post(import_name, 'AutoImport', is_outbound=False,
+                                     destination=destination, hidden=hidden)
+
+    options = dict(max_errors=max_errors, existing_table_rows=existing_table_rows,
+                   distkey=distkey, sortkey1=sortkey1, sortkey2=sortkey2,
+                   column_delimiter=delimiter, first_row_is_header=headers)
+
+    client.imports.post_syncs(
+        import_job.id,
+        source=dict(file=dict(id=file_id)),
+        destination=dict(database_table=dict(schema=schema, table=table)),
+        advanced_options=options)
+
+    fut = run_job(import_job.id, api_key=api_key, client=client)
+
+    if archive:
+
+        def f(x):
+            return client.imports.put_archive(import_job.id, True)
+
+        fut.add_done_callback(f)
+
     return fut
 
 
@@ -690,40 +803,3 @@ def _download_callback(job_id, run_id, client, filename):
             return _download_file(url, filename)
 
     return callback
-
-
-def _import_bytes(buf, database, table, client, max_errors,
-                  existing_table_rows, distkey, sortkey1, sortkey2, delimiter,
-                  headers, credential_id, polling_interval, archive, hidden):
-    schema, table = table.split(".", 1)
-    db_id = client.get_database_id(database)
-    cred_id = credential_id or client.default_credential
-    delimiter = DELIMITERS.get(delimiter)
-    assert delimiter, "delimiter must be one of {}".format(DELIMITERS.keys())
-
-    kwargs = dict(schema=schema, name=table, remote_host_id=db_id,
-                  credential_id=cred_id, max_errors=max_errors,
-                  existing_table_rows=existing_table_rows, distkey=distkey,
-                  sortkey1=sortkey1, sortkey2=sortkey2,
-                  column_delimiter=delimiter, first_row_is_header=headers,
-                  hidden=hidden)
-
-    import_job = client.imports.post_files(**kwargs)
-    put_response = requests.put(import_job.upload_uri, buf)
-
-    put_response.raise_for_status()
-    run_job_result = client._session.post(import_job.run_uri)
-    run_job_result.raise_for_status()
-    run_info = run_job_result.json()
-    fut = CivisFuture(client.imports.get_files_runs,
-                      (run_info['importId'], run_info['id']),
-                      polling_interval=polling_interval,
-                      client=client,
-                      poll_on_creation=False)
-    if archive:
-
-        def f(x):
-            return client.imports.put_archive(import_job.id, True)
-
-        fut.add_done_callback(f)
-    return fut

--- a/civis/utils/__init__.py
+++ b/civis/utils/__init__.py
@@ -1,3 +1,3 @@
-from ._jobs import run_job
+from ._jobs import run_job, retry
 
-__all__ = ["run_job"]
+__all__ = ["run_job", "retry"]

--- a/civis/utils/_jobs.py
+++ b/civis/utils/_jobs.py
@@ -1,6 +1,11 @@
+import logging
+import time
+
 from civis import APIClient
 from civis.futures import CivisFuture
 from civis.utils._deprecation import deprecate_param
+
+log = logging.getLogger(__name__)
 
 
 @deprecate_param('v2.0.0', 'api_key')
@@ -30,3 +35,48 @@ def run_job(job_id, api_key=None, client=None):
                        (job_id, run['id']),
                        client=client,
                        poll_on_creation=False)
+
+
+def retry(exceptions, retries=5, delay=0.5, backoff=2):
+    """
+    Retry decorator
+
+    Parameters
+    ----------
+    exceptions: Exception
+        exceptions to trigger retry
+    retries: int, optional
+        number of retries to perform
+    delay: float, optional
+        delay before next retry
+    backoff: int, optional
+        factor used to increase delay after each retry
+
+    Returns
+    -------
+    retry decorator
+
+    Raises
+    ------
+    exception raised by decorator function
+    """
+    def deco_retry(f):
+        def f_retry(*args, **kwargs):
+            n_failed = 0
+            new_delay = delay
+            while True:
+                try:
+                    return f(*args, **kwargs)
+                except exceptions as exc:
+                    if n_failed < retries:
+                        n_failed += 1
+                        msg = "%s, Retrying in %d seconds..." % (str(exc), new_delay)
+                        log.debug(msg)
+                        time.sleep(new_delay)
+                        new_delay *= backoff
+                    else:
+                        raise exc
+
+        return f_retry
+
+    return deco_retry


### PR DESCRIPTION
Update file_to_civis to use multipart uploads
Add retry decorator to file_to_civis
Add new function civisfile_to_civis to import an existing file from files endpoint
Update csv_to_civis and dataframe_to_civis to use file_to_civis and civisfile_to_civis instead of _import_bytes