### PR TITLE
BUG Don't error when cancelling completed ContainerFutures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed parsing of multiword endpoints. Parsing no longer removes underscores
   in endpoint names.
+- In ``civis.futures.ContainerFuture``, return ``False`` when users attempt to cancel
+  an already-completed job. Previously, the object would sometimes give a ``CivisAPIError``
+  with a 404 status code. This fix affects the executors and joblib backend, which
+  use the ``ContainerFuture``.
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -13,7 +13,7 @@ import threading
 import six
 
 from civis import APIClient
-from civis.base import DONE
+from civis.base import CivisAPIError, DONE
 from civis.polling import PollableResult, _ResultPollingThread
 
 from pubnub.pubnub import PubNub
@@ -279,7 +279,15 @@ class ContainerFuture(CivisFuture):
             elif not self.done():
                 # Cancel the job and store the result of the cancellation in
                 # the "finished result" attribute, `_result`.
-                self._result = self.client.scripts.post_cancel(self.job_id)
+                try:
+                    self._result = self.client.scripts.post_cancel(self.job_id)
+                except CivisAPIError as exc:
+                    if exc.status_code == 404:
+                        # The most likely way to get this error
+                        # is for the job to already be completed.
+                        return False
+                    else:
+                        raise
                 for waiter in self._waiters:
                     waiter.add_cancelled(self)
                 self._condition.notify_all()

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -384,6 +384,28 @@ def _setup_client_mock(job_id=-10, run_id=100, n_failures=8,
     return c
 
 
+def test_cancel_finished_job():
+    # If we try to cancel a completed job, we get a 404 error.
+    # That shouldn't be sent to the user.
+
+    # Set up a mock client which will give an exception when
+    # you try to cancel any job.
+    c = _setup_client_mock()
+    err_resp = response.Response({
+        'status_code': 404,
+        'error': 'not_found',
+        'errorDescription': 'The requested resource could not be found.',
+        'content': True})
+    err_resp.json = lambda: err_resp.json_data
+    c.scripts.post_cancel.side_effect = CivisAPIError(err_resp)
+    c.scripts.post_containers_runs.return_value.state = 'running'
+
+    fut = ContainerFuture(-10, 100, polling_interval=1, client=c,
+                          poll_on_creation=False)
+    assert not fut.done()
+    assert fut.cancel() is False
+
+
 def test_future_no_retry_error():
     # Verify that with no retries, exceptions on job polling
     #  are raised to the user


### PR DESCRIPTION
If you call `scripts.post_cancel` on a completed script, you get a `CivisAPIError` with a 404 status code. We'd gated this call behind an `if not self.done()`, but it's possible for jobs to complete before the done status updates. This is most prominent when using polling to update job status. This patch causes all 404 errors on `post_cancel` to return `False` for the cancelled status (since they obviously weren't cancelled).