### PR TITLE
ENH Add CivisML v2.2 template IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Executors in ``futures`` (and the joblib backend, which uses them) will now
   add "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables
   to the child jobs they create (#236)
+- Update default CivisML version to v2.2. This includes a new function
+  ``ModelPipeline.register_pretrained_model`` which allows users to train
+  a model outside of Civis Platform and use CivisML to score it at scale (#242, #247).
 - Added a new parameter ``dvs_to_predict`` to ``civis.ml.ModelPipeline.predict``.
   This allows users to select a subset of a model's outputs for scoring (#241).
 - Added `civis.io.export_to_civis_file` to store results of a SQL query

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -42,10 +42,11 @@ _PRED_TEMPLATES = {10582: 10583,  # v2.1
                    9112: 9113,    # v1.1
                    8387: 9113,    # v1.0
                    7020: 7021,    # v0.5
-                   11028: 10616,  # v2.2 registration CHANGE ME
+                   11219: 11220,  # v2.2
+                   11221: 11220,  # v2.2 registration
                    }
 _CIVISML_TEMPLATE = None  # CivisML training template to use
-REGISTRATION_TEMPLATES = [11028,  # v2.2 CHANGE ME
+REGISTRATION_TEMPLATES = [11221,  # v2.2
                           ]
 
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -39,8 +39,8 @@ import pytest
 from civis.ml import _model
 
 
-LATEST_TRAIN_TEMPLATE = 10582
-LATEST_PRED_TEMPLATE = 10583
+LATEST_TRAIN_TEMPLATE = 11219
+LATEST_PRED_TEMPLATE = 11220
 
 
 def setup_client_mock(script_id=-10, run_id=100, state='succeeded',


### PR DESCRIPTION
The ``ModelPipeline`` will now create v2.2 models in CivisML by default.