### PR TITLE
 BUG SQL jobs should poll on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   with a 404 status code. This fix affects the executors and joblib backend, which
   use the ``ContainerFuture``.
 - Tell ``flake8`` to ignore a broad except in a ``CivisFuture`` callback.
+- Don't skip the first status poll of SQL scripts. Avoids a bug where completed scripts
+  could take 9.5 minutes to register an immediate failure.
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -241,8 +241,7 @@ def read_civis_sql(sql, database, use_pandas=False, job_name=None,
                                     csv_settings=csv_settings,
                                     hidden=hidden)
     fut = CivisFuture(client.scripts.get_sql_runs, (script_id, run_id),
-                      polling_interval=polling_interval, client=client,
-                      poll_on_creation=False)
+                      polling_interval=polling_interval, client=client)
     if archive:
 
         def f(x):
@@ -397,8 +396,7 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
                                     credential_id, hidden=hidden,
                                     csv_settings=csv_settings)
     fut = CivisFuture(client.scripts.get_sql_runs, (script_id, run_id),
-                      polling_interval=polling_interval, client=client,
-                      poll_on_creation=False)
+                      polling_interval=polling_interval, client=client)
     download = _download_callback(script_id, run_id, client, filename,
                                   headers, compression)
     fut.add_done_callback(download)
@@ -530,8 +528,7 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                                     csv_settings=csv_settings)
 
     fut = CivisFuture(client.scripts.get_sql_runs, (script_id, run_id),
-                      polling_interval=polling_interval, client=client,
-                      poll_on_creation=False)
+                      polling_interval=polling_interval, client=client)
 
     outputs = fut.result()["output"]
     if not outputs:


### PR DESCRIPTION
We've set the `CivisFuture`'s `poll_on_creation` parameter to `False` when we know that we just started the jobs. This saves a Platform API call, which can matter when starting hundreds of jobs at once. However, it's possible for SQL to fail fast enough that the job has already completed by the time we can subscribe to the notification endpoint. If that happens, we miss the completion notice and need to wait for the fallback poll in another 9.5 minutes. Switch `CivisFuture` objects connected to SQL scripts to not skip the first poll. Continue to use `poll_on_creation=False` for imports and container scripts. Those should take longer to complete.