### PR TITLE
DOC: Adding missing function documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Added more robust parsing for tablename parsing in io.  You may now
   pass in tables like schema."tablename.with.periods".
+- Adding in missing documentation for civis_file_to_table
 
 ### Added
 - Added a utility function which can robustly split a Redshift schema name

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -21,6 +21,7 @@ from Civis will all be treated as strings.
 
    civis_to_csv
    civis_to_multifile_csv
+   civis_file_to_table
    csv_to_civis
    dataframe_to_civis
    read_civis


### PR DESCRIPTION
Looks like we forgot to add a line to the docs about this function.  I imagine there is a way to programmatically add all function from a namespace, we might want to look into that in the future.