### PR TITLE
DOC Surface civis.io.split_schema_tablename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
+- Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)
+- Surfaced `civis.io.split_schema_tablename` in the Sphinx docs. (#294)
 
-- Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`.
 ## 1.10.0 - 2019-04-09
 ### Added
 - `CivisFuture` has the `job_id` and `run_id` property attributes. (#290)

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -8,10 +8,10 @@ Tables
 ------
 
 Often, your data will be in structured format like a table in a relational
-database, a CSV or a dataframe. The following functions handle moving
+database, a CSV, or a dataframe. The following functions handle moving
 structured data to and from Civis. When using these functions, it is
-recommended to have `pandas` installed and to pass `use_pandas=True` in
-the appropriate functions. If `pandas` is not installed, data returned
+recommended to have ``pandas`` installed and to pass ``use_pandas=True`` in
+the appropriate functions. If ``pandas`` is not installed, data returned
 from Civis will all be treated as strings.
 
 .. currentmodule:: civis.io
@@ -27,6 +27,7 @@ from Civis will all be treated as strings.
    read_civis
    read_civis_sql
    export_to_civis_file
+   split_schema_tablename
 
 Files
 -----


### PR DESCRIPTION
Users have reported having trouble finding the documentation of `civis.io.split_schema_tablename`. Let's surface it.