### PR TITLE
MAINT Relax requirements on click and jsonschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   DeprecationWarning under Python 3.7. (#295)
 - Changed pubnub version requirement in requirements.txt to match setup.py
   (#295)
+- Loosened version requirements of `click` to include v7 and `jsonschema`
+  to include v3. (#286, #300)
 - Surfaced `civis.io.split_schema_tablename` in the Sphinx docs. (#294)
 
 ## 1.10.0 - 2019-04-09

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 pyyaml>=3.0,<=5.99
-click>=6.0,<=6.99
+click>=6.0,<=7
 funcsigs==1.0.2 ; python_version == '2.7'
 future>=0.16,<=0.99 ; python_version == '2.7'
 futures==3.1.1 ; python_version == '2.7'
 jsonref>=0.1,<=0.2
 requests>=2.12.0,==2.*
-jsonschema>=2.5.1,==2.*
+jsonschema>=2.5.1,<=3
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib~=0.11

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ def main():
         long_description=README,
         install_requires=[
             'pyyaml>=3.0,<=5.99',
-            'click>=6.0,<=6.99',
+            'click>=6.0,<=7',
             'jsonref>=0.1.0,<=0.2',
             'requests>=2.12.0,==2.*',
-            'jsonschema>=2.5.1,==2.*',
+            'jsonschema>=2.5.1,<=3',
             'six>=1.10,<=1.99',
             'joblib>=0.11,<=0.11.99',
             'pubnub>=4.0,<=4.99',


### PR DESCRIPTION
Use newer versions of these packages in tests. It seems to work.

Closes #286 .