### PR TITLE
WIP: Adding in cache invalidation for get_api_spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### Changed
+- The caches used in generate_classes and get_api_spec will now invalidate
+  after a period of time to prevent stale API specs in long running Python
+  instances (after 10 hours and 5 hours, respectively).
+
 ### Fixed
 - Added more robust parsing for tablename parsing in io.  You may now
   pass in tables like schema."tablename.with.periods".

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ six>=1.10,<=1.99
 joblib~=0.11
 pubnub~=4
 cloudpickle~=0.2
+cachetools>=2.0.1


### PR DESCRIPTION
This adds a timer to the api spec cache in `generate_classes`.  Effectively this means that calls to `APIClient()` will now poll for a new api spec if the call is made 10 hours after the first call.

Resolves #233.

TODO:

- [ ] Pass integration tests