### PR TITLE
BUG Include JSONs in package data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added more robust parsing for tablename parsing in io.  You may now
   pass in tables like schema."tablename.with.periods".
 - Adding in missing documentation for civis_file_to_table
+- Include JSON files with pip distributions (#244)
 
 ### Added
 - Added a utility function which can robustly split a Redshift schema name

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ def main():
         url="https://www.civisanalytics.com",
         description="Access the Civis Platform API",
         packages=find_packages(),
+        include_package_data=True,
         data_files=[(os.path.join('civis', 'tests'),
                      glob(os.path.join('civis', 'tests', '*.json')))],
         long_description=README,


### PR DESCRIPTION
We want to include JSON files with installations of the API client; there are JSON blobs with caches of API endpoints which are useful for testing. The `data_files` argument installs the JSON files when running `python setup.py install`, but they don't come when you run `pip install`. Setting `include_package_data=True` will include everything in the `MANIFEST.in`, including the JSON files.