### PR TITLE
DOC Improve parallel documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
 - New notebook-related CLI commands: "new", "up", "down", and "open".
+- Additional documentation for using the Civis joblib backend (#199)
 
 ### Fixed
 - Relaxed requirement on ``cloudpickle`` version number (#187)

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -33,23 +33,47 @@ tool for your code:
   joblib backend provides an easy way to run these parallel computations in
   different Civis Platform scripts.
 
-`joblib <https://pythonhosted.org/joblib/index.html>`_ is a tool which facilitates
-parallel processing in Python. The :func:`~civis.parallel.make_backend_factory`,
-:func:`~civis.parallel.infer_backend_factory`, and 
+Joblib
+------
+`joblib <https://pythonhosted.org/joblib/index.html>`_ is an open source
+Python library which facilitates parallel processing in Python.
+Joblib uses Python's ``multiprocessing`` library to run functions
+in parallel, but it also allows users to define their own
+"back end" for parallel computation. The Civis Python API client takes
+advantage of this to let you easily run your own code in parallel
+through Civis Platform.
+
+The :func:`~civis.parallel.make_backend_factory`,
+:func:`~civis.parallel.infer_backend_factory`, and
 :func:`~civis.parallel.make_backend_template_factory` functions allow you
 to define a "civis" parallel computation backend which will transparently
 distribute computation in cloud resources managed by the Civis Platform.
 
+See the `joblib user guide <https://pythonhosted.org/joblib/parallel.html>`_
+for examples of using joblib to do parallel computation.
+Note that the descriptions of "memmapping" aren't relevant to using
+Civis Platform as a backend, since your jobs will potentially run
+on different computers and can't share memory.
+Using the Civis joblib backend to run jobs in parallel in the cloud
+looks the same as running jobs in parallel on your local computer,
+except that you first need to set up the "civis" backend.
+
 How to use
 ----------
-Begin by defining the backend. The Civis joblib backend creates and runs 
+Begin by defining the backend. The Civis joblib backend creates and runs
 Container Scripts, and the :func:`~civis.parallel.make_backend_factory`
 function accepts several arguments which will be passed to
 :func:`~civis.resources._resources.Scripts.post_containers`.
-Use the ``docker_image_name``, ``docker_image_tag``, ``repo_http_uri``,
-and ``repo_ref`` parameters to define the environment in which your
-code will be run. Make sure that this environment includes all of the code
-which you're parallelizing.
+For example, you could pass a ``repo_http_uri`` or ``repo_ref``
+to clone a repository from GitHub into the container which will run
+your function. Use the ``docker_image_name`` and ``docker_image_tag``
+to select a custom Docker image for your job.
+You can provide a ``setup_cmd`` to run setup in bash before your
+function executes in Python. The default ``setup_cmd`` will run
+``python setup.py install`` in the base directory of any ``repo_http_uri``
+which you include in your backend setup.
+Make sure that the environment you define for your Civis backend
+includes all of the code which your parallel function will call.
 
 The :func:`~civis.parallel.make_backend_factory` function will return a
 backend factory which should be given to the :func:`joblib.register_parallel_backend`
@@ -59,7 +83,7 @@ function. For example::
     >>> from civis.parallel import make_backend_factory
     >>> be_factory = make_backend_factory()
     >>> register_parallel_backend('civis', be_factory)
-    
+
 Direct ``joblib`` to use a custom backend by entering a :func:`joblib.parallel_backend`
 context::
 
@@ -67,7 +91,7 @@ context::
     >>> with parallel_backend('civis'):
     ...     # Do joblib parallel computation here.
 
-You can find more about custom joblib backends in the 
+You can find more about custom joblib backends in the
 `joblib documentation <http://pythonhosted.org/joblib/parallel.html#custom-backend-api-experimental>`_.
 
 Note that :class:`joblib.Parallel` takes both a ``n_jobs`` and ``pre_dispatch``
@@ -101,33 +125,43 @@ Instead of defining and creating new container scripts with
 :func:`~civis.parallel.make_backend_factory`, you can use
 :func:`~civis.parallel.make_backend_template_factory` to launch custom scripts from
 a templated script. To use the template factory, your backing container script must
-have the Civis Python client installed, and its run command must finish 
+have the Civis Python client installed, and its run command must finish
 by calling ``civis_joblib_worker`` with no arguments. The template must accept the
 parameter "JOBLIB_FUNC_FILE_ID". The Civis joblib backend will use this parameter
 to transport your remote work.
 
 Examples
 --------
-Parallel computation using the default joblib backend 
+Parallel computation using the default joblib backend
 (this uses processes on your local computer)::
 
+    >>> def my_func(num1, num2):
+    ...     return 2 * num1 + num2
     >>> from joblib import delayed, Parallel
     >>> parallel = Parallel(n_jobs=5)
-    >>> print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
-    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    >>> args = [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]
+    >>> print(parallel(delayed(my_func)(*a) for a in args))
+    [1, 3, 5, 7, 9, 11, 13]
 
 You can do the the same parallel computation using the Civis backend
 by creating and registering a backend factory and entering a
-``with parallel_backend('civis')`` context::
+``with parallel_backend('civis')`` context. The code below will start
+seven different jobs in Civis Platform (with up to 5 running at once).
+Each job will call the function ``my_func`` with a different set of
+arguments from the list ``args``.::
 
+    >>> def my_func(num1, num2):
+    ...     return 2 * num1 + num2
+    >>> from joblib import delayed, Parallel
     >>> from joblib import parallel_backend, register_parallel_backend
     >>> from civis.parallel import make_backend_factory
     >>> register_parallel_backend('civis', make_backend_factory(
     ...     required_resources={"cpu": 512, "memory": 256}))
+    >>> args = [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]
     >>> with parallel_backend('civis'):
     ...    parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
-    ...    print(parallel(delayed(sqrt)(i ** 2) for i in range(10)))
-    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    ...    print(parallel(delayed(my_func)(*a) for a in args))
+    [1, 3, 5, 7, 9, 11, 13]
 
 You can use the Civis joblib backend to parallelize any code which
 uses joblib internally, such as scikit-learn::
@@ -165,23 +199,23 @@ a ``max_job_retries`` value above 0 when creating your backend factory.
 This will automatically retry a job (potentially more than once) before giving
 up and keeping an exception.
 
-Logging: The Civis joblib backend uses the standard library 
-`logging module <https://docs.python.org/3/library/logging.html>`_, 
+Logging: The Civis joblib backend uses the standard library
+`logging module <https://docs.python.org/3/library/logging.html>`_,
 with debug emits for events which might help you diagnose errors.
 See also the "verbose" argument to :class:`joblib.Parallel`, which
 prints information to either stdout or stderr.
 
 Mismatches between your local environment and the environment in the
 Civis container script jobs are a common source of errors.
-To run a function in the Civis platform, any modules called by 
-that function must be importable from a Python interpreter running 
+To run a function in the Civis platform, any modules called by
+that function must be importable from a Python interpreter running
 in the container script. For example, if you use :class:`joblib.Parallel`
 with :func:`numpy.sqrt`, the joblib backend must be set to run
 your function in a container which has :mod:`numpy` installed.
 If you see an error such as::
 
     ModuleNotFoundError: No module named 'numpy'
-    
+
 this signifies that the function you're trying to run doesn't exist
 in the remote environment. Select a Docker container with the module installed,
 or install it in your remote environment by using the ``repo_http_uri``

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -135,22 +135,22 @@ Examples
 Parallel computation using the default joblib backend
 (this uses processes on your local computer)::
 
-    >>> def my_func(num1, num2):
+    >>> def expensive_calculation(num1, num2):
     ...     return 2 * num1 + num2
     >>> from joblib import delayed, Parallel
     >>> parallel = Parallel(n_jobs=5)
     >>> args = [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]
-    >>> print(parallel(delayed(my_func)(*a) for a in args))
+    >>> print(parallel(delayed(expensive_calculation)(*a) for a in args))
     [1, 3, 5, 7, 9, 11, 13]
 
 You can do the the same parallel computation using the Civis backend
 by creating and registering a backend factory and entering a
 ``with parallel_backend('civis')`` context. The code below will start
-seven different jobs in Civis Platform (with up to 5 running at once).
-Each job will call the function ``my_func`` with a different set of
-arguments from the list ``args``.::
+seven different jobs in Civis Platform (with up to five running at once).
+Each job will call the function ``expensive_calculation`` with a
+different set of arguments from the list ``args``.::
 
-    >>> def my_func(num1, num2):
+    >>> def expensive_calculation(num1, num2):
     ...     return 2 * num1 + num2
     >>> from joblib import delayed, Parallel
     >>> from joblib import parallel_backend, register_parallel_backend
@@ -160,7 +160,7 @@ arguments from the list ``args``.::
     >>> args = [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]
     >>> with parallel_backend('civis'):
     ...    parallel = Parallel(n_jobs=5, pre_dispatch='n_jobs')
-    ...    print(parallel(delayed(my_func)(*a) for a in args))
+    ...    print(parallel(delayed(expensive_calculation)(*a) for a in args))
     [1, 3, 5, 7, 9, 11, 13]
 
 You can use the Civis joblib backend to parallelize any code which


### PR DESCRIPTION
Add more detail to the Sphinx documentation for the `parallel` module. Change the example of using the joblib backend so that it runs a user-defined function, to make it explicit that users can provide their own code instead of only running built-in functions.