### PR TITLE
BUG check for primary key to determine how to read index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- `civis.ml.ModelFuture.table` checks for primary key before reading in
+  data (#276)
+
 
 ## 1.9.2 - 2018-12-03
 ### Fixed

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -489,20 +489,23 @@ class ModelFuture(ContainerFuture):
 
         return self._train_data
 
+    def _table_primary_key(self):
+        # metadata path to input parameters is different
+        # for training and prediction
+        if self.is_training:
+            pkey = self.metadata[
+                'run']['configuration']['data']['primary_key']
+        else:
+            pkey = self.metadata[
+                'jobs'][0]['run']['configuration']['data']['primary_key']
+        return pkey
+
     @property
     def table(self):
         self.result()  # Block and raise errors if any
         if self._table is None:
             # An index column will only be present if primary key is
-            # metadata path to input parameters is different
-            # for training and prediction
-            if self.is_training:
-                pkey = self.metadata[
-                    'run']['configuration']['data']['primary_key']
-            else:
-                pkey = self.metadata[
-                    'jobs'][0]['run']['configuration']['data']['primary_key']
-            if pkey is None:
+            if self._table_primary_key() is None:
                 index_col = False
             else:
                 index_col = 0

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -493,13 +493,25 @@ class ModelFuture(ContainerFuture):
     def table(self):
         self.result()  # Block and raise errors if any
         if self._table is None:
+            # An index column will only be present if a primary key was specified
+            # metadata path to input parameters is different
+            # for training and prediction
+            if self.is_training:
+                pkey = self.metadata['run']['configuration']['data']['primary_key']
+            else:
+                pkey = self.metadata['jobs'][0]['run']['configuration']['data']['primary_key']
+            if pkey is None:
+                index_col = False
+            else:
+                index_col = 0
+                
             if self.is_training:
                 try:
                     # Training jobs only have one output table, the OOS scores
                     self._table = _load_table_from_outputs(self.job_id,
                                                            self.run_id,
                                                            self.table_fname,
-                                                           index_col=0,
+                                                           index_col=index_col,
                                                            client=self.client)
                 except FileNotFoundError:
                     # Just pass here, because we want the table to stay None
@@ -514,7 +526,7 @@ class ModelFuture(ContainerFuture):
                           '["output_file_ids"]`.'.format(len(output_ids)))
                 self._table = cio.file_to_dataframe(output_ids[0],
                                                     client=self.client,
-                                                    index_col=0)
+                                                    index_col=index_col)
         return self._table
 
     @property

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -493,18 +493,20 @@ class ModelFuture(ContainerFuture):
     def table(self):
         self.result()  # Block and raise errors if any
         if self._table is None:
-            # An index column will only be present if a primary key was specified
+            # An index column will only be present if primary key is
             # metadata path to input parameters is different
             # for training and prediction
             if self.is_training:
-                pkey = self.metadata['run']['configuration']['data']['primary_key']
+                pkey = self.metadata[
+                    'run']['configuration']['data']['primary_key']
             else:
-                pkey = self.metadata['jobs'][0]['run']['configuration']['data']['primary_key']
+                pkey = self.metadata[
+                    'jobs'][0]['run']['configuration']['data']['primary_key']
             if pkey is None:
                 index_col = False
             else:
                 index_col = 0
-                
+
             if self.is_training:
                 try:
                     # Training jobs only have one output table, the OOS scores

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -451,7 +451,7 @@ def test_state():
 
 @mock.patch.object(_model.ModelFuture, "metadata",
                    return_value={'run': {'configuration':
-                            {'data': {'primary_key': 'foo'}}}})
+                                         {'data': {'primary_key': 'foo'}}}})
 @mock.patch.object(_model, "_load_table_from_outputs", return_value='bar')
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
@@ -465,7 +465,7 @@ def test_table(mock_res, mock_lt, mock_meta):
 
 @mock.patch.object(_model.ModelFuture, "metadata",
                    return_value={'run': {'configuration':
-                            {'data': {'primary_key': None}}}})
+                                         {'data': {'primary_key': None}}}})
 @mock.patch.object(_model, "_load_table_from_outputs", return_value='bar')
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
@@ -479,7 +479,7 @@ def test_table_no_pkey(mock_res, mock_lt, mock_meta):
 
 @mock.patch.object(_model.ModelFuture, "metadata",
                    return_value={'run': {'configuration':
-                            {'data': {'primary_key': 'foo'}}}})
+                                         {'data': {'primary_key': 'foo'}}}})
 @mock.patch.object(_model, "_load_table_from_outputs")
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -449,10 +449,13 @@ def test_state():
     assert mf.state == 'failed'
 
 
+@mock.patch.object(_model.ModelFuture, "metadata",
+                   return_value={'run': {'configuration':
+                            {'data': {'primary_key': 'foo'}}}})
 @mock.patch.object(_model, "_load_table_from_outputs", return_value='bar')
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
-def test_table(mock_res, mock_lt):
+def test_table(mock_res, mock_lt, mock_meta):
     c = setup_client_mock(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     assert mf.table == 'bar'
@@ -460,10 +463,27 @@ def test_table(mock_res, mock_lt):
                                     index_col=0, client=c)
 
 
+@mock.patch.object(_model.ModelFuture, "metadata",
+                   return_value={'run': {'configuration':
+                            {'data': {'primary_key': None}}}})
+@mock.patch.object(_model, "_load_table_from_outputs", return_value='bar')
+@mock.patch.object(_model.ModelFuture, "result")
+@mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
+def test_table_no_pkey(mock_res, mock_lt, mock_meta):
+    c = setup_client_mock(3, 7)
+    mf = _model.ModelFuture(3, 7, client=c)
+    assert mf.table == 'bar'
+    mock_lt.assert_called_once_with(3, 7, 'predictions.csv',
+                                    index_col=False, client=c)
+
+
+@mock.patch.object(_model.ModelFuture, "metadata",
+                   return_value={'run': {'configuration':
+                            {'data': {'primary_key': 'foo'}}}})
 @mock.patch.object(_model, "_load_table_from_outputs")
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_model_exception", mock.Mock())
-def test_table_None(mock_res, mock_lt):
+def test_table_None(mock_res, mock_lt, mock_meta):
     mock_lt.side_effect = FileNotFoundError()
     c = setup_client_mock(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=3,<4
+pytest>=3.6,<4
 sphinx>=1.7.0,<2.0.0
 flake8>=3.0.4,==3.*
 mock==2.0.0 ; python_version == '2.7'


### PR DESCRIPTION
This PR fixes a bug to ensure compatibility with CivisML v2.2.2. In 2.2.2, CivisML does not create an index column when the user does not specify a primary key. This fix forces `civis.ml.ModelFuture.table` to check for a primary key before determining if the first column is an index or not. Unfortunately, the metadata structure is different for training and prediction, so this fix includes two complicated hardcoded paths through the metadata, but I don't see any way around this. I tested the fix on three actual model jobs (training with pkey, predict with pkey, predict without pkey) and it behaved as expected for all three.