### PR TITLE
[CIVP-12839] Fixing name parsing of multiword endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Optional arguments to API endpoints now display in function signatures.
   Function signatures show a default value of "DEFAULT"; arguments will still
   only be transmitted to the Civis Platform API when explicitly provided. (#140)
+- ``APIClient.feature_flags`` has been deprecated to avoid a name collision
+   with the feature_flags endpoint. In v2.0.0, ``APIClient.featureflags``
+   will be renamed to ``APIClient.feature_flags``.
+- The following APIClient attributes have been deprecated in favor of the
+  attribute that includes underscores:
+  ``APIClient.bocceclusters`` -> ``APIClient.bocce_clusters``
+  ``APIClient.matchtargets`` -> ``APIClient.match_targets``
+  ``APIClient.remotehosts`` -> ``APIClient.remote_hosts``
+
+### Fixed
+- Fixed parsing of multiword endpoints. Parsing no longer removes underscores
+  in endpoint names.
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import logging
+import warnings
 
 from civis.compat import lru_cache
 from civis.resources import generate_classes_maybe_cached
@@ -292,6 +293,12 @@ class APIClient(MetaMixin):
 
     @property
     def feature_flags(self):
+        msg = ("The property APIClient.feature_flags is deprecated "
+               "and will be replaced with a FeatureFlags object to access the "
+               "feature_flags endpoint in v2.0.0.  To access the "
+               "FeatureFlags endpoint in this version please use "
+               "APIClient.featureflags.")
+        warnings.warn(msg)
         if self._feature_flags:
             return self._feature_flags
         me = self.users.list_me()

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -538,11 +538,11 @@ def generate_classes_maybe_cached(cache, api_key, api_version, resources):
             raise ValueError(msg.format(type(cache)))
         spec = JsonRef.replace_refs(raw_spec)
         classes = parse_api_spec(spec, api_version, resources)
-    classes = add_no_underscore_compatibility(classes)
-    return classes
+    classes_ = _add_no_underscore_compatibility(classes)
+    return classes_
 
 
-def add_no_underscore_compatibility(classes):
+def _add_no_underscore_compatibility(classes):
     """ Add class names without underscores for compatibility.
 
     Previously, no resources had underscores in APIClient.  Parsing of
@@ -553,11 +553,12 @@ def add_no_underscore_compatibility(classes):
     be removed in v2.0.0.
     """
     new = ["bocce_clusters", "match_targets", "remote_hosts", "feature_flags"]
+    classes_ = {}
     class_names = list(classes.keys())
     for class_name in class_names:
+        if class_name != "feature_flags":
+            classes_[class_name] = classes[class_name]
         if class_name in new:
             class_name_no_us = "".join(class_name.split("_"))
-            classes[class_name_no_us] = classes[class_name]
-        if class_name == "feature_flags":
-            classes.pop(class_name)
-    return classes
+            classes_[class_name_no_us] = classes[class_name]
+    return classes_

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -396,7 +396,7 @@ def parse_path(path, operations, api_version, resources):
     attached to the class as a method.
     """
     path = path.strip('/')
-    base_path = path.split('/')[0]
+    base_path = path.split('/')[0].lower()
     methods = []
     if exclude_resource(path, api_version, resources):
         return base_path, methods

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -397,16 +397,15 @@ def parse_path(path, operations, api_version, resources):
     """
     path = path.strip('/')
     base_path = path.split('/')[0]
-    class_name = to_camelcase(base_path)
     methods = []
     if exclude_resource(path, api_version, resources):
-        return class_name, methods
+        return base_path, methods
     for verb, op in operations.items():
         method = parse_method(verb, op, path)
         if method is None:
             continue
         methods.append(method)
-    return class_name, methods
+    return base_path, methods
 
 
 def parse_api_spec(api_spec, api_version, resources):
@@ -433,12 +432,12 @@ def parse_api_spec(api_spec, api_version, resources):
     paths = api_spec['paths']
     classes = {}
     for path, ops in paths.items():
-        class_name, methods = parse_path(path, ops, api_version, resources)
-        class_name_lower = class_name.lower()
-        if methods and classes.get(class_name_lower) is None:
-            classes[class_name_lower] = type(str(class_name), (Endpoint,), {})
+        base_path, methods = parse_path(path, ops, api_version, resources)
+        class_name = to_camelcase(base_path)
+        if methods and classes.get(base_path) is None:
+            classes[base_path] = type(str(class_name), (Endpoint,), {})
         for method_name, method in methods:
-            setattr(classes[class_name_lower], method_name, method)
+            setattr(classes[base_path], method_name, method)
     return classes
 
 
@@ -539,4 +538,27 @@ def generate_classes_maybe_cached(cache, api_key, api_version, resources):
             raise ValueError(msg.format(type(cache)))
         spec = JsonRef.replace_refs(raw_spec)
         classes = parse_api_spec(spec, api_version, resources)
+    classes = add_no_underscore_compatibility(classes)
     return classes
+
+
+def add_no_underscore_compatibility(classes):
+    """ Add class names without underscores for compatibility.
+
+    Previously, no resources had underscores in APIClient.  Parsing of
+    resources has been fixed so now these resources will have underscores.
+    This adds an extra class for those resources without an underscore
+    for compatibility. Additionally, this removes the resource "feature_flags"
+    as APIClient has a name collision with this resource. This will
+    be removed in v2.0.0.
+    """
+    new = ["bocce_clusters", "match_targets", "remote_hosts", "feature_flags"]
+    class_names = list(classes.keys())
+    for class_name in class_names:
+        if class_name in new:
+            class_name_no_us = "".join(class_name.split("_"))
+            classes[class_name_no_us] = classes[class_name]
+        if class_name == "feature_flags":
+            classes.pop(class_name)
+    return classes
+

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -561,4 +561,3 @@ def add_no_underscore_compatibility(classes):
         if class_name == "feature_flags":
             classes.pop(class_name)
     return classes
-

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -323,3 +323,25 @@ def test_generate_classes_maybe_cached(mock_parse, mock_gen, mock_open):
     with pytest.raises(ValueError):
         _resources.generate_classes_maybe_cached(bad_spec, api_key,
                                                  api_version, resources)
+
+
+@mock.patch('civis.resources._resources.parse_method', autospec=True)
+def test_parse_api_spec_names(mock_method):
+    """ Test that path parsing preserves underscore in resource name."""
+    mock_method.return_value = ("method_a", lambda x: x)
+    mock_ops = {"get": None, "post": None}
+    mock_paths = {"/two_words/": mock_ops, "/oneword/": mock_ops}
+    mock_api_spec = {"paths": mock_paths}
+    classes = _resources.parse_api_spec(mock_api_spec, "1.0", "all")
+    assert sorted(classes.keys()) == ["oneword", "two_words"]
+    assert classes["oneword"].__name__ == "Oneword"
+    assert classes["two_words"].__name__ == "TwoWords"
+
+
+def test_add_no_underscore_compatibility():
+    classes = dict(bocce_clusters=1,
+                   feature_flags=2)
+    new_classes = _resources.add_no_underscore_compatibility(classes)
+    assert new_classes["bocceclusters"] == 1
+    assert new_classes["bocce_clusters"] == 1
+    assert new_classes.get("feature_flags") is None

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -341,7 +341,7 @@ def test_parse_api_spec_names(mock_method):
 def test_add_no_underscore_compatibility():
     classes = dict(bocce_clusters=1,
                    feature_flags=2)
-    new_classes = _resources.add_no_underscore_compatibility(classes)
+    new_classes = _resources._add_no_underscore_compatibility(classes)
     assert new_classes["bocceclusters"] == 1
     assert new_classes["bocce_clusters"] == 1
     assert new_classes.get("feature_flags") is None


### PR DESCRIPTION
Certain endpoints with multi-word names like "match_targets" were being parsed as a single word.  This changes calls like

```python
client = civis.APIClient()
client.matchtargets.list()
```

To

```python
client = civis.APIClient()
client.match_targets.list()
```

Todo:
- [x] fix parsing
- [x] update tests
- [x] update change log with changed endpoint names