### PR TITLE
In Which We Pass the API Client Through From civis_to_multifile_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `_stash_dataframe_as_csv` in `civis/ml/_model.py` now uses a `StringIO`
   object which has the `getvalue` method (required by `pandas` v0.23.1
   if a file-like object is passed into `df.to_csv`). (#259)
+- `civis_to_multifile_csv` fully respects the `client` keyword argument
 
 ### Added
 - Added instructions in the README for adding an API key to a Windows 10

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -958,7 +958,7 @@ def _include_header(client, sql, include_header, database, credential_id,
     headers = None
 
     # can't do a parallel unload when sql contains an order by
-    if not include_header or re.search('order\s+by', sql, re.I | re.M):
+    if not include_header or re.search(r'order\s+by', sql, re.I | re.M):
         return include_header, headers
 
     try:

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -604,7 +604,7 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                                .format(script_id))
 
     buf = io.BytesIO()
-    civis_to_file(outputs[0]['file_id'], buf)
+    civis_to_file(outputs[0]['file_id'], buf, client=client)
     txt = io.TextIOWrapper(buf, encoding='utf-8')
     txt.seek(0)
     unload_manifest = json.load(txt)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -243,6 +243,25 @@ class ImportTests(CivisVCRTestCase):
                                                              'console.s3.'
                                                              'amazonaws.com/')
 
+    @mock.patch('civis.io._tables.CivisFuture')
+    @mock.patch('civis.io._tables.civis_to_file')
+    @mock.patch('civis.io._tables._sql_script')
+    def test_civis_to_multifile_passes_client(
+            self, m_sql_script, m_civis_to_file, m_CivisFuture, *mocks):
+        """Ensure the client kwarg is passed forward."""
+        m_sql_script.return_value = (mock.MagicMock(), mock.MagicMock())
+        # We need to write some JSON into the buffer to avoid errors.
+        m_civis_to_file.side_effect = (
+            lambda _, buf, *args, **kwargs: buf.write(b'{}')
+        )
+        mock_client = mock.MagicMock()
+
+        civis.io.civis_to_multifile_csv('sql', 'db', client=mock_client)
+
+        m_civis_to_file.assert_called_once_with(
+            mock.ANY, mock.ANY, client=mock_client
+        )
+
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_transfer_table(self, *mocks):
         result = civis.io.transfer_table('redshift-general', 'redshift-test',


### PR DESCRIPTION
- forward the client kwarg from `civis_to_multifile_csv` to `civis_to_file`
- fix a new flake8 error: `civis/io/_tables.py:961:11: W605 invalid escape sequence '\s'`

@elliothevel 
@keithing what does the release process look like? Got a bug I was hoping to get a fix out for soon.