### PR TITLE
MAINT Tell flake8 to ignore broad except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed parsing of multiword endpoints. Parsing no longer removes underscores
   in endpoint names.
+- Tell ``flake8`` to ignore a broad except in a ``CivisFuture`` callback.
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -163,7 +163,7 @@ class PollableResult(CivisAsyncResultBase):
             if result.state in FAILED:
                 try:
                     err_msg = str(result['error'])
-                except:
+                except:  # NOQA
                     err_msg = str(result)
                 self._set_api_exception(exc=CivisJobFailure(err_msg, result),
                                         result=result)


### PR DESCRIPTION
This use of `except` is recording an exception and handling it in a way in which the user can deal with it, rather than hiding an exception inside a callback. `flake8` started complaining about it with the new v3.5 release.