### PR TITLE
make it easier to upload local files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   of threads and ``pubnub`` subscription.
 - Updated API specification and base resources to include all general
   availability endpoints.
+- Changed ``civis.io.file_to_civis`` and ``civis.io.civis_to_file`` to allow
+  strings for paths to local files in addition to just file/buffer objects.
 
 ### Fixed
 - Fixed parsing of multiword endpoints. Parsing no longer removes underscores

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -192,8 +192,9 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
 
     Parameters
     ----------
-    buf : file-like object
-        The file or other buffer that you wish to upload.
+    buf : file-like object or str
+        The file or other buffer that you wish to upload. Strings will be
+        treated as paths to local files to open.
     name : str
         The name you wish to give the file.
     api_key : DEPRECATED str, optional
@@ -213,6 +214,8 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
 
     Examples
     --------
+    >>> # Upload file at a given path on the local filesystem.
+    >>> file_id = file_to_civis("my_data.csv", 'my_data')
     >>> # Upload file which expires in 30 days
     >>> with open("my_data.csv", "r") as f:
     ...     file_id = file_to_civis(f, 'my_data')
@@ -235,6 +238,16 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     Small or non-seekable file-like objects will be uploaded with a
     single post.
     """
+    if isinstance(buf, str):
+        with open(buf, 'rb') as f:
+            return _file_to_civis(
+                f, name, api_key=api_key, client=client, **kwargs)
+    else:
+        return _file_to_civis(
+            buf, name, api_key=api_key, client=client, **kwargs)
+
+
+def _file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     if client is None:
         client = APIClient(api_key=api_key)
 
@@ -273,9 +286,9 @@ def civis_to_file(file_id, buf, api_key=None, client=None):
     ----------
     file_id : int
         The Civis file ID.
-    buf : file-like object
-        The file or other buffer to write the contents of the Civis file
-        into.
+    buf : file-like object or str
+        A buffer or path specifying where to write the contents of the Civis
+        file. Strings will be treated as paths to local files to open.
     api_key : DEPRECATED str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.
@@ -290,9 +303,26 @@ def civis_to_file(file_id, buf, api_key=None, client=None):
     Examples
     --------
     >>> file_id = 100
+    >>> # Download a file to a path on the local filesystem.
+    >>> civis_to_file(file_id, "my_file.txt")
+    >>> # Download a file to a file object.
     >>> with open("my_file.txt", "wb") as f:
     ...    civis_to_file(file_id, f)
+    >>> # Download a file as a bytes object.
+    >>> import io
+    >>> buf = io.BytesIO()
+    >>> civis_to_file(file_id, buf)
+    >>> # Note that s could be converted to a string with s.decode('utf-8').
+    >>> s = buf.read()
     """
+    if isinstance(buf, str):
+        with open(buf, 'wb') as f:
+            _civis_to_file(file_id, f, api_key=api_key, client=client)
+    else:
+        _civis_to_file(file_id, buf, api_key=api_key, client=client)
+
+
+def _civis_to_file(file_id, buf, api_key=None, client=None):
     if client is None:
         client = APIClient(api_key=api_key)
     files_response = client.files.get(file_id)

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -238,7 +238,7 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     Small or non-seekable file-like objects will be uploaded with a
     single post.
     """
-    if isinstance(buf, str):
+    if isinstance(buf, six.string_types):
         with open(buf, 'rb') as f:
             return _file_to_civis(
                 f, name, api_key=api_key, client=client, **kwargs)
@@ -315,7 +315,7 @@ def civis_to_file(file_id, buf, api_key=None, client=None):
     >>> # Note that s could be converted to a string with s.decode('utf-8').
     >>> s = buf.read()
     """
-    if isinstance(buf, str):
+    if isinstance(buf, six.string_types):
         with open(buf, 'wb') as f:
             _civis_to_file(file_id, f, api_key=api_key, client=client)
     else:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -360,3 +360,24 @@ def test_load_json(mock_c2f):
     mock_c2f.side_effect = _dump_json
     out = civis.io.file_to_json(13, client=mock.Mock())
     assert out == obj
+
+
+@mock.patch('civis.io._files._civis_to_file')
+@mock.patch('%s.open' % __name__, create=True)
+def test_civis_to_file_local(mock_open, mock_civis_to_file_helper):
+    # Test that passing a path to civis_to_file opens a file.
+    civis.io.civis_to_file(123, "foo")
+    mock_open.return_value = mock_file = mock.Mock()
+    assert mock_open.called_once_with("foo", "wb")
+    assert mock_civis_to_file_helper.called_once_with(123, mock_file)
+
+
+@mock.patch('civis.io._files._file_to_civis')
+@mock.patch('%s.open' % __name__, create=True)
+def test_file_to_civis(mock_open, mock_file_to_civis_helper):
+    # Test that passing a path to file_to_civis opens a file.
+    civis.io.file_to_civis("foo", "foo_name")
+    mock_open.return_value = mock_file = mock.Mock()
+    assert mock_open.called_once_with("foo", "rb")
+    assert mock_file_to_civis_helper.called_once_with(
+        "foo", "foo_name", mock_file)


### PR DESCRIPTION
This facilitates uploads from or downloads to local files by allowing users to specify paths rather than file/buffer objects.  This particular type of polymorphism seems pretty well-accepted (cf. [pandas.read_csv](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html)).