### PR TITLE
ENH Public schema/tablename-splitting function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added more robust parsing for tablename parsing in io.  You may now
   pass in tables like schema."tablename.with.periods".
 
+### Added
+- Added a utility function which can robustly split a Redshift schema name
+  and table name which are presented as a single string joined by a "." (#225)
+
 ## 1.8.1 - 2018-02-01
 ### Added
 - Added a script for integration tests (smoke tests).

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -209,7 +209,7 @@ class MetaMixin():
             If an exact table match can't be found.
         """
         database_id = self.get_database_id(database)
-        schema, name = civis.io._robust_schema_table_split(table)
+        schema, name = civis.io.split_schema_tablename(table)
         tables = self.tables.list(database_id=database_id, schema=schema,
                                   name=name)
         if not tables:

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1015,4 +1015,4 @@ def split_schema_tablename(table):
         raise ValueError("Cannot parse schema and table. "
                          "Does '{}' follow the pattern 'schema.table'?"
                          .format(table))
-    return schema_name_tup
+    return tuple(schema_name_tup)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -37,7 +37,7 @@ CHUNK_SIZE = 32 * 1024
 log = logging.getLogger(__name__)
 __all__ = ['read_civis', 'read_civis_sql', 'civis_to_csv',
            'civis_to_multifile_csv', 'dataframe_to_civis', 'csv_to_civis',
-           'civis_file_to_table']
+           'civis_file_to_table', 'split_schema_tablename']
 
 DELIMITERS = {
     ',': 'comma',
@@ -632,7 +632,7 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
         to_csv_kwargs = {'encoding': 'utf-8', 'index': False}
         to_csv_kwargs.update(kwargs)
         df.to_csv(tmp_path, **to_csv_kwargs)
-        _, name = _robust_schema_table_split(table)
+        _, name = split_schema_tablename(table)
         file_id = file_to_civis(tmp_path, name, client=client)
 
     delimiter = ','
@@ -813,7 +813,9 @@ def civis_file_to_table(file_id, database, table, client=None,
     if client is None:
         client = APIClient(resources='all')
 
-    schema, table = _robust_schema_table_split(table)
+    schema, table = split_schema_tablename(table)
+    if schema is None:
+        raise ValueError("Provide a schema as part of the `table` input.")
     db_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
     delimiter = DELIMITERS.get(delimiter)
@@ -978,12 +980,37 @@ def _download_callback(job_id, run_id, filename, headers, compression):
     return callback
 
 
-def _robust_schema_table_split(table):
+def split_schema_tablename(table):
+    """Split a Redshift 'schema.tablename' string
+
+    Remember that special characters (such as '.') can only
+    be included in a schema or table name if delimited by double-quotes.
+
+    Parameters
+    ----------
+    table: str
+        Either a Redshift schema and table name combined
+        with a ".", or else a single table name.
+
+    Returns
+    -------
+    schema, tablename
+        A 2-tuple of strings. The ``schema`` may be None if the input
+        is only a table name, but the ``tablename`` will always be filled.
+
+    Raises
+    ------
+    ValueError
+        If the input ``table`` is not separable into a schema and
+        table name.
+    """
     reader = csv.reader(StringIO(six.text_type(table)),
                         delimiter=".",
                         doublequote=True,
                         quotechar='"')
     schema_name_tup = next(reader)
+    if len(schema_name_tup) == 1:
+        schema_name_tup = (None, schema_name_tup[0])
     if len(schema_name_tup) != 2:
         raise ValueError("Cannot parse schema and table. "
                          "Does '{}' follow the pattern 'schema.table'?"

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -411,11 +411,11 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
     ('schema."tab""le."', ['schema', 'tab"le.']),
     ('table_with_no_schema', [None, 'table_with_no_schema']),
 ])
-def test_robust_schema_table_split(table, expected):
+def test_split_schema_tablename(table, expected):
     assert civis.io._tables.split_schema_tablename(table) == expected
 
 
-def test_robust_schema_table_split_raises():
+def test_split_schema_tablename_raises():
     s = "table.with.too.many.periods"
     with pytest.raises(ValueError):
         civis.io._tables.split_schema_tablename(s)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -408,13 +408,14 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
     ('schema."t.able"', ['schema', 't.able']),
     ('schema.table"', ['schema', 'table"']),
     ('"sch.ema"."t.able"', ['sch.ema', 't.able']),
-    ('schema."tab""le."', ['schema', 'tab"le.'])
+    ('schema."tab""le."', ['schema', 'tab"le.']),
+    ('table_with_no_schema', [None, 'table_with_no_schema']),
 ])
 def test_robust_schema_table_split(table, expected):
-    assert civis.io._tables._robust_schema_table_split(table) == expected
+    assert civis.io._tables.split_schema_tablename(table) == expected
 
 
 def test_robust_schema_table_split_raises():
-    s = "table_with_no_schema"
+    s = "table.with.too.many.periods"
     with pytest.raises(ValueError):
-        schema, table = civis.io._tables._robust_schema_table_split(s)
+        civis.io._tables.split_schema_tablename(s)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -404,12 +404,12 @@ def test_file_to_civis(mock_open, mock_file_to_civis_helper):
 
 
 @pytest.mark.parametrize("table,expected", [
-    ('schema.table', ['schema', 'table']),
-    ('schema."t.able"', ['schema', 't.able']),
-    ('schema.table"', ['schema', 'table"']),
-    ('"sch.ema"."t.able"', ['sch.ema', 't.able']),
-    ('schema."tab""le."', ['schema', 'tab"le.']),
-    ('table_with_no_schema', [None, 'table_with_no_schema']),
+    ('schema.table', ('schema', 'table')),
+    ('schema."t.able"', ('schema', 't.able')),
+    ('schema.table"', ('schema', 'table"')),
+    ('"sch.ema"."t.able"', ('sch.ema', 't.able')),
+    ('schema."tab""le."', ('schema', 'tab"le.')),
+    ('table_with_no_schema', (None, 'table_with_no_schema')),
 ])
 def test_split_schema_tablename(table, expected):
     assert civis.io._tables.split_schema_tablename(table) == expected


### PR DESCRIPTION
The `_robust_schema_table_split` is pretty useful, and users may wish to use it themselves. Promote to a public function with a clearer name. Also modify the function so that a single table name, without a schema, is a valid input. In such a case, return `None` for the schema name.

Closes #223 .

I'm open to name suggestions, or if this function should live in a different namespace. Or if you think that the function shouldn't be public after all.