### PR TITLE
ENH Include Python version in User-Agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add the user's Python version to the User-Agent string. (#255, #301)
+
 ### Fixed
 - Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Allow users to access `civis.utils.run_job` after an `import civis`. (#305)
-
-### Added
 - `civis.io.dataframe_to_file` and `civis.io.json_to_file` convenience functions.
   (#262, #304)
-
-### Added
 - Add the user's Python version to the User-Agent string. (#255, #301)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- Add the user's Python version to the User-Agent string. (#255, #301)
+
 ### Changed
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)
 - Loosened version requirement of `jsonref` to include `0.2` to fix a

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -3,6 +3,7 @@ from builtins import super
 import logging
 import os
 import re
+import sys
 import time
 import uuid
 
@@ -53,7 +54,11 @@ def open_session(api_key, max_retries=5, user_agent="civis-python"):
     session = requests.Session()
     session.auth = (api_key, '')
     session_agent = session.headers.get('User-Agent', '')
-    user_agent = "{}/{} {}".format(user_agent, civis_version, session_agent)
+    ver_string = "{}.{}.{}".format(sys.version_info.major,
+                                   sys.version_info.minor,
+                                   sys.version_info.micro)
+    user_agent = "{}/Python v{} Civis v{} {}".format(
+        user_agent, ver_string, civis_version, session_agent)
     session.headers.update({"User-Agent": user_agent.strip()})
     max_retries = AggressiveRetry(max_retries, backoff_factor=.75,
                                   status_forcelist=civis.civis.RETRY_CODES)


### PR DESCRIPTION
Collect the user's Python version along with the API client version. This can be useful in evaluating maintenance requirements going forward.

Closes #255 .