### PR TITLE
remove extra space in the notebooks new CLI command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Reworded output of `civis notebooks new` CLI command (#215)
 
 ## 1.8.0 - 2018-01-23
 ### Added

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -99,7 +99,9 @@ def notebooks_new_cmd(language='python3', mem=None, cpu=None):
     kwargs = {'memory': mem, 'cpu': cpu}
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     new_nb = client.notebooks.post(language=language, **kwargs)
-    print("Created new {} notebook with ID {} .".format(language, new_nb.id))
+    print("Created new {language} notebook with ID {id} in Civis Platform"
+          " (https://platform.civisanalytics.com/#/notebooks/{id})."
+          .format(language=language, id=new_nb.id))
     _notebooks_up(new_nb.id)
     _notebooks_open(new_nb.id)
 


### PR DESCRIPTION
@stephen-hoover, did you have this space there intentionally?  I just used `civis notebooks new`, and the space seemed odd.