### PR TITLE
Fix handling of empty responses from run cancellation endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 - `get_table_id` will correctly handle quoted schema.tablename. (#285)
+- Fix parsing of empty responses from run cancellation endpoints. (#287)
 
 ## 1.9.3 - 2019-02-05
 ### Fixed

--- a/civis/response.py
+++ b/civis/response.py
@@ -32,7 +32,7 @@ def _response_to_json(response):
     CivisClientError
         If the data in the raw response cannot be parsed.
     """
-    if response.status_code in [204, 205]:
+    if response.content == b'':
         return None
     else:
         try:

--- a/civis/tests/test_response.py
+++ b/civis/tests/test_response.py
@@ -26,6 +26,7 @@ def _create_mock_response(data, headers):
 def _create_empty_response(code, headers):
     mock_response = mock.MagicMock(spec=requests.Response)
     mock_response.status_code = code
+    mock_response.content = b''
     mock_response.headers = headers
     return mock_response
 
@@ -101,7 +102,8 @@ def test_response_to_json_no_error():
 
 
 def test_response_to_no_content_snake():
-    for code in [204, 205]:
+    # Test empty response handling for codes where we're likely to see them.
+    for code in [202, 204, 205]:
         raw_response = _create_empty_response(code, {'header1': 'val1'})
         data = convert_response_data_type(raw_response, return_type='snake')
 


### PR DESCRIPTION
The Scripts and Jobs run cancellation endpoints (e.g., DELETE /jobs/{job_id}/runs/{run_id})
return an empty response with a 202 error code, which is reasonable, I think.

The client currently raises a CivisClientError("Unable to parse JSON from response", ...) in that case because it only expects empty responses for 204 or 205.  This fixes that so that users will be able to use the client with those endpoints.