### PR TITLE
BUG make 'sequential' the default remote backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
 
 ### Fixed
+- Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``
+  parameter default to 'threading' as opposed to 'civis'. The default of 'civis' would launch additional
+  containers in nested calls to ``joblib.Parallel``. (#205)
 
 ### Performance Enhancements
 - ``civis.io.file_to_civis`` now uses additional file handles for multipart upload instead of writing to disk to reduce disk usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``
-  parameter default to 'threading' as opposed to 'civis'. The default of 'civis' would launch additional
+  parameter default to 'sequential' as opposed to 'civis'. The default of 'civis' would launch additional
   containers in nested calls to ``joblib.Parallel``. (#205)
 
 ### Performance Enhancements

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -135,7 +135,7 @@ def infer_backend_factory(required_resources=None,
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential 
+        container. The default of 'sequential' uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
         Civis joblib backend that launched the container.
     **kwargs:
@@ -281,7 +281,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential 
+        container. The default of 'sequential' uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
         Civis joblib backend that launched the container.
     **kwargs:

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -51,7 +51,7 @@ def infer_backend_factory(required_resources=None,
                           max_submit_retries=0,
                           max_job_retries=0,
                           hidden=True,
-                          remote_backend='civis',
+                          remote_backend='threading',
                           **kwargs):
     """Infer the container environment and return a backend factory.
 
@@ -135,7 +135,8 @@ def infer_backend_factory(required_resources=None,
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'civis' uses an exact copy of the Civis
+        container. The default of 'threading' uses the joblib threading backend
+        in the container. The value 'civis' uses an exact copy of the Civis
         joblib backend that launched the container.
     **kwargs:
         Additional keyword arguments will be passed directly to
@@ -221,7 +222,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
                          max_submit_retries=0,
                          max_job_retries=0,
                          hidden=True,
-                         remote_backend='civis',
+                         remote_backend='threading',
                          **kwargs):
     """Create a joblib backend factory that uses Civis Container Scripts
 
@@ -280,7 +281,8 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'civis' uses an exact copy of the Civis
+        container. The default of 'threading' uses the joblib threading backend
+        in the container. The value 'civis' uses an exact copy of the Civis
         joblib backend that launched the container.
     **kwargs:
         Additional keyword arguments will be passed
@@ -738,7 +740,7 @@ class _CivisBackend(ParallelBackendBase):
                  from_template_id=None,
                  max_submit_retries=0,
                  client=None,
-                 remote_backend='civis',
+                 remote_backend='threading',
                  **executor_kwargs):
         self.setup_cmd = setup_cmd
         self.from_template_id = from_template_id

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -51,7 +51,7 @@ def infer_backend_factory(required_resources=None,
                           max_submit_retries=0,
                           max_job_retries=0,
                           hidden=True,
-                          remote_backend='threading',
+                          remote_backend='sequential',
                           **kwargs):
     """Infer the container environment and return a backend factory.
 
@@ -135,7 +135,7 @@ def infer_backend_factory(required_resources=None,
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'threading' uses the joblib threading backend
+        container. The default of 'sequential' uses the joblib sequential backend
         in the container. The value 'civis' uses an exact copy of the Civis
         joblib backend that launched the container.
     **kwargs:
@@ -222,7 +222,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
                          max_submit_retries=0,
                          max_job_retries=0,
                          hidden=True,
-                         remote_backend='threading',
+                         remote_backend='sequential',
                          **kwargs):
     """Create a joblib backend factory that uses Civis Container Scripts
 
@@ -281,7 +281,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'threading' uses the joblib threading backend
+        container. The default of 'sequential' uses the joblib sequential backend
         in the container. The value 'civis' uses an exact copy of the Civis
         joblib backend that launched the container.
     **kwargs:
@@ -740,7 +740,7 @@ class _CivisBackend(ParallelBackendBase):
                  from_template_id=None,
                  max_submit_retries=0,
                  client=None,
-                 remote_backend='threading',
+                 remote_backend='sequential',
                  **executor_kwargs):
         self.setup_cmd = setup_cmd
         self.from_template_id = from_template_id

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -285,7 +285,7 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
         is the joblib backend to use when executing code within joblib in the
         container. The default of 'sequential' uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
-        Civis joblib backend that launched the container.Note that with the
+        Civis joblib backend that launched the container. Note that with the
         value 'civis', one can potentially use more jobs than specified by
         ``n_jobs``.
     **kwargs:

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -137,7 +137,9 @@ def infer_backend_factory(required_resources=None,
         is the joblib backend to use when executing code within joblib in the
         container. The default of 'sequential' uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
-        Civis joblib backend that launched the container.
+        Civis joblib backend that launched the container. Note that with the
+        value 'civis', one can potentially use more jobs than specified by
+        ``n_jobs``.
     **kwargs:
         Additional keyword arguments will be passed directly to
         :func:`~civis.APIClient.scripts.post_containers`, potentially
@@ -283,7 +285,9 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
         is the joblib backend to use when executing code within joblib in the
         container. The default of 'sequential' uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
-        Civis joblib backend that launched the container.
+        Civis joblib backend that launched the container.Note that with the
+        value 'civis', one can potentially use more jobs than specified by
+        ``n_jobs``.
     **kwargs:
         Additional keyword arguments will be passed
         directly to :func:`~civis.APIClient.scripts.post_containers`.

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -135,9 +135,9 @@ def infer_backend_factory(required_resources=None,
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential backend
-        in the container. The value 'civis' uses an exact copy of the Civis
-        joblib backend that launched the container.
+        container. The default of 'sequential' uses the joblib sequential 
+        backend in the container. The value 'civis' uses an exact copy of the
+        Civis joblib backend that launched the container.
     **kwargs:
         Additional keyword arguments will be passed directly to
         :func:`~civis.APIClient.scripts.post_containers`, potentially
@@ -281,9 +281,9 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential backend
-        in the container. The value 'civis' uses an exact copy of the Civis
-        joblib backend that launched the container.
+        container. The default of 'sequential' uses the joblib sequential 
+        backend in the container. The value 'civis' uses an exact copy of the
+        Civis joblib backend that launched the container.
     **kwargs:
         Additional keyword arguments will be passed
         directly to :func:`~civis.APIClient.scripts.post_containers`.

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -202,7 +202,7 @@ def test_infer(mock_make_factory, mock_job):
         max_submit_retries=0,
         max_job_retries=0,
         hidden=True,
-        remote_backend='civis',
+        remote_backend='threading',
         **expected)
 
 
@@ -313,7 +313,7 @@ def test_infer_from_custom_job(mock_make_factory):
                        'max_submit_retries': mock.ANY,
                        'max_job_retries': mock.ANY,
                        'hidden': True,
-                       'remote_backend': 'civis'}
+                       'remote_backend': 'threading'}
     for key in civis.parallel.KEYS_TO_INFER:
         expected_kwargs[key] = mock_script[key]
     mock_make_factory.assert_called_once_with(**expected_kwargs)

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -202,7 +202,7 @@ def test_infer(mock_make_factory, mock_job):
         max_submit_retries=0,
         max_job_retries=0,
         hidden=True,
-        remote_backend='threading',
+        remote_backend='sequential',
         **expected)
 
 
@@ -313,7 +313,7 @@ def test_infer_from_custom_job(mock_make_factory):
                        'max_submit_retries': mock.ANY,
                        'max_job_retries': mock.ANY,
                        'hidden': True,
-                       'remote_backend': 'threading'}
+                       'remote_backend': 'sequential'}
     for key in civis.parallel.KEYS_TO_INFER:
         expected_kwargs[key] = mock_script[key]
     mock_make_factory.assert_called_once_with(**expected_kwargs)


### PR DESCRIPTION
Before we used 'civis' as the default. This means that containers are viral. Using the threading default is probably less confusing/surprising. IDK if we had this discussion before, but whatever the case, I am now convinced this is a better choice.

Closes #206 

@jmemich for viz