### PR TITLE
MAINT add python 3.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7"
+# xenial and sudo workaround currently required for 3.7 on Travis,
+# see: https://github.com/travis-ci/travis-ci/issues/9815
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `civis.ml.ModelFuture.table` checks for primary key before reading in
   data (#276)
 
+### Added
+- Test for Python 3.7 compatibility (#277)
+
 
 ## 1.9.2 - 2018-12-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 - `civis.ml.ModelFuture.table` checks for primary key before reading in
-  data (#276)
+  data. (#276)
 
 ### Added
 - Test for Python 3.7 compatibility (#277)

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ dependencies with
 Python version support
 ----------------------
 
-Python 2.7, 3.4, 3.5, and 3.6
+Python 2.7, 3.4, 3.5, 3.6, and 3.7
 
 .. end-include-marker-python-version-support-section
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       PYTHON_VERSION: "3.6.5"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.2"
+      PYTHON_ARCH: "64"
+
   # Environmental variables
   CIVIS_API_KEY: "FOOBAR"
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 


### PR DESCRIPTION
This PR adds tests for Python 3.7 compatibility. #266 mentions updating the documentation, but I couldn't find anywhere in the docs that explicitly mention compatible Python versions. Happy to add a section if that would be helpful.

Fixes #266. 