### PR TITLE
ENH default to dynamically calculating number of training jobs in CivisML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
 - New notebook-related CLI commands: "new", "up", "down", and "open".
 - Additional documentation for using the Civis joblib backend (#199)
+- Documented additional soft dependencies for CivisML (#201)
+
+### Changed
+- Changed `ModelPipeline.train` default for `n_jobs` from 4 to `None`,
+  so that `n_jobs` will be dynamically calculated by default (#201)
 
 ### Fixed
 

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -909,7 +909,8 @@ class ModelPipeline:
         n_jobs : int, optional
             Number of jobs to use for training and validation. Defaults to
             `None`, which allows CivisML to dynamically calculate an
-            appropriate number of workers to use.
+            appropriate number of workers to use (in general, as many as
+            possible without using all resources in the cluster).
             Increase n_jobs to parallelize over many hyperparameter
             combinations in grid search/hyperband, or decrease to use fewer
             computational resources at once.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,15 +37,19 @@ set ``use_pandas=True`` in functions that accept that parameter.  To install
    pip install pandas
 
 Machine learning features in the ``ml`` namespace have a soft dependency on
-``scikit-learn`` and ``pandas``. Install ``scikit-learn`` to
+``scikit-learn``, ``pandas``, ``civisml-extensions``, and
+``glmnet``. Install ``scikit-learn`` to
 export your trained models from the Civis Platform or to
 provide your own custom models. Use ``pandas`` to download model predictions
-from the Civis Platform. Install these dependencies with
+from the Civis Platform. Use ``civisml-extensions`` and ``glmnet`` to
+access a successfully trained model object. Install these dependencies with
 
 .. code-block:: bash
 
    pip install scikit-learn
    pip install pandas
+   pip install civisml-extensions
+   pip install glmnet
 
 
 Python version support

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,12 +37,10 @@ set ``use_pandas=True`` in functions that accept that parameter.  To install
    pip install pandas
 
 Machine learning features in the ``ml`` namespace have a soft dependency on
-``scikit-learn``, ``pandas``, ``civisml-extensions``, and
-``glmnet``. Install ``scikit-learn`` to
+``scikit-learn`` and ``pandas``. Install ``scikit-learn`` to
 export your trained models from the Civis Platform or to
 provide your own custom models. Use ``pandas`` to download model predictions
-from the Civis Platform. Use ``civisml-extensions`` and ``glmnet`` to
-access a successfully trained model object. The ``civis.ml`` code
+from the Civis Platform. The ``civis.ml`` code
 optionally uses the `feather <https://github.com/wesm/feather>`_
 format to transfer data from your local computer to Civis
 Platform. Install these dependencies with
@@ -51,9 +49,20 @@ Platform. Install these dependencies with
 
    pip install scikit-learn
    pip install pandas
+   pip install feather-format
+
+
+Some CivisML models have open-source dependencies in
+addition to ``scikit-learn``, which you may need if you want to
+download the model object. These dependencies are
+``civisml-extensions``, ``glmnet``, and ``muffnn``. Install these
+dependencies with
+   
+.. code-block:: bash
+
    pip install civisml-extensions
    pip install glmnet
-   pip install feather-format
+   pip install muffnn
 
 
 Python version support

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -29,7 +29,28 @@ Note that whichever option you chose, CivisML will pre-process your data to
 one-hot-encode categorical features (the non-numerical columns) to binary indicator columns
 before sending the features to the :class:`~sklearn.pipeline.Pipeline`.
 
-       
+Model Dependencies
+------------------
+
+Many models built in CivisML have open-source dependencies in addition
+to ``scikit-learn``, and you will need to install these dependencies
+to access the model object. Models which use the default CivisML ETL,
+along with models which use stacking or hyperband, depend on
+``civisml-extensions``. Pre-defined models which include a feature
+selection step ("sparse_logistic", "sparse_linear_regressor",
+"sparse_ridge_regressor", "stacking_classifier", and
+"stacking_regressor") depend on ``glmnet``. Pre-defined MLP models
+("multilayer_perceptron_classifier" and
+"multilayer_perceptron_regressor") depend on ``muffnn``. These
+dependencies can be installed with
+
+.. code-block:: bash
+
+   pip install civisml-extensions
+   pip install glmnet
+   pip install muffnn
+
+
 Pre-Defined Models
 ------------------
 

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -126,7 +126,9 @@ hyperparameter names, and the values are lists of hyperparameter
 values to grid search over. You can run hyperparameter tuning in parallel by
 setting the ``n_jobs``
 parameter to however many jobs you would like to run in
-parallel. ``n_jobs`` defaults to 4.
+parallel. By default, ``n_jobs`` is dynamically calculated based on
+the resources available on your cluster, such that a modeling job will
+never take up more than 90% of the cluster resources at once.
 
 `Hyperband <https://arxiv.org/abs/1603.06560>`_
 is an efficient approach to hyperparameter optimization, and


### PR DESCRIPTION
This PR changes the default `n_jobs` in `ModelPipeline.train` from 4 to `None`, so that it will be calculated dynamically by default. I also updated the docs to reflect that change, and documented `ModelPipeline`'s soft dependency on `glmnet` and `civisml-extensions` for accessing model objects.