### PR TITLE
ENH Include parent job and run ID in children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added a utility function which can robustly split a Redshift schema name
   and table name which are presented as a single string joined by a "." (#225)
 - Added docstrings for `civis.find` and `civis.find_one`. (#224)
+- Executors in ``futures`` (and the joblib backend, which uses them) will now
+  add "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables
+  to the child jobs they create (#236)
 
 ### Changed
 - Switched to pip install-ing dependencies for building the documentation (#230)

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -476,6 +476,13 @@ class _ContainerShellExecutor(_CivisExecutor):
     with necessary changes for parallelizing over different Container
     Script inputs rather than over functions.
 
+    Jobs created through this executor will have environment variables
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
+    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
+    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    environment variables available, the child will not have
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+
     .. note:: If you expect to run a large number of jobs, you may
               wish to set automatic retries of failed jobs
               (via `max_n_retries`) to protect against network and
@@ -587,6 +594,13 @@ class CustomScriptExecutor(_CivisExecutor):
     Each Custom Script will be created from the same template, but may
     use different arguments. This class follows the implementations in
     :ref:`concurrent.futures`.
+
+    If your template has settable parameters "CIVIS_PARENT_JOB_ID" and
+    "CIVIS_PARENT_RUN_ID", then this executor will fill them with the contents
+    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
+    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    environment variables available, the child will not have
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
 
     .. note:: If you expect to run a large number of jobs, you may
               wish to set automatic retries of failed jobs

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -60,6 +60,13 @@ def infer_backend_factory(required_resources=None,
     relevant parameters (e.g. the Docker image) of the container
     it's running inside of.
 
+    Jobs created through this backend will have environment variables
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
+    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
+    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    environment variables available, the child will not have
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+
     .. note:: This function will read the state of the parent
               container job at the time this function executes. If the
               user has modified the container job since the run started
@@ -228,6 +235,13 @@ def make_backend_factory(docker_image_name="civisanalytics/datascience-python",
                          **kwargs):
     """Create a joblib backend factory that uses Civis Container Scripts
 
+    Jobs created through this backend will have environment variables
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
+    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
+    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    environment variables available, the child will not have
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+
     .. note:: The total size of function parameters in `Parallel()`
               calls on this backend must be less than 5 GB due to
               AWS file size limits.
@@ -391,6 +405,13 @@ def make_backend_template_factory(from_template_id,
                                   max_job_retries=0,
                                   hidden=True):
     """Create a joblib backend factory that uses Civis Custom Scripts.
+
+    If your template has settable parameters "CIVIS_PARENT_JOB_ID" and
+    "CIVIS_PARENT_RUN_ID", then this executor will fill them with the contents
+    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
+    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    environment variables available, the child will not have
+    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
 
     Parameters
     ----------

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -106,6 +106,15 @@ to transport code and data from the parent environment to the Civis Platform.
 This means that you may parallelize dynamically-defined functions and classes,
 including lambda functions.
 
+The joblib backend will automatically add environment variables called
+"CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID", holding the values
+of the job and run IDs of the Civis Platform job in which you're
+running the joblib backend (if any). Your functions could use these
+to communicate with the parent job or to recognize that they're in
+a process which has been created by another Civis Platform job.
+However, where possible you should let the joblib backend itself
+transport the return value of the function it's running back to the parent.
+
 Infer backend parameters
 ------------------------
 If you're writing code which will run inside a Civis Container Script, then


### PR DESCRIPTION
It can be useful for child jobs to know which job created them. This injects environment variables into child jobs which give the job and run ID of the creator. Note that the joblib backend uses the `_ContainerShellExecutor` to launch its jobs, so this change affects it as well. Custom scripts will only have parent job and run IDs if the template provides that parameter. There's no way to inject environment variables which the template creator didn't explicitly allow for.