### PR TITLE
ENH Re-raise warnings from CivisML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Require this when using ``pd.Categorical`` types, since CSVs require us to
   re-infer column types, and this can fail. Using feather should also give a
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
+- ``ModelFuture`` objects will emit any warnings which occurred during their
+  corresponding CivisML job (#204)
 
 ### Fixed
 


### PR DESCRIPTION
When retrieving metadata, check the "warnings" key (present on all jobs) for any warnings which were recorded during the CivisML run. Reraise them as exactly as possible. We always attempt to download metadata after a job completes so that we can check for any errors, so we'll always see warnings from jobs as they complete.