### PR TITLE
BUG Use requirements.txt in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
+
+### Fixed
+- Use ``requirements.txt`` file in ``setup.py`` instead of repeating requirements (#187).
+
 
 ## 1.7.1 - 2017-11-16
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=2.5.1,==2.*
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib~=0.11
-pubnub~=4
+pubnub~=4.0
 cloudpickle~=0.2

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,11 @@ def get_version():
     return ".".join([MAJOR, MINOR, MICRO])
 
 
+def read(fname):
+    with open(os.path.join(os.path.dirname(__file__), fname)) as _in:
+        return _in.read()
+
+
 def main():
     with open('README.rst') as README_FILE:
         README = README_FILE.read()
@@ -48,25 +53,7 @@ def main():
         data_files=[(os.path.join('civis', 'tests'),
                      glob(os.path.join('civis', 'tests', '*.json')))],
         long_description=README,
-        install_requires=[
-            'pyyaml>=3.0,<=3.99',
-            'click>=6.0,<=6.99',
-            'jsonref>=0.1.0,<=0.1.99',
-            'requests>=2.12.0,==2.*',
-            'jsonschema>=2.5.1,==2.*',
-            'six>=1.10,<=1.99',
-            'joblib>=0.11,<=0.11.99',
-            'pubnub>=4.0,<=4.99',
-            'cloudpickle>=0.2.0,<=0.3.99',
-        ],
-        extras_require={
-            ':python_version=="2.7"': [
-                'funcsigs==1.0.2',
-                'future>=0.16,<=0.99',
-                'futures==3.1.1',
-                'functools32>=3.2,<=3.99'
-            ],
-        },
+        install_requires=read('requirements.txt').strip().split('\n'),
         entry_points={
             'console_scripts': [
                 'civis = civis.cli.__main__:main',


### PR DESCRIPTION
Instead of repeating requirements in the `setup.py` file, read from `requirements.txt`. This fixes the error that we were being too restrictive on the `cloudpickle` version, and makes sure we don't diverge in requirements again.