### PR TITLE
BUG Fix unintentional dependency on scikit-learn for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)
+
 ### Changed
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)
 - Loosened version requirement of `jsonref` to include `0.2` to fix a

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -37,6 +37,7 @@ try:
         NO_SKLEARN = False
 except ImportError:
     NO_SKLEARN = True
+    _sklearn_reg_para_backend = None
 
 log = logging.getLogger(__name__)
 _THIS_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
The `test_parallel.test_setup_remote_backend` function would give an error if scikit-learn was not installed. This is because we try to mock the `parallel._sklearn_reg_para_backend` function, and that doesn't exist if scikit-learn isn't installed. Fix by ensuring that attribute is always defined.

Closes #245 .