### PR TITLE
ENH CLI commands to open notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
+- New notebook-related CLI commands: "launch", "up", "down", and "open".
 
 ### Fixed
 - Relaxed requirement on ``cloudpickle`` version number (#187)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
-- New notebook-related CLI commands: "launch", "up", "down", and "open".
+- New notebook-related CLI commands: "new", "up", "down", and "open".
 
 ### Fixed
 - Relaxed requirement on ``cloudpickle`` version number (#187)

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -25,7 +25,8 @@ from jsonref import JsonRef
 import yaml
 from civis.cli._cli_commands import (
     civis_ascii_art, files_download_cmd, files_upload_cmd,
-    notebooks_download_cmd)
+    notebooks_download_cmd, notebooks_launch_cmd,
+    notebooks_up, notebooks_down, notebooks_open)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis._utils import open_session
 from civis.compat import FileNotFoundError
@@ -222,6 +223,10 @@ def add_extra_commands(cli):
     files_cmd.add_command(files_upload_cmd)
     notebooks_cmd = cli.commands['notebooks']
     notebooks_cmd.add_command(notebooks_download_cmd)
+    notebooks_cmd.add_command(notebooks_launch_cmd)
+    notebooks_cmd.add_command(notebooks_up)
+    notebooks_cmd.add_command(notebooks_down)
+    notebooks_cmd.add_command(notebooks_open)
     cli.add_command(civis_ascii_art)
 
 

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -25,7 +25,7 @@ from jsonref import JsonRef
 import yaml
 from civis.cli._cli_commands import (
     civis_ascii_art, files_download_cmd, files_upload_cmd,
-    notebooks_download_cmd, notebooks_launch_cmd,
+    notebooks_download_cmd, notebooks_new_cmd,
     notebooks_up, notebooks_down, notebooks_open)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis._utils import open_session
@@ -223,7 +223,7 @@ def add_extra_commands(cli):
     files_cmd.add_command(files_upload_cmd)
     notebooks_cmd = cli.commands['notebooks']
     notebooks_cmd.add_command(notebooks_download_cmd)
-    notebooks_cmd.add_command(notebooks_launch_cmd)
+    notebooks_cmd.add_command(notebooks_new_cmd)
     notebooks_cmd.add_command(notebooks_up)
     notebooks_cmd.add_command(notebooks_down)
     notebooks_cmd.add_command(notebooks_open)

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -86,7 +86,7 @@ def notebooks_download_cmd(notebook_id, path):
             f.write(lines)
 
 
-@click.command('launch')
+@click.command('new')
 @click.argument('language', type=click.Choice(['python3', 'python2', 'r']),
                 default='python3')
 @click.option('--mem', type=int, default=None,

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -92,7 +92,7 @@ def notebooks_download_cmd(notebook_id, path):
 @click.option('--mem', type=int, default=None,
               help='Memory allocated for this notebook in MiB.')
 @click.option('--cpu', type=int, default=None,
-              help='CPU available for this notebook in 1/1000 of a core.')
+              help='CPU available for this notebook in 1/1024 of a core.')
 def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
     """Create a new notebook and open it in the browser."""
     client = civis.APIClient()
@@ -109,7 +109,7 @@ def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
 @click.option('--mem', type=int, default=None,
               help='Memory allocated for this notebook in MiB.')
 @click.option('--cpu', type=int, default=None,
-              help='CPU available for this notebook in 1/1000 of a core.')
+              help='CPU available for this notebook in 1/1024 of a core.')
 def notebooks_up(notebook_id, mem=None, cpu=None):
     """Start an existing notebook and open it in the browser."""
     client = civis.APIClient()

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -93,7 +93,7 @@ def notebooks_download_cmd(notebook_id, path):
               help='Memory allocated for this notebook in MiB.')
 @click.option('--cpu', type=int, default=None,
               help='CPU available for this notebook in 1/1000 of a core.')
-def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
+def notebooks_new_cmd(language='python3', mem=None, cpu=None):
     """Create a new notebook and open it in the browser."""
     client = civis.APIClient()
     kwargs = {'memory': mem, 'cpu': cpu}

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -8,6 +8,7 @@ import os
 
 import click
 import requests
+import webbrowser
 
 import civis
 from civis.io import file_to_civis, civis_to_file
@@ -83,6 +84,71 @@ def notebooks_download_cmd(notebook_id, path):
     with open(path, 'wb') as f:
         for lines in chunked:
             f.write(lines)
+
+
+@click.command('launch')
+@click.argument('language', type=click.Choice(['python3', 'python2', 'r']),
+                default='python3')
+@click.option('--mem', type=int, default=None,
+              help='Memory allocated for this notebook in MiB.')
+@click.option('--cpu', type=int, default=None,
+              help='CPU available for this notebook in 1/1000 of a core.')
+def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
+    """Create a new notebook and open it in the browser."""
+    client = civis.APIClient()
+    kwargs = {'memory': mem, 'cpu': cpu}
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    new_nb = client.notebooks.post(language=language, **kwargs)
+    print("Created new {} notebook with ID {} .".format(language, new_nb.id))
+    _notebooks_up(new_nb.id)
+    _notebooks_open(new_nb.id)
+
+
+@click.command('up')
+@click.argument('notebook_id', type=int)
+@click.option('--mem', type=int, default=None,
+              help='Memory allocated for this notebook in MiB.')
+@click.option('--cpu', type=int, default=None,
+              help='CPU available for this notebook in 1/1000 of a core.')
+def notebooks_up(notebook_id, mem=None, cpu=None):
+    """Start an existing notebook and open it in the browser."""
+    client = civis.APIClient()
+    kwargs = {'memory': mem, 'cpu': cpu}
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    client.notebooks.patch(notebook_id, **kwargs)
+    _notebooks_up(notebook_id)
+    _notebooks_open(notebook_id)
+
+
+def _notebooks_up(notebook_id):
+    client = civis.APIClient()
+    return client.notebooks.post_deployments(notebook_id)
+
+
+@click.command('down')
+@click.argument('notebook_id', type=int)
+def notebooks_down(notebook_id):
+    """Shut down a running notebook."""
+    client = civis.APIClient()
+    nb = client.notebooks.get(notebook_id)
+    state = nb['most_recent_deployment']['state']
+    if state not in ['running', 'pending']:
+        print('Notebook is in state "{}" and can\'t be stopped.'.format(state))
+    deployment_id = nb['most_recent_deployment']['deploymentId']
+    client.notebooks.delete_deployments(notebook_id, deployment_id)
+
+
+@click.command('open')
+@click.argument('notebook_id', type=int)
+def notebooks_open(notebook_id):
+    """Open an existing notebook in the browser."""
+    _notebooks_open(notebook_id)
+
+
+def _notebooks_open(notebook_id):
+    url = 'https://platform.civisanalytics.com/#/notebooks/{}?fullscreen=true'
+    url = url.format(notebook_id)
+    webbrowser.open(url, new=2, autoraise=True)
 
 
 @click.command('civis', help="Print Civis")

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -92,7 +92,7 @@ def notebooks_download_cmd(notebook_id, path):
 @click.option('--mem', type=int, default=None,
               help='Memory allocated for this notebook in MiB.')
 @click.option('--cpu', type=int, default=None,
-              help='CPU available for this notebook in 1/1024 of a core.')
+              help='CPU available for this notebook in 1/1000 of a core.')
 def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
     """Create a new notebook and open it in the browser."""
     client = civis.APIClient()
@@ -109,7 +109,7 @@ def notebooks_launch_cmd(language='python3', mem=None, cpu=None):
 @click.option('--mem', type=int, default=None,
               help='Memory allocated for this notebook in MiB.')
 @click.option('--cpu', type=int, default=None,
-              help='CPU available for this notebook in 1/1024 of a core.')
+              help='CPU available for this notebook in 1/1000 of a core.')
 def notebooks_up(notebook_id, mem=None, cpu=None):
     """Start an existing notebook and open it in the browser."""
     client = civis.APIClient()

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -37,7 +37,7 @@ backend for your Jupyter notebooks.
 
   Download a notebook from Civis Platform to the requested file on the local filesystem.
 
-- ``civis notebooks launch [$LANGUAGE] [--mem $MEMORY] [--cpu $CPU]``
+- ``civis notebooks new [$LANGUAGE] [--mem $MEMORY] [--cpu $CPU]``
 
   Create a new notebook, allocate resources for it, and open it in a tab
   of your default web browser. This command is the most similar to ``jupyter notebook``.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -26,3 +26,36 @@ endpoints to make uploading and downloading files easier:
 
 The default output format is YAML, but the ``--json-output`` allows you to
 get output in JSON.
+
+Notebooks
+---------
+
+The following CLI-only commands make it easier to use Civis Platform as a
+backend for your Jupyter notebooks.
+
+- ``civis notebooks download $NOTEBOOK_ID $PATH``
+
+  Download a notebook from Civis Platform to the requested file on the local filesystem.
+
+- ``civis notebooks launch [$LANGUAGE] [--mem $MEMORY] [--cpu $CPU]``
+
+  Create a new notebook, allocate resources for it, and open it in a tab
+  of your default web browser. This command is the most similar to ``jupyter notebook``.
+  By default, Civis Platform will create a Python 3 notebook, but you can
+  request any other language. Optional resource parameters let you allocate
+  more memory or CPU to your notebook.
+
+- ``civis notebooks up $NOTEBOOK_ID [--mem $MEMORY] [--cpu $CPU]``
+
+  Allocate resources for a notebook which already exists in Civis Platform
+  and open it in a tab of your default browser. Optional resource
+  arguments allow you to change resources allocated to your notebook
+  (default to using the same resources as the previous run).
+
+- ``civis notebooks down $NOTEBOOK_ID``
+
+  Stop a running notebook and free up the resources allocated to it.
+
+- ``civis notebooks open $NOTEBOOK_ID``
+
+  Open an existing notebook (which may or may not be running) in your default browser.


### PR DESCRIPTION
Add commands to the CLI to allow users to more easily open new notebooks. New commands are:
- launch : Create a new notebook, deploy it, and open it in a new brower tab.
- up : Start an existing notebook running and open it in a new browser tab.
- down : Stop a running notebook.
- open : Open an existing notebook in a new browser tab (if it's not running, don't start it).

These are usability improvements to make Civis Platform as a notebook backend even more transparent to users.