### PR TITLE
 BUG Start pubnub subscriptions in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   underscores.
 - Use ``civis.compat.TemporaryDirectory`` in ``civis.io.file_to_civis`` to be
   compatible with Python 2.7
+- Catch notifications sent up to 30 seconds before the ``CivisFuture`` connects.
+  Fixes a bug where we would sometimes miss an immediate error on SQL scripts (#174).
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -147,7 +147,12 @@ class CivisFuture(PollableResult):
                                        self._reset_polling_thread)
         pubnub = PubNub(pnconfig)
         pubnub.add_listener(listener)
-        pubnub.subscribe().channels(channels).execute()
+
+        # Start our subscription 30 seconds in the past to catch any
+        # missed messages.
+        # https://www.pubnub.com/docs/python/api-reference-misc#time
+        token = int((time.time() - 30) * 10**7)
+        pubnub.subscribe().channels(channels).with_timetoken(token).execute()
         return pubnub
 
     def _pubnub_config(self):


### PR DESCRIPTION
If a SQL query fails, it can fail fast, sometimes faster than we can connect to our notifications channel. When we connect, request messages for the previous 30 seconds so that we can see if our job failed before we were able to finish setting up the connection to the notifications channel.

Two more small things fixed while I investigated this:
- Avoid unneeded API call in download_callback: The `CivisFuture` will already have results of the GET /scripts/sql call, so we don't need to make it again.
- Include polling_interval when getting headers: The `_include_headers` function should take a `polling_interval` parameter so that users can get the same polling behavior in the header `CivisFuture` as the primary query's `CivisFuture`.