### PR TITLE
COMPAT Deprecation decorator takes multiple parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#262, #304)
 - Add the user's Python version to the User-Agent string. (#255, #301)
 - Added a `last_response` parameter to the `APIClient` object. (#153, #302)
+- The deprecate_param decorator can take multiple parameter names, to allow
+  Python 2.7 compatibility for multiple deprecations. (#311)
 
 ### Fixed
 - Fix unintentional dependency on scikit-learn for `parallel` module tests. (#245, #303)

--- a/civis/tests/test_deprecate.py
+++ b/civis/tests/test_deprecate.py
@@ -25,6 +25,27 @@ def test_deprecate_kwarg():
         "The warning should mention the function name."
 
 
+def test_deprecate_multiple_kwarg():
+    # Verify that we get a warning if the deprecated parameter is
+    # used as a keyword argument.
+    decorated_func = _deprecation.deprecate_param(
+        'v2.0.0', 'param2', 'param3')(adder)
+
+    with pytest.warns(FutureWarning) as record:
+        output = decorated_func(1, param2=3, param3=5)
+
+    assert output == 9, "The function should still give the expected output."
+    assert len(record) == 1, "Only one warning should be raised."
+    assert "v2.0.0" in record[0].message.args[0], \
+        "The warning should mention the removal version."
+    assert "param2" in record[0].message.args[0], \
+        "The warning should mention the first deprecated parameter."
+    assert "param3" in record[0].message.args[0], \
+        "The warning should mention the second deprecated parameter."
+    assert __name__ + ".adder" in record[0].message.args[0], \
+        "The warning should mention the function name."
+
+
 def test_deprecate_pos_arg():
     # Verify that we get a warning if the deprecated parameter is
     # used as a positional argument.
@@ -39,6 +60,27 @@ def test_deprecate_pos_arg():
         "The warning should mention the removal version."
     assert "param2" in record[0].message.args[0], \
         "The warning should mention the deprecated parameter."
+    assert __name__ + ".adder" in record[0].message.args[0], \
+        "The warning should mention the function name."
+
+
+def test_deprecate_multiple_pos_arg():
+    # Verify that we get a warning if the deprecated parameter is
+    # used as a positional argument.
+    decorated_func = _deprecation.deprecate_param(
+        'v2.0.0', 'param2', 'param3')(adder)
+
+    with pytest.warns(FutureWarning) as record:
+        output = decorated_func(1, 3, 5)
+
+    assert output == 9, "The function should still give the expected output."
+    assert len(record) == 1, "Only one warning should be raised."
+    assert "v2.0.0" in record[0].message.args[0], \
+        "The warning should mention the removal version."
+    assert "param2" in record[0].message.args[0], \
+        "The warning should mention the first deprecated parameter."
+    assert "param3" in record[0].message.args[0], \
+        "The warning should mention the second deprecated parameter."
     assert __name__ + ".adder" in record[0].message.args[0], \
         "The warning should mention the function name."
 


### PR DESCRIPTION
In Python v3, multiple layers of the deprecation decorator work as expected. But we run into problems with Python v2.7 (apparently due to missing features in the `Signature` class). If the decorator takes multiple parameter names, it's more complex, but will be compatible with more Python versions.