### PR TITLE
BUG A file-like object as arg to df.to_csv must have the method getvalue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
+- `_stash_dataframe_as_csv` in `civis/ml/_model.py` now uses a `StringIO`
+  object which has the `getvalue` method (required by `pandas` v0.23.1
+  if a file-like object is passed into `df.to_csv`). (#259)
 
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -3,7 +3,6 @@
 import builtins
 from builtins import super
 from collections import namedtuple
-import io
 import json
 import logging
 import os

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -125,15 +125,14 @@ def _stash_dataframe_as_feather(df, client):
 
 def _stash_dataframe_as_csv(df, client):
     civis_fname = 'modelpipeline_data.csv'
-    buf = six.BytesIO()
     if six.PY3:
-        txt = io.TextIOWrapper(buf, encoding='utf-8')
+        txt = io.StringIO()
     else:
-        txt = buf
+        txt = six.BytesIO()
     df.to_csv(txt, encoding='utf-8', index=False)
     txt.flush()
-    buf.seek(0)
-    file_id = cio.file_to_civis(buf, name=civis_fname, client=client)
+    txt.seek(0)
+    file_id = cio.file_to_civis(txt, name=civis_fname, client=client)
 
     return file_id
 

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -126,7 +126,7 @@ def _stash_dataframe_as_feather(df, client):
 def _stash_dataframe_as_csv(df, client):
     civis_fname = 'modelpipeline_data.csv'
     if six.PY3:
-        txt = io.StringIO()
+        txt = six.StringIO()
     else:
         txt = six.BytesIO()
     df.to_csv(txt, encoding='utf-8', index=False)

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1,12 +1,12 @@
 from builtins import super
 from collections import namedtuple
 from concurrent.futures import CancelledError
+from six import StringIO
 import json
 import os
 import pickle
 import tempfile
 
-import six
 import joblib
 try:
     import pandas as pd
@@ -173,7 +173,7 @@ def test_stash_local_data_from_dataframe_csv(mock_file):
     assert _model._stash_dataframe_as_csv(df, mock.Mock()) == -11
     mock_file.assert_called_once_with(mock.ANY, name='modelpipeline_data.csv',
                                       client=mock.ANY)
-    assert isinstance(mock_file.call_args[0][0], six.StringIO)
+    assert isinstance(mock_file.call_args[0][0], StringIO)
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -5,8 +5,8 @@ import json
 import os
 import pickle
 import tempfile
-import io
 
+import six
 import joblib
 try:
     import pandas as pd
@@ -173,7 +173,7 @@ def test_stash_local_data_from_dataframe_csv(mock_file):
     assert _model._stash_dataframe_as_csv(df, mock.Mock()) == -11
     mock_file.assert_called_once_with(mock.ANY, name='modelpipeline_data.csv',
                                       client=mock.ANY)
-    assert isinstance(mock_file.call_args[0][0], io.StringIO)
+    assert isinstance(mock_file.call_args[0][0], six.StringIO)
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1,11 +1,11 @@
 from builtins import super
 from collections import namedtuple
 from concurrent.futures import CancelledError
-from six import BytesIO
 import json
 import os
 import pickle
 import tempfile
+import io
 
 import joblib
 try:
@@ -173,7 +173,7 @@ def test_stash_local_data_from_dataframe_csv(mock_file):
     assert _model._stash_dataframe_as_csv(df, mock.Mock()) == -11
     mock_file.assert_called_once_with(mock.ANY, name='modelpipeline_data.csv',
                                       client=mock.ANY)
-    assert isinstance(mock_file.call_args[0][0], BytesIO)
+    assert isinstance(mock_file.call_args[0][0], io.StringIO)
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")


### PR DESCRIPTION
Since `pandas` v0.23.1 (specifically from https://github.com/pandas-dev/pandas/pull/21300), if a file-like object is passed into `df.to_csv`, the object must have the method `getvalue`, or else an `AttributeError` is raised (which is what we have observed from #258). An `io.TextIOWrapper` object doesn't have the method `getvalue`, which caused the latest build failures in #258. This PR switches to `io.StringIO` instead.