### PR TITLE
MAINT Don't call file_to_civis with deprecated api_key

### DIFF
--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -553,7 +553,7 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     buf.seek(0)
     delimiter = ','
     name = table.split('.')[-1]
-    file_id = file_to_civis(buf, name, api_key=api_key, client=client)
+    file_id = file_to_civis(buf, name, client=client)
     fut = civis_file_to_table(file_id, database, table,
                               client=client, max_errors=max_errors,
                               existing_table_rows=existing_table_rows,
@@ -646,7 +646,7 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
 
     name = path.basename(filename)
     with open(filename, "rb") as data:
-        file_id = file_to_civis(data, name, api_key=api_key, client=client)
+        file_id = file_to_civis(data, name, client=client)
         log.info('Uploaded file %s to Civis file %s', filename, file_id)
         fut = civis_file_to_table(file_id, database, table,
                                   client=client, max_errors=max_errors,


### PR DESCRIPTION
The `civis.io._table.dataframe_to_civis` and `civis.io._table.csv_to_civis` functions were calling `file_to_civis` with both the `api_key` and `client` arguments. Those are redundant, and the `api_key` parameter is deprecated. Remove uses of `api_key` to avoid giving users a deprecation warning they can't control.