### PR TITLE
ENH dataframe and json to-file conveniences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- `civis.io.dataframe_to_file` and `civis.io.json_to_file` convenience functions.
+  (#262, #304)
+
 ### Fixed
 - Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)
 


### PR DESCRIPTION
We have functions to download Civis File objects and convert them to a DataFrame or a JSON object. Add functions to go the other way. In particular, users often expect the `dataframe_to_file` function and are surprised that it doesn't exist.

Closes #262 .