### PR TITLE
DOC Remove n_jobs from CivisML predict example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   speed improvement; it reads and writes faster than CSVs and produces smaller files (#200).
 - ``ModelFuture`` objects will emit any warnings which occurred during their
   corresponding CivisML job (#204)
+- Removed line setting "n_jobs" from an example of CivisML prediction.
+  Recommended use is to let CivisML determine the number of jobs itself (#211).
 
 ### Fixed
 - Restored the pre-v1.7.0 default behavior of the ``joblib`` backend by setting the ``remote_backend``

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -677,8 +677,7 @@ class ModelPipeline:
     >>> pred = model.predict(table_name='schema.demographics_table ',
     ...                      database_name='My Redshift Cluster',
     ...                      output_table='schema.predicted_survey_response',
-    ...                      if_exists='drop',
-    ...                      n_jobs=50)
+    ...                      if_exists='drop')
     >>> df_pred = pred.table  # Blocks until finished
     # Modify the parameters of the base estimator in a default model:
     >>> model = ModelPipeline('sparse_logistic', 'depvar',


### PR DESCRIPTION
The recommended use is to leave the default `n_jobs=None` so that CivisML can determine for itself how many jobs to use.