### PR TITLE
Ensure DataFrame import successfully occurs

### DIFF
--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -14,8 +14,10 @@ try:
 except ImportError:
     has_pandas = False
 
+import numpy as np
+
 import civis
-from civis.io import _files
+from civis.io import _files, _tables
 from civis.compat import mock, FileNotFoundError, TemporaryDirectory
 from civis.response import Response
 from civis.base import CivisAPIError
@@ -496,3 +498,52 @@ def test_sql_script():
         hidden=False,
         csv_settings={})
     mock_client.scripts.post_sql_runs.assert_called_once_with(export_job_id)
+
+
+def test_clean_text_plain():
+    """ Test clean_text with plain strings """
+
+    test_text = 'foo'
+    assert test_text == _tables.clean_text(test_text)
+
+    test_text = 'foo bar'
+    assert test_text == _tables.clean_text(test_text)
+
+    test_text = 'foo \\ bar'
+    assert test_text == _tables.clean_text(test_text)
+
+    test_text = 'foo " bar'
+    assert test_text == _tables.clean_text(test_text)
+
+
+def test_clean_text_ending_backslash():
+    """ Test clean_text with ending backslash """
+    test_text = 'foo\\'
+    expected_result = 'foo\\ '
+
+    assert expected_result == _tables.clean_text(test_text)
+
+
+def test_clean_text_backslash_double_quote():
+    """ Test clean_text with backslash before double quote """
+
+    test_text = 'foo\\"'
+    expected_result = 'foo\\ "'
+
+    assert expected_result == _tables.clean_text(test_text)
+
+    test_text = 'foo\\"\\'
+    expected_result = 'foo\\ "\\ '
+
+    assert expected_result == _tables.clean_text(test_text)
+
+
+def test_clean_text_nan():
+    """ Test clean_text with nan """
+    expected_result = ''
+
+    test_text = np.NaN
+    assert expected_result == _tables.clean_text(test_text)
+
+    test_text = None
+    assert expected_result == _tables.clean_text(test_text)


### PR DESCRIPTION
This is related to this ongoing JIRA

https://civisanalytics.atlassian.net/browse/CIVP-12730

Platform import simply can't handle files that have a `/"` anywhere in the file.

If a double quote is escaped with a backslash, the import fails.
If a file has fields enclosed by double quotes and any field ends with a `/`, the import fails.

This PR does two things to ensure a DataFrame will be succesfully imported via API:
1. Cleans dataframe fields by inserting a space in between a backslash and double quotesand inserts a space at the end of any string that ends with a backslash.
2. Exports the DataFrame to CSV with | as the delimiter, doublequotes doubled up to escape, `\` as the escapechar and all fields enclosed in double quotes and imports it into platform with the same parameters.

There may be a broader goal of preparing any file (including already existing CSVs) in this fashion to ensure successful import to Platform but for now, this only addresses the dataframe to Civis situation.

I've encountered this bug while writing the Classy & MobileCommons integrations and wrote a modified version of dataframe_to_civis to handle the `/"` problems. This PR brings over the changes that have been succesfully importing data from those system.

I've included tests for the clean_text function.