### PR TITLE
MAINT Add changelog rule to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 civis/tests/cassettes/*.yaml -diff
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   and table name which are presented as a single string joined by a "." (#225)
 - Added docstrings for `civis.find` and `civis.find_one`. (#224)
 
+### Changed
+- Added a merge rule for the changelog to .gitattributes (#229)
+
 ## 1.8.1 - 2018-02-01
 ### Added
 - Added a script for integration tests (smoke tests).


### PR DESCRIPTION
Let git know how we prefer to merge changelogs; this will mean fewer merge conflicts for contributors.