### PR TITLE
BUG Fix multipart upload log strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Added missing string formatting to a log emit in file multipart upload (#217)
+
 ### Changed
 - Updated CivisML 2.0 notebook (#214)
 - Reworded output of `civis notebooks new` CLI command (#215)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-- Added missing string formatting to a log emit in file multipart upload (#217)
+- Added missing string formatting to a log emit in file multipart upload and
+  correct ordering of parameters in another log emit (#217)
 
 ### Changed
 - Updated CivisML 2.0 notebook (#214)

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -122,7 +122,7 @@ def _multipart_upload(buf, name, file_size, client, **kwargs):
     num_parts = int(math.ceil((file_size) / float(part_size)))
 
     log.debug('Uploading file with %s bytes using %s file parts with a part '
-              'size of %s bytes', file_size, part_size, num_parts)
+              'size of %s bytes', file_size, num_parts, part_size)
     file_response = client.files.post_multipart(name=name, num_parts=num_parts,
                                                 **kwargs)
 

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -148,7 +148,7 @@ def _multipart_upload(buf, name, file_size, client, **kwargs):
             msg = _get_aws_error_message(part_response)
             raise HTTPError(msg, response=part_response)
 
-        log.debug('Completed upload of file part', part_num)
+        log.debug('Completed upload of file part %s', part_num)
 
     # upload each part
     try:


### PR DESCRIPTION
Without this "%s", we see an error message for every fragment of multipart uploads. Also correct the order of two values in a multipart upload debug emit.