### PR TITLE
Adding robust parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Added more robust parsing for tablename parsing in io.  You may now
+  pass in tables like schema."tablename.with.periods".
 
 ## 1.8.1 - 2018-02-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-### Changed
+### Fixed
 - Added more robust parsing for tablename parsing in io.  You may now
   pass in tables like schema."tablename.with.periods".
 

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import logging
 
 from civis.compat import lru_cache
+from civis.io._tables import _robust_schema_table_split
 from civis.resources import generate_classes_maybe_cached
 from civis._utils import get_api_key
 
@@ -208,7 +209,7 @@ class MetaMixin():
             If an exact table match can't be found.
         """
         database_id = self.get_database_id(database)
-        schema, name = table.split('.')
+        schema, name = _robust_schema_table_split(table)
         tables = self.tables.list(database_id=database_id, schema=schema,
                                   name=name)
         if not tables:

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 import logging
 
+import civis
 from civis.compat import lru_cache
-from civis.io._tables import _robust_schema_table_split
 from civis.resources import generate_classes_maybe_cached
 from civis._utils import get_api_key
 
@@ -209,7 +209,7 @@ class MetaMixin():
             If an exact table match can't be found.
         """
         database_id = self.get_database_id(database)
-        schema, name = _robust_schema_table_split(table)
+        schema, name = civis.io._robust_schema_table_split(table)
         tables = self.tables.list(database_id=database_id, schema=schema,
                                   name=name)
         if not tables:

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -54,8 +54,9 @@ def read_civis(table, database, columns=None, use_pandas=False,
     Parameters
     ----------
     table : str
-        Name of table, including schema, in the database. I.e.
-        ``'my_schema.my_table'``.
+        Name of table, including schema, in the database. E.g.
+        ``'my_schema.my_table'``. Schemas or tablenames with periods must
+        be double quoted, e.g. ``'my_schema."my.table"'``.
     database : str or int
         Read data from this database. Can be the database name or ID.
     columns : list, optional
@@ -565,7 +566,8 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
         Upload data into this database. Can be the database name or ID.
     table : str
         The schema and table you want to upload to. E.g.,
-        ``'scratch.table'``.
+        ``'scratch.table'``. Schemas or tablenames with periods must
+        be double quoted, e.g. ``'scratch."my.table"'``.
     api_key : DEPRECATED str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import re
+import six
 import shutil
 import warnings
 import zlib
@@ -978,7 +979,7 @@ def _download_callback(job_id, run_id, filename, headers, compression):
 
 
 def _robust_schema_table_split(table):
-    reader = csv.reader(StringIO(table),
+    reader = csv.reader(StringIO(six.text_type(table)),
                         delimiter=".",
                         doublequote=True,
                         quotechar='"')

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -978,6 +978,10 @@ def _download_callback(job_id, run_id, filename, headers, compression):
 
 
 def _robust_schema_table_split(table):
+    reader = csv.reader(StringIO(table),
+                        delimiter=".",
+                        doublequote=True,
+                        quotechar='"')
     schema_name_tup = next(csv.reader(StringIO(table), delimiter="."))
     if len(schema_name_tup) != 2:
         raise ValueError("Cannot parse schema and table. "

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -982,7 +982,7 @@ def _robust_schema_table_split(table):
                         delimiter=".",
                         doublequote=True,
                         quotechar='"')
-    schema_name_tup = next(csv.reader(StringIO(table), delimiter="."))
+    schema_name_tup = next(reader)
     if len(schema_name_tup) != 2:
         raise ValueError("Cannot parse schema and table. "
                          "Does '{}' follow the pattern 'schema.table'?"

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -403,15 +403,18 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
         "foo", "foo_name", mock_file)
 
 
-def test_robust_schema_table_split():
-    strs = ['schema.table', 'schema."t.able"', 'schema.table"',
-            '"sch.ema"."t.able"', 'schema."tab""le."']
-    schemas = ['schema', 'schema', 'schema', 'sch.ema', 'schema']
-    tables = ['table', 't.able', 'table"', 't.able', 'tab"le.']
-    for s, exp_schema, exp_table in zip(strs, schemas, tables):
-        schema, table = civis.io._tables._robust_schema_table_split(s)
-        assert schema == exp_schema
-        assert table == exp_table
+@pytest.mark.parametrize("table,expected", [
+    ('schema.table', ['schema', 'table']),
+    ('schema."t.able"', ['schema', 't.able']),
+    ('schema.table"', ['schema', 'table"']),
+    ('"sch.ema"."t.able"', ['sch.ema','t.able']),
+    ('schema."tab""le."', ['schema','tab"le.'])
+])
+def test_robust_schema_table_split(table, expected):
+    assert civis.io._tables._robust_schema_table_split(table) == expected
+
+
+def test_robust_schema_table_split_raises():
+    s = "table_with_no_schema"
     with pytest.raises(ValueError):
-        s = "table_no_schema"
         schema, table = civis.io._tables._robust_schema_table_split(s)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -407,8 +407,8 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
     ('schema.table', ['schema', 'table']),
     ('schema."t.able"', ['schema', 't.able']),
     ('schema.table"', ['schema', 'table"']),
-    ('"sch.ema"."t.able"', ['sch.ema','t.able']),
-    ('schema."tab""le."', ['schema','tab"le.'])
+    ('"sch.ema"."t.able"', ['sch.ema', 't.able']),
+    ('schema."tab""le."', ['schema', 'tab"le.'])
 ])
 def test_robust_schema_table_split(table, expected):
     assert civis.io._tables._robust_schema_table_split(table) == expected

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -401,3 +401,17 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
     assert mock_open.called_once_with("foo", "rb")
     assert mock_file_to_civis_helper.called_once_with(
         "foo", "foo_name", mock_file)
+
+
+def test_robust_schema_table_split():
+    strs = ['schema.table', 'schema."t.able"', 'schema.table"',
+            '"sch.ema"."t.able"', 'schema."tab""le."']
+    schemas = ['schema', 'schema', 'schema', 'sch.ema', 'schema']
+    tables = ['table', 't.able', 'table"', 't.able', 'tab"le.']
+    for s, exp_schema, exp_table in zip(strs, schemas, tables):
+        schema, table = civis.io._tables._robust_schema_table_split(s)
+        assert schema == exp_schema
+        assert table == exp_table
+    with pytest.raises(ValueError):
+        s = "table_no_schema"
+        schema, table = civis.io._tables._robust_schema_table_split(s)


### PR DESCRIPTION
Fixes #219.  This PR allows users to pass in tables that contain periods in the schema and/or tablename, so long as they are in double quotes (as is the SQL convention).  For instance `schema."my.table"` or `"sch.ma"."tab.le"`.

If a user passes `table` without a schema, there will now be a more helpful error as well.