### PR TITLE
[CIVP-13616] doubled disk usage in multipart upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
 
-### Changed
-- ``civis.io.dataframe_to_civis`` writes dataframes to disk instead of using an in memory buffer
-
 ### Fixed
 - Relaxed requirement on ``cloudpickle`` version number (#187)
+
+### Performance Enhancements
 - ``civis.io.file_to_civis`` now uses additional file handles for multipart upload instead of writing to disk to reduce disk usage
+- ``civis.io.dataframe_to_civis`` writes dataframes to disk instead of using an in memory buffer
 
 
 ## 1.7.1 - 2017-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
 
+### Changed
+- ``civis.io.dataframe_to_civis`` writes dataframes to disk instead of using an in memory buffer
+
 ### Fixed
 - Relaxed requirement on ``cloudpickle`` version number (#187)
+- ``civis.io.file_to_civis`` now uses additional file handles for multipart upload instead of writing to disk to reduce disk usage
 
 
 ## 1.7.1 - 2017-11-16

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -129,3 +129,19 @@ def retry(exceptions, retries=5, delay=0.5, backoff=2):
         return f_retry
 
     return deco_retry
+
+
+class BufferedPartialReader(object):
+    def __init__(self, buf, max_bytes):
+        self.max_bytes = max_bytes
+        self.bytes_read = 0
+        self.buf = buf
+        self.len = max_bytes
+
+    def read(self, size=-1):
+        if self.bytes_read >= self.max_bytes:
+            return b''
+        bytes_left = self.max_bytes - self.bytes_read
+        data = self.buf.read(min(size, bytes_left))
+        self.bytes_read += len(data)
+        return data

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -133,15 +133,19 @@ def retry(exceptions, retries=5, delay=0.5, backoff=2):
 
 class BufferedPartialReader(object):
     def __init__(self, buf, max_bytes):
+        self.buf = buf
         self.max_bytes = max_bytes
         self.bytes_read = 0
-        self.buf = buf
         self.len = max_bytes
 
     def read(self, size=-1):
         if self.bytes_read >= self.max_bytes:
             return b''
         bytes_left = self.max_bytes - self.bytes_read
-        data = self.buf.read(min(size, bytes_left))
+        if size < 0:
+            bytes_to_read = bytes_left
+        else:
+            bytes_to_read = min(size, bytes_left)
+        data = self.buf.read(bytes_to_read)
         self.bytes_read += len(data)
         return data

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     HAS_PANDAS = False
 
-MIN_MULTIPART_SIZE = 10 * 2 ** 20  # 50MB # >>>
+MIN_MULTIPART_SIZE = 50 * 2 ** 20  # 50MB
 MIN_PART_SIZE = 5 * 2 ** 20  # 5MB
 MAX_PART_SIZE = 5 * 2 ** 30  # 5GB
 MAX_FILE_SIZE = 5 * 2 ** 40  # 5TB

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -229,7 +229,7 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     # if buf is not a file handle or if current position is not 0
     # then write to a file
     if not isinstance(buf, io.BufferedReader) or buf.tell() != 0:
-       with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             tmp_path = os.path.join(tmp_dir, 'file_to_civis.csv')
             try:
                 with open(tmp_path, 'wb') as fin:

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -84,21 +84,16 @@ def _buf_len(buf):
     return None
 
 
-def _is_bytes(buf):
-    if hasattr(buf, 'mode'):
-        if 'b' in buf.mode:
-            return True
-        return False
-
+def _is_str(buf):
     if buf.seekable():
         try:
             pos = buf.tell()
             data = buf.read(5)
             buf.seek(pos)
             data.decode('utf-8')
-            return True
-        except AttributeError:
             return False
+        except AttributeError:
+            return True
 
     return None
 
@@ -248,15 +243,11 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     # if buf is not a file handle or if current position is not 0
     # then write to a file
     if not isinstance(buf, io.BufferedReader) or buf.tell() != 0:
-        # determine mode to rewrite file else don't rewrite
-        is_bytes = _is_bytes(buf)
-        if is_bytes is None:
-            return _file_to_civis(
-                buf, name, api_key=api_key, client=client, **kwargs)
-        elif is_bytes:
-            mode = 'wb'
-        else:
+        # determine mode to rewrite file; default is bytes
+        if _is_str(buf):
             mode = 'w'
+        else:
+            mode = 'wb'
 
         with TemporaryDirectory() as tmp_dir:
             tmp_path = os.path.join(tmp_dir, 'file_to_civis.csv')

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -625,11 +625,9 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
 
     with TemporaryDirectory() as tmp_dir:
         tmp_path = os.path.join(tmp_dir, 'dataframe_to_civis.csv')
-        with open(tmp_path, 'w') as fin:
-            df.to_csv(fin, encoding='utf-8', index=False, **kwargs)
-        with open(tmp_path, 'rb') as fout:
-            name = table.split('.')[-1]
-            file_id = file_to_civis(fout, name, client=client)
+        df.to_csv(tmp_path, encoding='utf-8', index=False, **kwargs)
+        name = table.split('.')[-1]
+        file_id = file_to_civis(tmp_path, name, client=client)
 
     delimiter = ','
     fut = civis_file_to_table(file_id, database, table,

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -3,9 +3,9 @@ import csv
 from os import path
 import io
 import logging
+import os
 import re
 import shutil
-import tempfile
 import warnings
 import zlib
 
@@ -623,11 +623,13 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)
 
-    with tempfile.NamedTemporaryFile() as buf:
-        df.to_csv(buf, encoding='utf-8', index=False, **kwargs)
-        buf.seek(0)
-        name = table.split('.')[-1]
-        file_id = file_to_civis(buf, name, client=client)
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = os.path.join(tmp_dir, 'dataframe_to_civis.csv')
+        with open(tmp_path, 'w') as fin:
+            df.to_csv(fin, encoding='utf-8', index=False, **kwargs)
+        with open(tmp_path, 'rb') as fout:
+            name = table.split('.')[-1]
+            file_id = file_to_civis(fout, name, client=client)
 
     delimiter = ','
     fut = civis_file_to_table(file_id, database, table,


### PR DESCRIPTION
- `dataframe_to_civis` now writes the dataframe to disk instead of an in memory buffer
- `file_to_civis` will re-write buffers that are not instances of io.BufferedReader to disk
- `_multipart_upload` will no longer re-write file parts to disk; instead it will open new file handles