### PR TITLE
Update documentation for CivisML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+- Documentation updated to reflect CivisML 2.1 features (#209)
 - ``civis.io.dataframe_to_civis``, ``civis.io.csv_to_civis``, and ``civis.io.civis_file_to_table`` functions now support the `diststyle` parameter.
 - New notebook-related CLI commands: "new", "up", "down", and "open".
 - Additional documentation for using the Civis joblib backend (#199)

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -582,7 +582,8 @@ class ModelPipeline:
     dependent_variable : string or List[str]
         The dependent variable of the training dataset.
         For a multi-target problem, this should be a list of
-        column names of dependent variables.
+        column names of dependent variables. Nulls in the dependent
+        variable will automatically be dropped.
     primary_key : string, optional
         The unique ID (primary key) of the training dataset.
         This will be used to index the out-of-sample scores.
@@ -590,10 +591,11 @@ class ModelPipeline:
         Specify parameters for the final stage estimator in a
         predefined model, e.g. ``{'C': 2}`` for a "sparse_logistic"
         model.
-    cross_validation_parameters : dict, optional
-        Cross validation parameter grid for learner parameters, e.g.
+    cross_validation_parameters : dict or string, optional
+        Options for cross validation. For grid search, supply a 
+        parameter grid as a dictionary, e.g.,
         ``{{'n_estimators': [100, 200, 500], 'learning_rate': [0.01, 0.1],
-        'max_depth': [2, 3]}}``.
+        'max_depth': [2, 3]}}``. For hyperband, pass the string "hyperband".
     model_name : string, optional
         The prefix of the Platform modeling jobs. It will have
         " Train" or " Predict" added to become the Script title.
@@ -1196,7 +1198,10 @@ class ModelPipeline:
             Action to take if the prediction table already exists.
         n_jobs : int, optional
             Number of concurrent Platform jobs to use
-            for multi-file / large table prediction.
+            for multi-file / large table prediction. Defaults to
+            `None`, which allows CivisML to dynamically calculate an
+            appropriate number of workers to use (in general, as many as
+            possible without using all resources in the cluster).
         polling_interval : float, optional
             Check for job completion every this number of seconds.
             Do not set if using the notifications endpoint.

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -582,8 +582,8 @@ class ModelPipeline:
     dependent_variable : string or List[str]
         The dependent variable of the training dataset.
         For a multi-target problem, this should be a list of
-        column names of dependent variables. Nulls in the dependent
-        variable will automatically be dropped.
+        column names of dependent variables. Nulls in a single
+        dependent variable will automatically be dropped.
     primary_key : string, optional
         The unique ID (primary key) of the training dataset.
         This will be used to index the out-of-sample scores.

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -592,7 +592,7 @@ class ModelPipeline:
         predefined model, e.g. ``{'C': 2}`` for a "sparse_logistic"
         model.
     cross_validation_parameters : dict or string, optional
-        Options for cross validation. For grid search, supply a 
+        Options for cross validation. For grid search, supply a
         parameter grid as a dictionary, e.g.,
         ``{{'n_estimators': [100, 200, 500], 'learning_rate': [0.01, 0.1],
         'max_depth': [2, 3]}}``. For hyperband, pass the string "hyperband".

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -25,30 +25,8 @@ cross-validation happens over all steps together.
 You can define your model in two ways, either by selecting a pre-defined algorithm
 or by providing your own scikit-learn
 :class:`~sklearn.pipeline.Pipeline` or :class:`~sklearn.base.BaseEstimator` object.
-Note that whichever option you chose, CivisML will pre-process your data to
-one-hot-encode categorical features (the non-numerical columns) to binary indicator columns
-before sending the features to the :class:`~sklearn.pipeline.Pipeline`.
-
-Model Dependencies
-------------------
-
-Many models built in CivisML have open-source dependencies in addition
-to ``scikit-learn``, and you will need to install these dependencies
-to access the model object. Models which use the default CivisML ETL,
-along with models which use stacking or hyperband, depend on
-``civisml-extensions``. Pre-defined models which include a feature
-selection step ("sparse_logistic", "sparse_linear_regressor",
-"sparse_ridge_regressor", "stacking_classifier", and
-"stacking_regressor") depend on ``glmnet``. Pre-defined MLP models
-("multilayer_perceptron_classifier" and
-"multilayer_perceptron_regressor") depend on ``muffnn``. These
-dependencies can be installed with
-
-.. code-block:: bash
-
-   pip install civisml-extensions
-   pip install glmnet
-   pip install muffnn
+Note that whichever option you chose, CivisML will pre-process your
+data using either its default ETL, or ETL that you provide (see :ref:`custom-etl`).
 
 
 Pre-Defined Models
@@ -105,8 +83,10 @@ Custom Models
 
 You can create your own :class:`~sklearn.pipeline.Pipeline` instead of using one of
 the pre-defined ones. Create the object and pass it as the ``model`` parameter
-of the :class:`~civis.ml.ModelPipeline`. Your model must be built from libraries which CivisML
-recognizes. You can use code from
+of the :class:`~civis.ml.ModelPipeline`. Your model must follow the
+scikit-learn API, and you will need to include any dependencies as
+:ref:`custom-dependencies` if they are not already installed in
+CivisML. Common libraries you may want to use include: 
 
 - `scikit-learn <http://scikit-learn.org>`_ v0.18.1
 - `glmnet <https://github.com/civisanalytics/python-glmnet>`_ v2.0.0
@@ -118,6 +98,8 @@ either you add a missing value imputation step or that your data doesn't have an
 missing values. If you're making a classification model, the model must have a ``predict_proba``
 method. If the class you're using doesn't have a ``predict_proba`` method,
 you can add one by wrapping it in a :class:`~sklearn.calibration.CalibratedClassifierCV`.
+
+..  _custom-etl:
 
 Custom ETL
 ----------
@@ -205,6 +187,8 @@ small values, ranging between .0003 and .03, with a mean close to
 .006. Similarly, the truncated exponential distribution for the random
 forest and extra trees models skews toward small values, ranging
 between .01 and 1, and with a mean close to .1.
+
+.. _custom-dependencies:
 
 Custom Dependencies
 -------------------
@@ -341,7 +325,10 @@ the following pip-installable dependencies enhance the capabilities of the
 - scikit-learn
 - glmnet
 - feather-format
+- civisml-extensions
+- muffnn
 
+  
 Install :mod:`pandas` if you wish to download tables of predictions.
 You can also model on :class:`~pandas.DataFrame` objects in your interpreter.
 
@@ -356,9 +343,16 @@ is lost when writing data as a CSV.
 If you wish to use custom models or download trained models,
 you'll need scikit-learn installed.
 
-The "sparse_logistic", "sparse_linear_regressor", and "sparse_ridge_regressor" models
-all use the public Civis Analytics ``glmnet`` library. Install it if you wish to download
-a model created from one of these pre-defined models.
+Several pre-defined models rely on public Civis Analytics
+libraries. The "sparse_logistic", "sparse_linear_regressor",
+"sparse_ridge_regressor", "stacking_classifier", and "stacking_regressor" models
+all use the ``glmnet`` library. Pre-defined MLP models
+("multilayer_perceptron_classifier" and
+"multilayer_perceptron_regressor") depend on the ``muffnn``
+library. Finally, models which use the default CivisML ETL,
+along with models which use stacking or hyperband, depend on
+``civisml-extensions``. Install these packages if you wish to download
+the pre-defined models that depend on them.
 
 Object reference
 ================

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -86,12 +86,13 @@ the pre-defined ones. Create the object and pass it as the ``model`` parameter
 of the :class:`~civis.ml.ModelPipeline`. Your model must follow the
 scikit-learn API, and you will need to include any dependencies as
 :ref:`custom-dependencies` if they are not already installed in
-CivisML. Common libraries you may want to use include: 
+CivisML. Preinstalled libraries available for your use include:
 
-- `scikit-learn <http://scikit-learn.org>`_ v0.18.1
+- `scikit-learn <http://scikit-learn.org>`_ v0.19.1
 - `glmnet <https://github.com/civisanalytics/python-glmnet>`_ v2.0.0
 - `xgboost <http://xgboost.readthedocs.io>`_ v0.6a2
-- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.1.1
+- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.2.0
+- `civisml-extensions <https://github.com/civisanalytics/civisml-extensions>`_ v.0.1.6
 
 When you're assembling your own model, remember that you'll have to make certain that
 either you add a missing value imputation step or that your data doesn't have any
@@ -154,7 +155,7 @@ Note that if you want to use hyperband with a custom model, you will need to
 wrap your estimator in a
 :class:`civismlext.hyperband.HyperbandSearchCV` estimator yourself.
 
-CivisML runs pre-defined with hyperband using the following
+CivisML runs pre-defined models with hyperband using the following
 distributions:
 
 +------------------------------------+--------------------+-----------------------------------------------------------------------------+


### PR DESCRIPTION
This PR updates the documentation and `ModelPipeline` docstrings to reflect new features and defaults in CivisML 2.1.