### PR TITLE
ENH Allow missing model validation metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
 - ``ModelFuture`` objects will emit any warnings which occurred during their
   corresponding CivisML job (#204)
+- ``ModelFuture`` objects will return an empty dictionary if validation metadata
+  are missing, rather than issuing an exception or returning ``None`` (#208)
 
 ### Fixed
 - Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
 - ``ModelFuture`` objects will emit any warnings which occurred during their
   corresponding CivisML job (#204)
-- If validation metadata are missing, ``ModelFuture`` objects will return ``None``
-  for metrics or validation metadata, rather than issuing an exception (#208)
 
 ### Fixed
 - Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``
   parameter default to 'sequential' as opposed to 'civis'. The default of 'civis' would launch additional
   containers in nested calls to ``joblib.Parallel``. (#205)
+- If validation metadata are missing, ``ModelFuture`` objects will return ``None``
+  for metrics or validation metadata, rather than issuing an exception (#208)
 
 ### Performance Enhancements
 - ``civis.io.file_to_civis`` now uses additional file handles for multipart upload instead of writing to disk to reduce disk usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
 - ``ModelFuture`` objects will emit any warnings which occurred during their
   corresponding CivisML job (#204)
-- ``ModelFuture`` objects will return an empty dictionary if validation metadata
-  are missing, rather than issuing an exception or returning ``None`` (#208)
+- If validation metadata are missing, ``ModelFuture`` objects will return ``None``
+  for metrics or validation metadata, rather than issuing an exception (#208)
 
 ### Fixed
 - Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -547,7 +547,11 @@ class ModelFuture(ContainerFuture):
                 self._val_metadata = {}
             else:
                 self._val_metadata = cio.file_to_json(fid, client=self.client)
-        return self._val_metadata
+        if not self._val_metadata:
+            # Convert an empty dictionary to None
+            return None
+        else:
+            return self._val_metadata
 
     @property
     def metrics(self):

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -536,16 +536,22 @@ class ModelFuture(ContainerFuture):
     @_block_and_handle_missing
     def validation_metadata(self):
         if self._val_metadata is None:
-            fid = cio.file_id_from_run_output('metrics.json',
-                                              self.train_job_id,
-                                              self.train_run_id,
-                                              client=self.client)
-            self._val_metadata = cio.file_to_json(fid, client=self.client)
+            try:
+                fid = cio.file_id_from_run_output('metrics.json',
+                                                  self.train_job_id,
+                                                  self.train_run_id,
+                                                  client=self.client)
+            except FileNotFoundError:
+                # Use an empty dictionary to indicate that
+                # we've already checked for metadata.
+                self._val_metadata = {}
+            else:
+                self._val_metadata = cio.file_to_json(fid, client=self.client)
         return self._val_metadata
 
     @property
     def metrics(self):
-        if self.validation_metadata is not None:
+        if self.validation_metadata:
             return self.validation_metadata['metrics']
         else:
             return None

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -571,7 +571,7 @@ def test_validation_metadata_missing(mock_spe, mock_f2f,
     c = setup_client_mock(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
 
-    assert mf.validation_metadata == {}
+    assert mf.validation_metadata is None
     assert mf.metrics is None
     assert mock_f2f.call_count == 0
     assert mock_file_id_from_run_output.call_count == 1

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -562,6 +562,22 @@ def test_validation_metadata_training(mock_spe, mock_f2f,
 
 
 @mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
+@mock.patch.object(_model.cio, "file_to_json", autospec=True)
+@mock.patch.object(_model.ModelFuture, "_set_model_exception")
+def test_validation_metadata_missing(mock_spe, mock_f2f,
+                                     mock_file_id_from_run_output):
+    # Make sure that missing validation metadata doesn't cause an error
+    mock_file_id_from_run_output.side_effect = FileNotFoundError
+    c = setup_client_mock(3, 7)
+    mf = _model.ModelFuture(3, 7, client=c)
+
+    assert mf.validation_metadata == {}
+    assert mf.metrics is None
+    assert mock_f2f.call_count == 0
+    assert mock_file_id_from_run_output.call_count == 1
+
+
+@mock.patch.object(_model.cio, "file_id_from_run_output", autospec=True)
 @mock.patch.object(_model.cio, "file_to_json", return_value='foo',
                    autospec=True)
 @mock.patch.object(_model.ModelFuture, "_set_model_exception")


### PR DESCRIPTION
With CivisML v2, users can choose to skip the validation step. If that happens, there will be no validation metadata stored. This change lets the `ModelFuture` handle missing validation metadata files without issuing an error.