### PR TITLE
In Which We Flush Buffers After Finishing Writing to Them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   pass in tables like schema."tablename.with.periods".
 - Adding in missing documentation for civis_file_to_table
 - Include JSON files with pip distributions (#244)
+- Added flush to `civis_to_file` when passed a user-created buffer,
+  ensuring the buffer contains the entire file when subsequently read.
 
 ### Added
 - Added a utility function which can robustly split a Redshift schema name

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -303,6 +303,7 @@ def civis_to_file(file_id, buf, api_key=None, client=None):
             _civis_to_file(file_id, f, api_key=api_key, client=client)
     else:
         _civis_to_file(file_id, buf, api_key=api_key, client=client)
+        buf.flush()
 
 
 def _civis_to_file(file_id, buf, api_key=None, client=None):


### PR DESCRIPTION
I'd written some code like
```python
with tempfile.NamedTemporaryFile() as temp:
    civis.io.civis_to_file(file_id, temp)
    df = pandas.read_csv(temp.name)
```
with a bit of extra logic for `read_csv`-ing in chunks to keep from going out of memory.
Because `temp` wasn't being flushed, I would occasionally get errors from unexpected end of files. 

I'm not sure if that's expected behavior or not (if I'm passing the buffer to `civis_to_file` should I be expected to flush it myself?) but flushing them `civis_to_file`-side seems harmless at worst and bug-avoiding at best.

@mheilman 