### PR TITLE
ENH utils module available from civis namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- Allow users to access `civis.utils.run_job` after an `import civis`. (#305)
 
 ### Fixed
 - Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
-from civis import io, ml, parallel
+from civis import io, ml, parallel, utils
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
-           "ml", "parallel"]
+           "ml", "parallel", "utils"]


### PR DESCRIPTION
Import `utils` into `civis` so that users can access `civis.utils.run_job` after an `import civis` import. Many users expect this and are surprised when it's not available.