### PR TITLE
Add utils to civis package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added instructions in the README for adding an API key to a Windows 10
   environment
 - Configured Windows CI using AppVeyor. (#258)
+- Added `utils` to the list of imports in `civis` so that `civis.utils.run_job` can be called directly once `civis` has been imported. (#261)
 
 ### Changed
 - Coalesced `README.rst` and `index.rst`. (#254)

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
-from civis import io, ml, parallel
+from civis import io, ml, parallel, utils
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
-           "ml", "parallel"]
+           "ml", "parallel", "utils"]


### PR DESCRIPTION
This adds the `utils` module to `civis` so that users can run `civis.utils.run_job` directly after having imported `civis`.

Previously, they'd have to add `from civis.utils import run_job` to their script.