### PR TITLE
MAINT Configure Windows CI using AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10
   environment
+- Configured Windows CI using AppVeyor. (#258)
 
 ### Changed
 - Coalesced `README.rst` and `index.rst`. (#254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - `_stash_dataframe_as_csv` in `civis/ml/_model.py` now uses a `StringIO`
   object which has the `getvalue` method (required by `pandas` v0.23.1
-  if a file-like object is passed into `df.to_csv`). (#259)
+  if a file-like object is passed into `df.to_csv`). (#260)
 
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+build: false  # Not a .NET project
+
+
+environment:
+  # For python environments: https://www.appveyor.com/docs/build-environment/#python
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.15"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.4"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.3"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.5"
+      PYTHON_ARCH: "64"
+
+  # Environmental variables
+  CIVIS_API_KEY: "FOOBAR"
+
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+
+install:
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"
+  - "%PYTHON%\\python.exe -m pip install -r dev-requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install -e ."
+
+
+test_script:
+  - "%PYTHON%\\Scripts\\flake8.exe civis"
+  - "%PYTHON%\\Scripts\\pytest.exe -rxXs --cov civis"

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -5,7 +5,6 @@ from six import BytesIO
 import json
 import os
 import pickle
-import tempfile
 import uuid
 
 import joblib

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import tempfile
+import uuid
 
 import joblib
 try:
@@ -143,8 +144,8 @@ def test_block_and_handle_missing(mock_fut):
 
 @mock.patch.object(_model.cio, 'file_to_civis', return_value=-11)
 def test_stash_local_data_from_file(mock_file):
-    with tempfile.NamedTemporaryFile() as tempfname:
-        fname = tempfname.name
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fname = os.path.join(temp_dir, str(uuid.uuid4()))
         with open(fname, 'wt') as _fout:
             _fout.write("a,b,c\n1,2,3\n")
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -5,7 +5,6 @@ from six import BytesIO
 import json
 import os
 import pickle
-import uuid
 
 import joblib
 try:
@@ -144,7 +143,7 @@ def test_block_and_handle_missing(mock_fut):
 @mock.patch.object(_model.cio, 'file_to_civis', return_value=-11)
 def test_stash_local_data_from_file(mock_file):
     with TemporaryDirectory() as temp_dir:
-        fname = os.path.join(temp_dir, str(uuid.uuid4()))
+        fname = os.path.join(temp_dir, 'tempfile')
         with open(fname, 'wt') as _fout:
             _fout.write("a,b,c\n1,2,3\n")
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -33,7 +33,7 @@ except ImportError:
 from civis import APIClient
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
-from civis.compat import mock, FileNotFoundError
+from civis.compat import mock, FileNotFoundError, TemporaryDirectory
 from civis.response import Response
 import pytest
 
@@ -144,7 +144,7 @@ def test_block_and_handle_missing(mock_fut):
 
 @mock.patch.object(_model.cio, 'file_to_civis', return_value=-11)
 def test_stash_local_data_from_file(mock_file):
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with TemporaryDirectory() as temp_dir:
         fname = os.path.join(temp_dir, str(uuid.uuid4()))
         with open(fname, 'wt') as _fout:
             _fout.write("a,b,c\n1,2,3\n")

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -98,8 +98,6 @@ class ImportTests(CivisVCRTestCase):
 
             cls.export_job_id = result.sql_id
 
-    @pytest.mark.skipif(sys.platform.startswith('win'),
-                        reason='does not work yet for Windows')  # TODO
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -99,7 +99,7 @@ class ImportTests(CivisVCRTestCase):
 
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
             tmp = open(fname, 'w+b')
             with zipfile.ZipFile(tmp, 'w', zipfile.ZIP_DEFLATED) as zip_file:
@@ -151,7 +151,7 @@ class ImportTests(CivisVCRTestCase):
 
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_csv_to_civis(self, *mocks):
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
             tmp = open(fname, 'w+b')
             tmp.write(b'a,b,c\n1,2,3')
@@ -270,7 +270,7 @@ class ImportTests(CivisVCRTestCase):
 
     def test_download_file(self, *mocks):
         expected = '"1","2","3"\n'
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
             tmp = open(fname, 'w+b')
             civis.io._tables._download_file(self.export_url, tmp.name,

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -133,12 +133,11 @@ class ImportTests(CivisVCRTestCase):
         civis.io._files.MIN_MULTIPART_SIZE = 1
         with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
-            tmp = open(fname, 'w+b')
-            tmp.write(b'a,b,c\n1,2,3')
-            tmp.flush()
-            tmp.seek(0)
-            result = civis.io.file_to_civis(tmp, fname)
-            tmp.close()
+            with open(fname, 'w+b') as tmp:
+                tmp.write(b'a,b,c\n1,2,3')
+                tmp.flush()
+                tmp.seek(0)
+                result = civis.io.file_to_civis(tmp, fname)
 
             civis.io._files.MIN_MULTIPART_SIZE = curr_size
 
@@ -155,10 +154,9 @@ class ImportTests(CivisVCRTestCase):
     def test_csv_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
-            tmp = open(fname, 'w+b')
-            tmp.write(b'a,b,c\n1,2,3')
-            tmp.flush()
-            tmp.close()
+            with open(fname, 'w+b') as tmp:
+                tmp.write(b'a,b,c\n1,2,3')
+                tmp.flush()
 
             table = "scratch.api_client_test_fixture"
             database = 'redshift-general'

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -4,6 +4,7 @@ import os
 from six import StringIO, BytesIO
 import tempfile
 import zipfile
+import uuid
 
 import pytest
 import vcr
@@ -98,7 +99,9 @@ class ImportTests(CivisVCRTestCase):
 
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
-        with tempfile.NamedTemporaryFile() as tmp:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            tmp = open(fname, 'w+b')
             with zipfile.ZipFile(tmp, 'w', zipfile.ZIP_DEFLATED) as zip_file:
                 zip_file.writestr(tmp.name, 'a,b,c\n1,2,3')
                 zip_member = zip_file.namelist()[0]
@@ -148,7 +151,9 @@ class ImportTests(CivisVCRTestCase):
 
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_csv_to_civis(self, *mocks):
-        with tempfile.NamedTemporaryFile() as tmp:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            tmp = open(fname, 'w+b')
             tmp.write(b'a,b,c\n1,2,3')
             tmp.flush()
 
@@ -265,7 +270,9 @@ class ImportTests(CivisVCRTestCase):
 
     def test_download_file(self, *mocks):
         expected = '"1","2","3"\n'
-        with tempfile.NamedTemporaryFile() as tmp:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            tmp = open(fname, 'w+b')
             civis.io._tables._download_file(self.export_url, tmp.name,
                                             b'', 'none')
             with open(tmp.name, "r") as f:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -98,7 +98,8 @@ class ImportTests(CivisVCRTestCase):
 
             cls.export_job_id = result.sql_id
 
-    @pytest.mark.skipif(sys.platform.startswith('win'))  # TODO
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason='does not work yet for Windows')  # TODO
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -4,7 +4,6 @@ import os
 from six import StringIO, BytesIO
 import zipfile
 import uuid
-import sys
 
 import pytest
 import vcr

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -138,6 +138,7 @@ class ImportTests(CivisVCRTestCase):
             tmp.flush()
             tmp.seek(0)
             result = civis.io.file_to_civis(tmp, fname)
+            tmp.close()
 
             civis.io._files.MIN_MULTIPART_SIZE = curr_size
 
@@ -157,6 +158,7 @@ class ImportTests(CivisVCRTestCase):
             tmp = open(fname, 'w+b')
             tmp.write(b'a,b,c\n1,2,3')
             tmp.flush()
+            tmp.close()
 
             table = "scratch.api_client_test_fixture"
             database = 'redshift-general'

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -3,7 +3,6 @@ import json
 import os
 from six import StringIO, BytesIO
 import zipfile
-import uuid
 
 import pytest
 import vcr
@@ -86,7 +85,7 @@ class ImportTests(CivisVCRTestCase):
 
             # create an export to check get_url. also tests export_csv
             with TemporaryDirectory() as temp_dir:
-                fname = os.path.join(temp_dir, str(uuid.uuid4()))
+                fname = os.path.join(temp_dir, 'tempfile')
                 sql = "SELECT * FROM scratch.api_client_test_fixture"
                 database = 'redshift-general'
                 result = civis.io.civis_to_csv(fname, sql, database,
@@ -100,9 +99,9 @@ class ImportTests(CivisVCRTestCase):
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:
-            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            fname = os.path.join(temp_dir, 'tempfile')
             with zipfile.ZipFile(fname, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-                archive_name = str(uuid.uuid4())
+                archive_name = 'archive_name'
                 zip_file.writestr(archive_name, 'a,b,c\n1,2,3')
                 zip_member = zip_file.namelist()[0]
                 with zip_file.open(zip_member) as zip_member_buf:
@@ -133,7 +132,7 @@ class ImportTests(CivisVCRTestCase):
         curr_size = civis.io._files.MIN_MULTIPART_SIZE
         civis.io._files.MIN_MULTIPART_SIZE = 1
         with TemporaryDirectory() as temp_dir:
-            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            fname = os.path.join(temp_dir, 'tempfile')
             with open(fname, 'w+b') as tmp:
                 tmp.write(b'a,b,c\n1,2,3')
                 tmp.flush()
@@ -154,7 +153,7 @@ class ImportTests(CivisVCRTestCase):
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_csv_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:
-            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            fname = os.path.join(temp_dir, 'tempfile')
             with open(fname, 'w+b') as tmp:
                 tmp.write(b'a,b,c\n1,2,3')
                 tmp.flush()
@@ -273,7 +272,7 @@ class ImportTests(CivisVCRTestCase):
     def test_download_file(self, *mocks):
         expected = '"1","2","3"\n'
         with TemporaryDirectory() as temp_dir:
-            fname = os.path.join(temp_dir, str(uuid.uuid4()))
+            fname = os.path.join(temp_dir, 'tempfile')
             civis.io._tables._download_file(self.export_url, fname,
                                             b'', 'none')
             with open(fname, "r") as f:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -135,8 +135,7 @@ class ImportTests(CivisVCRTestCase):
             fname = os.path.join(temp_dir, 'tempfile')
             with open(fname, 'w+b') as tmp:
                 tmp.write(b'a,b,c\n1,2,3')
-                tmp.flush()
-                tmp.seek(0)
+            with open(fname, 'r+b') as tmp:
                 result = civis.io.file_to_civis(tmp, fname)
 
             civis.io._files.MIN_MULTIPART_SIZE = curr_size
@@ -156,7 +155,6 @@ class ImportTests(CivisVCRTestCase):
             fname = os.path.join(temp_dir, 'tempfile')
             with open(fname, 'w+b') as tmp:
                 tmp.write(b'a,b,c\n1,2,3')
-                tmp.flush()
 
             table = "scratch.api_client_test_fixture"
             database = 'redshift-general'

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -87,7 +87,6 @@ class ImportTests(CivisVCRTestCase):
             # create an export to check get_url. also tests export_csv
             with TemporaryDirectory() as temp_dir:
                 fname = os.path.join(temp_dir, str(uuid.uuid4()))
-                tmp = open(fname, 'w+b')
                 sql = "SELECT * FROM scratch.api_client_test_fixture"
                 database = 'redshift-general'
                 result = civis.io.civis_to_csv(fname, sql, database,
@@ -274,7 +273,6 @@ class ImportTests(CivisVCRTestCase):
         expected = '"1","2","3"\n'
         with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
-            tmp = open(fname, 'w+b')
             civis.io._tables._download_file(self.export_url, fname,
                                             b'', 'none')
             with open(fname, "r") as f:

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -105,7 +105,8 @@ class ImportTests(CivisVCRTestCase):
         with TemporaryDirectory() as temp_dir:
             fname = os.path.join(temp_dir, str(uuid.uuid4()))
             with zipfile.ZipFile(fname, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-                zip_file.writestr(fname, 'a,b,c\n1,2,3')
+                archive_name = str(uuid.uuid4())
+                zip_file.writestr(archive_name, 'a,b,c\n1,2,3')
                 zip_member = zip_file.namelist()[0]
                 with zip_file.open(zip_member) as zip_member_buf:
                     result = civis.io.file_to_civis(zip_member_buf, zip_member)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -4,6 +4,7 @@ import os
 from six import StringIO, BytesIO
 import zipfile
 import uuid
+import sys
 
 import pytest
 import vcr
@@ -97,6 +98,7 @@ class ImportTests(CivisVCRTestCase):
 
             cls.export_job_id = result.sql_id
 
+    @pytest.mark.skipif(sys.platform.startswith('win'))  # TODO
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_zip_member_to_civis(self, *mocks):
         with TemporaryDirectory() as temp_dir:

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -71,7 +71,7 @@ class TestPolling(unittest.TestCase):
                                   poll_on_creation=False)
         pollable.done()  # Check status once to start the polling thread
         assert poller.call_count == 0
-        time.sleep(0.1)
+        time.sleep(0.02)
         assert poller.call_count > 0
 
     def test_reset_polling_thread(self):

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -71,8 +71,8 @@ class TestPolling(unittest.TestCase):
                                   poll_on_creation=False)
         pollable.done()  # Check status once to start the polling thread
         assert poller.call_count == 0
-        time.sleep(0.15)
-        assert poller.call_count == 1
+        time.sleep(0.1)
+        assert poller.call_count > 0
 
     def test_reset_polling_thread(self):
         pollable = PollableResult(

--- a/civis/tests/test_polling.py
+++ b/civis/tests/test_polling.py
@@ -71,7 +71,7 @@ class TestPolling(unittest.TestCase):
                                   poll_on_creation=False)
         pollable.done()  # Check status once to start the polling thread
         assert poller.call_count == 0
-        time.sleep(0.015)
+        time.sleep(0.15)
         assert poller.call_count == 1
 
     def test_reset_polling_thread(self):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6
 sphinx_rtd_theme>=0.2.4,<1.0.0
 numpydoc>=0.7.0,<1.0.0
-feather-format
+feather-format; sys_platform != 'win32' or (python_version >= '3.5')
 numpy
 pandas; python_version >= '3.5'
 pandas<0.21; python_version == '3.4'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6
 sphinx_rtd_theme>=0.2.4,<1.0.0
 numpydoc>=0.7.0,<1.0.0
-feather-format; sys_platform != 'win32' or (python_version >= '3.5')
+feather-format; sys_platform != 'win32' or python_version >= '3.5'
 numpy
 pandas; python_version >= '3.5'
 pandas<0.21; python_version == '3.4'


### PR DESCRIPTION
IT support has turned on AppVeyor for CI in Windows. This PR configures that, based on what we already have for Circle CI.

Resolves #10.