### PR TITLE
DOC Coalesce README.rst and index.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10
   environment
-- Coalesced `README.rst` and `index.rst`. (#254)
 
 ### Changed
+- Coalesced `README.rst` and `index.rst`. (#254)
 
 ## 1.9.0 - 2018-04-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10
   environment
+- Coalesced `README.rst` and `index.rst`. (#254)
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -15,21 +15,30 @@ Civis API Python Client
    :target: https://pypi.org/project/civis/
    :alt: Supported python versions for civis-python
 
+
 Introduction
 ------------
+
+.. start-introductory-paragraph
 
 The Civis API Python client is a Python package that helps analysts and
 developers interact with the Civis Platform. The package includes a set of
 tools around common workflows as well as a convenient interface to make
-requests directly to the Civis API. See the
+requests directly to the Civis API.
+
+.. end-introductory-paragraph
+
+Please see the
 `full documentation <https://civis-python.readthedocs.io>`_ for more details.
 
+.. start-api-keys
 
 API Keys
 --------
 
-Usage of ``civis-python`` requires a valid Civis Platform API key, which can
-be created by following the instructions
+In order to make requests to the Civis API,
+you will need a Civis Platform API key that is unique to you.
+Instructions for creating a new key are found
 `here <https://civis.zendesk.com/hc/en-us/articles/216341583-Generating-an-API-Key>`_.
 API keys have a set expiration date and new keys will need to be created at
 least every 30 days. ``civis-python`` will look for a ``CIVIS_API_KEY``
@@ -39,7 +48,7 @@ follow the steps below for your operating system to set up your environment.
 Linux / MacOS
 ~~~~~~~~~~~~~
 
-1. Add the following to ``.bash_profile`` for bash::
+1. Add the following to ``.bash_profile`` (or ``.bashrc`` for Linux) for bash::
 
     export CIVIS_API_KEY="alphaNumericApiK3y"
 
@@ -48,33 +57,36 @@ Linux / MacOS
 Windows 10
 ~~~~~~~~~~
 
-1. Navigate to ``Settings`` -> type "environment" in search bar ->
-   ``Edit environment variables for your account``. This can also be found
-   in ``System Properties`` -> ``Advanced`` -> ``Environment Variables...``.
+1. Navigate to "Settings" -> type "environment" in search bar ->
+   "Edit environment variables for your account". This can also be found
+   in "System Properties" -> "Advanced" -> "Environment Variables...".
 2. In the user variables section, if ``CIVIS_API_KEY`` already exists in
-   the list of environment variables, click on it and press ``Edit...``.
-   Otherwise, click ``New..``.
-3. Enter CIVIS_API_KEY as the ``Variable name``.
-4. Enter your API key as the ``Variable value``.  Your API key should look
+   the list of environment variables, click on it and press "Edit...".
+   Otherwise, click "New..".
+3. Enter CIVIS_API_KEY as the "Variable name".
+4. Enter your API key as the "Variable value".  Your API key should look
    like a long string of letters and numbers.
 
+.. end-api-keys
+
+.. start-installation
 
 Installation
 ------------
 
 After creating an API key and setting the ``CIVIS_API_KEY`` environmental
-variable, install ``civis-python`` with::
+variable, install the Python package ``civis`` with the recommended method via ``pip``::
 
     pip install civis
 
-Optionally, install ``pandas``, and ``pubnub`` to enable some functionality in ``civis-python``::
+Alternatively, if you are interested in the latest functionality not yet released through ``pip``,
+you may clone the code from GitHub and build from source:
 
-    pip install pandas
-    pip install pubnub
+.. code-block:: bash
 
-Installation of ``pandas`` will allow some functions to return ``DataFrame`` outputs.
-Installation of ``pubnub`` will improve performance in all functions which
-wait for a Civis Platform job to complete.
+   git clone https://github.com/civisanalytics/civis-python.git
+   cd civis-python
+   python setup.py install
 
 You can test your installation by running
 
@@ -84,9 +96,57 @@ You can test your installation by running
     client = civis.APIClient()
     print(client.users.list_me()['username'])
 
-If ``civis-python`` was installed correctly, this will print your Civis
+If ``civis`` was installed correctly, this will print your Civis
 Platform username.
 
+The client has a soft dependency on ``pandas`` to support features such as
+data type parsing.  If you are using the ``io`` namespace to read or write
+data from Civis, it is highly recommended that you install ``pandas`` and
+set ``use_pandas=True`` in functions that accept that parameter.  To install
+``pandas``:
+
+.. code-block:: bash
+
+   pip install pandas
+
+Machine learning features in the ``ml`` namespace have a soft dependency on
+``scikit-learn`` and ``pandas``. Install ``scikit-learn`` to
+export your trained models from the Civis Platform or to
+provide your own custom models. Use ``pandas`` to download model predictions
+from the Civis Platform. The ``civis.ml`` code
+optionally uses the `feather <https://github.com/wesm/feather>`_
+format to transfer data from your local computer to Civis
+Platform. Install these dependencies with
+
+.. code-block:: bash
+
+   pip install scikit-learn
+   pip install pandas
+   pip install feather-format
+
+
+Some CivisML models have open-source dependencies in
+addition to ``scikit-learn``, which you may need if you want to
+download the model object. These dependencies are
+``civisml-extensions``, ``glmnet``, and ``muffnn``. Install these
+dependencies with
+
+.. code-block:: bash
+
+   pip install civisml-extensions
+   pip install glmnet
+   pip install muffnn
+
+.. end-installation
+
+.. start-python-version-support
+
+Python version support
+----------------------
+
+Python 2.7, 3.4, 3.5, and 3.6
+
+.. end-python-version-support
 
 Usage
 -----
@@ -112,8 +172,11 @@ The Civis API may also be directly accessed via the ``APIClient`` class.
 See the `full documentation <https://civis-python.readthedocs.io>`_ for a more
 complete user guide.
 
+
+.. start-retries
+
 Retries
-~~~~~~~
+-------
 
 The API client will automatically retry for certain API error responses.
 
@@ -125,6 +188,9 @@ before retrying the request.
 If the error is one of [429, 502, 503, 504] and the request is not a ``patch*`` or ``post*``
 method, then the API client will retry the request several times, with a delay,
 to see if it will succeed.
+
+.. end-retires
+
 
 Build Documentation Locally
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -19,19 +19,19 @@ Civis API Python Client
 Introduction
 ------------
 
-.. start-introductory-paragraph
+.. start-include-marker-introductory-paragraph
 
 The Civis API Python client is a Python package that helps analysts and
 developers interact with the Civis Platform. The package includes a set of
 tools around common workflows as well as a convenient interface to make
 requests directly to the Civis API.
 
-.. end-introductory-paragraph
+.. end-include-marker-introductory-paragraph
 
 Please see the
 `full documentation <https://civis-python.readthedocs.io>`_ for more details.
 
-.. start-api-keys-section
+.. start-include-marker-api-keys-section
 
 API Keys
 --------
@@ -67,9 +67,9 @@ Windows 10
 4. Enter your API key as the "Variable value".  Your API key should look
    like a long string of letters and numbers.
 
-.. end-api-keys-section
+.. end-include-marker-api-keys-section
 
-.. start-installation-section
+.. start-include-marker-installation-section
 
 Installation
 ------------
@@ -137,16 +137,16 @@ dependencies with
    pip install glmnet
    pip install muffnn
 
-.. end-installation-section
+.. end-include-marker-installation-section
 
-.. start-python-version-support-section
+.. start-include-marker-python-version-support-section
 
 Python version support
 ----------------------
 
 Python 2.7, 3.4, 3.5, and 3.6
 
-.. end-python-version-support-section
+.. end-include-marker-python-version-support-section
 
 Usage
 -----
@@ -173,7 +173,7 @@ See the `full documentation <https://civis-python.readthedocs.io>`_ for a more
 complete user guide.
 
 
-.. start-retries-section
+.. start-include-marker-retries-section
 
 Retries
 -------
@@ -189,7 +189,7 @@ If the error is one of [429, 502, 503, 504] and the request is not a ``patch*`` 
 method, then the API client will retry the request several times, with a delay,
 to see if it will succeed.
 
-.. end-retires-section
+.. end-include-marker-retires-section
 
 
 Build Documentation Locally

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ requests directly to the Civis API.
 Please see the
 `full documentation <https://civis-python.readthedocs.io>`_ for more details.
 
-.. start-api-keys
+.. start-api-keys-section
 
 API Keys
 --------
@@ -41,7 +41,7 @@ you will need a Civis Platform API key that is unique to you.
 Instructions for creating a new key are found
 `here <https://civis.zendesk.com/hc/en-us/articles/216341583-Generating-an-API-Key>`_.
 API keys have a set expiration date and new keys will need to be created at
-least every 30 days. ``civis-python`` will look for a ``CIVIS_API_KEY``
+least every 30 days. The API client will look for a ``CIVIS_API_KEY``
 environmental variable to access your API key, so after creating a new API key,
 follow the steps below for your operating system to set up your environment.
 
@@ -67,9 +67,9 @@ Windows 10
 4. Enter your API key as the "Variable value".  Your API key should look
    like a long string of letters and numbers.
 
-.. end-api-keys
+.. end-api-keys-section
 
-.. start-installation
+.. start-installation-section
 
 Installation
 ------------
@@ -137,21 +137,21 @@ dependencies with
    pip install glmnet
    pip install muffnn
 
-.. end-installation
+.. end-installation-section
 
-.. start-python-version-support
+.. start-python-version-support-section
 
 Python version support
 ----------------------
 
 Python 2.7, 3.4, 3.5, and 3.6
 
-.. end-python-version-support
+.. end-python-version-support-section
 
 Usage
 -----
 
-``civis-python`` includes a number of wrappers around the Civis API for
+``civis`` includes a number of wrappers around the Civis API for
 common workflows.
 
 .. code-block:: python
@@ -173,7 +173,7 @@ See the `full documentation <https://civis-python.readthedocs.io>`_ for a more
 complete user guide.
 
 
-.. start-retries
+.. start-retries-section
 
 Retries
 -------
@@ -189,7 +189,7 @@ If the error is one of [429, 502, 503, 504] and the request is not a ``patch*`` 
 method, then the API client will retry the request several times, with a delay,
 to see if it will succeed.
 
-.. end-retires
+.. end-retires-section
 
 
 Build Documentation Locally

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,23 +5,23 @@ Civis API Python Client
 
 
 .. include:: ../../README.rst
-  :start-after: start-introductory-paragraph
-  :end-before: end-introductory-paragraph
+  :start-after: start-include-marker-introductory-paragraph
+  :end-before: end-include-marker-introductory-paragraph
 
 
 .. include:: ../../README.rst
-  :start-after: start-api-keys-section
-  :end-before: end-api-keys-section
+  :start-after: start-include-marker-api-keys-section
+  :end-before: end-include-marker-api-keys-section
 
 
 .. include:: ../../README.rst
-  :start-after: start-installation-section
-  :end-before: end-installation-section
+  :start-after: start-include-marker-installation-section
+  :end-before: end-include-marker-installation-section
 
 
 .. include:: ../../README.rst
-  :start-after: start-python-version-support-section
-  :end-before: end-python-version-support-section
+  :start-after: start-include-marker-python-version-support-section
+  :end-before: end-include-marker-python-version-support-section
 
 
 User Guide
@@ -31,8 +31,8 @@ For a more detailed walkthrough, see the :ref:`user_guide`.
 
 
 .. include:: ../../README.rst
-  :start-after: start-retries-section
-  :end-before: end-retires-section
+  :start-after: start-include-marker-retries-section
+  :end-before: end-include-marker-retires-section
 
 
 Client API Reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,18 +10,18 @@ Civis API Python Client
 
 
 .. include:: ../../README.rst
-  :start-after: start-api-keys
-  :end-before: end-api-keys
+  :start-after: start-api-keys-section
+  :end-before: end-api-keys-section
 
 
 .. include:: ../../README.rst
-  :start-after: start-installation
-  :end-before: end-installation
+  :start-after: start-installation-section
+  :end-before: end-installation-section
 
 
 .. include:: ../../README.rst
-  :start-after: start-python-version-support
-  :end-before: end-python-version-support
+  :start-after: start-python-version-support-section
+  :end-before: end-python-version-support-section
 
 
 User Guide
@@ -31,8 +31,8 @@ For a more detailed walkthrough, see the :ref:`user_guide`.
 
 
 .. include:: ../../README.rst
-  :start-after: start-retries
-  :end-before: end-retries
+  :start-after: start-retries-section
+  :end-before: end-retires-section
 
 
 Client API Reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,117 +3,36 @@
 Civis API Python Client
 =======================
 
-The Civis API Python client is a Python package that helps analysts and
-developers interact with the Civis Platform. The package includes a set of
-tools around common workflows as well as a convenient interface to make
-requests directly to the Civis API.
+
+.. include:: ../../README.rst
+  :start-after: start-introductory-paragraph
+  :end-before: end-introductory-paragraph
 
 
-Installation
-------------
-
-The recommended install method is pip:
-
-.. code-block:: bash
-
-   pip install civis
-
-Alternatively, you may clone the code from GitHub and build from source:
-
-.. code-block:: bash
-
-   git clone https://github.com/civisanalytics/civis-python.git
-   cd civis-python
-   python setup.py install
-
-The client has a soft dependency on ``pandas`` to support features such as
-data type parsing.  If you are using the ``io`` namespace to read or write
-data from Civis, it is highly recommended that you install ``pandas`` and
-set ``use_pandas=True`` in functions that accept that parameter.  To install
-``pandas``:
-
-.. code-block:: bash
-
-   pip install pandas
-
-Machine learning features in the ``ml`` namespace have a soft dependency on
-``scikit-learn`` and ``pandas``. Install ``scikit-learn`` to
-export your trained models from the Civis Platform or to
-provide your own custom models. Use ``pandas`` to download model predictions
-from the Civis Platform. The ``civis.ml`` code
-optionally uses the `feather <https://github.com/wesm/feather>`_
-format to transfer data from your local computer to Civis
-Platform. Install these dependencies with
-
-.. code-block:: bash
-
-   pip install scikit-learn
-   pip install pandas
-   pip install feather-format
+.. include:: ../../README.rst
+  :start-after: start-api-keys
+  :end-before: end-api-keys
 
 
-Some CivisML models have open-source dependencies in
-addition to ``scikit-learn``, which you may need if you want to
-download the model object. These dependencies are
-``civisml-extensions``, ``glmnet``, and ``muffnn``. Install these
-dependencies with
-   
-.. code-block:: bash
-
-   pip install civisml-extensions
-   pip install glmnet
-   pip install muffnn
+.. include:: ../../README.rst
+  :start-after: start-installation
+  :end-before: end-installation
 
 
-Python version support
-----------------------
-
-Python 2.7, 3.4, 3.5, and 3.6
-
-
-Authentication
---------------
-
-In order to make requests to the Civis API, you will need an API key that is
-unique to you. Instructions for creating a new key are found here:
-https://civis.zendesk.com/hc/en-us/articles/216341583-Generating-an-API-Key.
-By default, the Python client will look for your key in the environment
-variable ``CIVIS_API_KEY``. To add the API key to your environment, copy
-the key you generated to your clipboard and follow the instructions below
-for your operating system.
-
-**Mac**
-
-Open ``.bash_profile`` in TextEdit:
-
-.. code-block:: bash
-
-   cd ~/
-   touch .bash_profile
-   open -e .bash_profile
-
-Then add the following line, replacing ``api_key_here`` with your key::
-
-   export CIVIS_API_KEY="api_key_here"
-
-**Linux**
-
-Open ``.bashrc`` in your favorite editor (nano is used here):
-
-.. code-block:: bash
-
-   cd ~/
-   nano .bashrc
-
-Then add the following line, replacing ``api_key_here`` with your key::
-
-   export CIVIS_API_KEY="api_key_here"
+.. include:: ../../README.rst
+  :start-after: start-python-version-support
+  :end-before: end-python-version-support
 
 
 User Guide
 ----------
 
 For a more detailed walkthrough, see the :ref:`user_guide`.
+
+
+.. include:: ../../README.rst
+  :start-after: start-retries
+  :end-before: end-retries
 
 
 Client API Reference


### PR DESCRIPTION
This PR merges the repo's top-level `README.rst` and the Sphinx docs-specifics `index.rst`. The end result is that `README.rst` is the single source of truth for such items as installation and API keys, whereas `index.rst` is now minimal and contains (i) markers that draw text from `README.rst` and (ii) items specific to Sphinx docs such as `toctree`.

For the new `README.rst`, please check it out at my fork: https://github.com/jacksonllee/civis-python/blob/coalesce-readme-index-rst/README.rst

For the new `index.rst`, the compiled Sphinx docs will look like this:

![python-client-sphinx-docs](https://user-images.githubusercontent.com/6993153/39940991-bb8de210-5520-11e8-8f0e-7aac990134d5.gif)

Resolves #253.