### PR TITLE
BUG Fix tests in test_io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Include JSON files with pip distributions (#244)
 - Added flush to `civis_to_file` when passed a user-created buffer,
   ensuring the buffer contains the entire file when subsequently read.
+- Fix several tests in the `test_io` module (#248)
 
 ### Added
 - Added a utility function which can robustly split a Redshift schema name


### PR DESCRIPTION
The `test_civis_to_file_local` function had been writing a file to disk which remained behind after the test. Additionally, `called_once_with` is not a method of a `Mock` object; it becomes its own `Mock`, which takes any paramter given and always evaluates to `True`. Change all instances of those calls to `assert_called_once_with`. Add `autospec` to `patch` calls where possible to test that mocked functions are being called with valid arguments.