### PR TITLE
TST Test in Xenial environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
+dist: xenial
 language: python
 python:
     - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
-# xenial and sudo workaround currently required for 3.7 on Travis,
-# see: https://github.com/travis-ci/travis-ci/issues/9815
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+    - "3.7"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   the Civis joblib backend which newer versions of `joblib` can take
   advantage of. Also loosened version requirement on `cloudpickle` to
   include v1. (#296, #299)
+- Run all tests in Ubuntu Xenial. (#310)
 
 ## 1.10.0 - 2019-04-09
 ### Added


### PR DESCRIPTION
Python versions >=3.7 require OpenSSL 1.0.2+, which is not available in Trusty (the default environment). Switch to using Xenial (Ubuntu 16.04) for all of our tests, instead of only for v3.7. It seems that the sudo mode is no longer required.