### PR TITLE
update feather-format in dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,12 @@ vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6
 sphinx_rtd_theme>=0.2.4,<1.0.0
 numpydoc>=0.7.0,<1.0.0
-feather-format; sys_platform != 'win32' or python_version >= '3.5'
+
+# pyarrow (feather dependency) doesn't have wheels for Python 3.4 at the time
+# of writing (https://pypi.org/project/pyarrow/#files).
+# We'll only test with feather for 3.5+ to avoid having to compile Arrow in CI.
+feather-format ; python_version >= '3.5'
+
 numpy
 pandas; python_version >= '3.5'
 pandas<0.21; python_version == '3.4'


### PR DESCRIPTION
pyarrow doesn't have wheels for 3.4 now (see https://pypi.org/project/pyarrow/#files), so the build for master fails (see #264) because it can't install pyarrow, which is required for `feather-format`.

Ideally, we'd make it so travis could build arrow if necessary, but that seems nontrivial, so I'm continuing with the less-than-great solution of not testing feather when a wheel isn't available.