### PR TITLE
Upgrade dependency of jsonref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)
 - Loosened version requirement of `jsonref` to include `0.2` to fix a
   DeprecationWarning under Python 3.7. (#295)
+- Changed pubnub version requirement in requirements.txt to match setup.py
+  (#295)
 - Surfaced `civis.io.split_schema_tablename` in the Sphinx docs. (#294)
 
 ## 1.10.0 - 2019-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)
+- Loosened version requirement of `jsonref` to include `0.2` to fix a
+  DeprecationWarning under Python 3.7. (#295)
 - Surfaced `civis.io.split_schema_tablename` in the Sphinx docs. (#294)
 
 ## 1.10.0 - 2019-04-09

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ click>=6.0,<=6.99
 funcsigs==1.0.2 ; python_version == '2.7'
 future>=0.16,<=0.99 ; python_version == '2.7'
 futures==3.1.1 ; python_version == '2.7'
-jsonref>=0.1.0,<=0.1.99
+jsonref>=0.1,<=0.2
 requests>=2.12.0,==2.*
 jsonschema>=2.5.1,==2.*
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib~=0.11
-pubnub~=4
+pubnub~=4.0
 cloudpickle~=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=2.5.1,==2.*
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib~=0.11
-pubnub~=4.0
+pubnub>=4.0,<=4.99
 cloudpickle~=0.2

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def main():
         install_requires=[
             'pyyaml>=3.0,<=5.99',
             'click>=6.0,<=6.99',
-            'jsonref>=0.1.0,<=0.1.99',
+            'jsonref>=0.1.0,<=0.2',
             'requests>=2.12.0,==2.*',
             'jsonschema>=2.5.1,==2.*',
             'six>=1.10,<=1.99',


### PR DESCRIPTION
* Fixes DeprecationWarning in python 3.7
* Also fix pubnub ~= version that is no longer recognized in pip 19.0

This happens when jsonref 0.1 is used, but the warning is now fixed in jsonref 0.2:
```python
% python3 -W default
Python 3.7.3 (default, Mar 27 2019, 09:23:15)
[Clang 10.0.1 (clang-1001.0.46.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import civis
/usr/local/lib/python3.7/site-packages/jsonref.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

