### PR TITLE
FIX: Parse all the hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   with a 404 status code. This fix affects the executors and joblib backend, which
   use the ``ContainerFuture``.
 - Tell ``flake8`` to ignore a broad except in a ``CivisFuture`` callback.
+- Fixed parsing of endpoints containing hyphens.  Hyphens are replaced with
+  underscores.
 
 ### Added
 - ``civis.resources.cache_api_spec`` function to make it easier to record the

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -396,16 +396,16 @@ def parse_path(path, operations, api_version, resources):
     attached to the class as a method.
     """
     path = path.strip('/')
-    base_path = path.split('/')[0].lower()
+    modified_base_path = re.sub("-", "_", path.split('/')[0].lower())
     methods = []
     if exclude_resource(path, api_version, resources):
-        return base_path, methods
+        return modified_base_path, methods
     for verb, op in operations.items():
         method = parse_method(verb, op, path)
         if method is None:
             continue
         methods.append(method)
-    return base_path, methods
+    return modified_base_path, methods
 
 
 def parse_api_spec(api_spec, api_version, resources):

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -330,12 +330,15 @@ def test_parse_api_spec_names(mock_method):
     """ Test that path parsing preserves underscore in resource name."""
     mock_method.return_value = ("method_a", lambda x: x)
     mock_ops = {"get": None, "post": None}
-    mock_paths = {"/two_words/": mock_ops, "/oneword/": mock_ops}
+    mock_paths = {"/two_words/": mock_ops,
+                  "/oneword/": mock_ops,
+                  "/hyphen-words": mock_ops}
     mock_api_spec = {"paths": mock_paths}
     classes = _resources.parse_api_spec(mock_api_spec, "1.0", "all")
-    assert sorted(classes.keys()) == ["oneword", "two_words"]
+    assert sorted(classes.keys()) == ["hyphen_words", "oneword", "two_words"]
     assert classes["oneword"].__name__ == "Oneword"
     assert classes["two_words"].__name__ == "TwoWords"
+    assert classes["hyphen_words"].__name__ == "HyphenWords"
 
 
 def test_add_no_underscore_compatibility():


### PR DESCRIPTION
Resolves #177.  This replaces hyphens with underscores in endpoint paths.