### PR TITLE
MAINT Restrict cloudpickle version in Python 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)
+- Set `cloudpickle` requirements to <1.2 on Python v3.4. (#309)
 
 ### Changed
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib>=0.11,<=0.13
 pubnub>=4.0,<=4.99
-cloudpickle<=0.2,<=1
+cloudpickle<=0.2,<=1 ; python_version != '3.4
+cloudpickle<1.2 ; python_version == '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib>=0.11,<=0.13
 pubnub>=4.0,<=4.99
-cloudpickle<=0.2,<=1 ; python_version != '3.4
+cloudpickle<=0.2,<=1 ; python_version != '3.4'
 cloudpickle<1.2 ; python_version == '3.4'

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ def main():
             'six>=1.10,<=1.99',
             'joblib>=0.11,<=0.13.99',
             'pubnub>=4.0,<=4.99',
-            'cloudpickle>=0.2.0,<=1.99999',
+            "cloudpickle>=0.2.0,<=1.99999 ; python_version != '3.4'",
+            "cloudpickle>=0.2.0,<1.2 ; python_version == '3.4'",
         ],
         extras_require={
             ':python_version=="2.7"': [


### PR DESCRIPTION
Cloudpickle v1.2 released on June 7th, and our Python 3.4 build started failing. Set in requirements that Python 3.4 needs v1.1 or older.