### PR TITLE
[CIVP-12882] Update Pubnub reconnection policy

### DIFF
--- a/civis/futures.py
+++ b/civis/futures.py
@@ -151,7 +151,7 @@ class CivisFuture(PollableResult):
         pnconfig.cipher_key = channel_config['cipher_key']
         pnconfig.auth_key = channel_config['auth_key']
         pnconfig.ssl = True
-        pnconfig.reconnect_policy = PNReconnectionPolicy.LINEAR
+        pnconfig.reconnect_policy = PNReconnectionPolicy.EXPONENTIAL
         return pnconfig, channels
 
     def _check_message(self, message):


### PR DESCRIPTION
The default policy doesn't wait long enough between retries to successfully authenticate immediately after a Pubnub grant is refreshed.  Pubnub caches 403s so the client needs to wait at least 30 seconds before connecting again.  The exponential policy will wait long enough to resolve this particular issue.