### PR TITLE
BUG Relax requirement on cloudpickle version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
+
+### Fixed
+- Relaxed requirement on ``cloudpickle`` version number (#187)
+
 
 ## 1.7.1 - 2017-11-16
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def main():
             'six>=1.10,<=1.99',
             'joblib>=0.11,<=0.11.99',
             'pubnub>=4.0,<=4.99',
-            'cloudpickle>=0.2.0,<=0.3.99',
+            'cloudpickle>=0.2.0,<=0.99999',
         ],
         extras_require={
             ':python_version=="2.7"': [


### PR DESCRIPTION
The requirements file states that this library needs cloudpickle~=0.2, but the setup.py file states `cloudpickle>=0.2.0,<=0.3.99`. We don't need to have such a low upper limit in the setup.py file. Relax it to match the requirements.txt file.