### PR TITLE
ENH Model sharing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Add helper function to list CivisML models. (#314)
+- Added helper functions to share CivisML models with users or groups,
+  patterned after the existing API sharing endpoints. (#315)
 - Allow the base URL of the CLI to be configured through the
   `CIVIS_API_ENDPOINT` environment variable, like the civis Python module. (#312)
 - Allow the CLI log level to be configured with the `CIVIS_LOG_LEVEL`

--- a/civis/ml/_helper.py
+++ b/civis/ml/_helper.py
@@ -1,9 +1,12 @@
 from collections import namedtuple
+import logging
 
 from civis import APIClient
 from civis.ml._model import _PRED_TEMPLATES
 
-__all__ = ['list_models']
+__all__ = ['list_models', 'put_models_shares_groups',
+           'put_models_shares_users']
+log = logging.getLogger(__name__)
 
 # sentinel value for default author value
 SENTINEL = namedtuple('Sentinel', [])()
@@ -58,3 +61,176 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
                                         author=author,
                                         **kwargs)
     return models
+
+
+def put_models_shares_users(id, user_ids, permission_level, *,
+                            client=None,
+                            share_email_body='DEFAULT',
+                            send_shared_email='DEFAULT'):
+    """Set the permissions users have on this object
+
+    Use this on both training and scoring jobs.
+    If used on a training job, note that "read" permission is
+    sufficient to score the model.
+
+    Parameters
+    ----------
+    id : integer
+        The ID of the resource that is shared.
+    user_ids : list
+        An array of one or more user IDs.
+    permission_level : string
+        Options are: "read", "write", or "manage".
+    client : :class:`civis.APIClient`, optional
+        If not provided, an :class:`civis.APIClient` object will be
+        created from the :envvar:`CIVIS_API_KEY`.
+    share_email_body : string, optional
+        Custom body text for e-mail sent on a share.
+    send_shared_email : boolean, optional
+        Send email to the recipients of a share.
+
+    Returns
+    -------
+    readers : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    writers : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    owners : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    total_user_shares : integer
+        For owners, the number of total users shared. For writers and readers, the
+        number of visible users shared.
+    total_group_shares : integer
+        For owners, the number of total groups shared. For writers and readers, the
+        number of visible groups shared.
+    """
+    kwargs = {}
+    if send_shared_email != 'DEFAULT':
+        kwargs['send_shared_email'] = send_shared_email
+    if share_email_body != 'DEFAULT':
+        kwargs['share_email_body'] = share_email_body
+    return _share_model(id, user_ids, permission_level, entity_type='users',
+                        client=client, **kwargs)
+
+
+def put_models_shares_groups(id, group_ids, permission_level, *,
+                             client=None,
+                             share_email_body='DEFAULT',
+                             send_shared_email='DEFAULT'):
+    """Set the permissions groups have on this model.
+
+    Use this on both training and scoring jobs.
+    If used on a training job, note that "read" permission is
+    sufficient to score the model.
+
+    Parameters
+    ----------
+    id : integer
+        The ID of the resource that is shared.
+    group_ids : list
+        An array of one or more group IDs.
+    permission_level : string
+        Options are: "read", "write", or "manage".
+    client : :class:`civis.APIClient`, optional
+        If not provided, an :class:`civis.APIClient` object will be
+        created from the :envvar:`CIVIS_API_KEY`.
+    share_email_body : string, optional
+        Custom body text for e-mail sent on a share.
+    send_shared_email : boolean, optional
+        Send email to the recipients of a share.
+
+    Returns
+    -------
+    readers : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    writers : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    owners : dict::
+        - users : list::
+            - id : integer
+            - name : string
+        - groups : list::
+            - id : integer
+            - name : string
+    total_user_shares : integer
+        For owners, the number of total users shared. For writers and readers, the
+        number of visible users shared.
+    total_group_shares : integer
+        For owners, the number of total groups shared. For writers and readers, the
+        number of visible groups shared.
+    """
+    kwargs = {}
+    if send_shared_email != 'DEFAULT':
+        kwargs['send_shared_email'] = send_shared_email
+    if share_email_body != 'DEFAULT':
+        kwargs['share_email_body'] = share_email_body
+    return _share_model(id, group_ids, permission_level, entity_type='groups',
+                        client=client, **kwargs)
+
+
+def _share_model(job_id, entity_ids, permission_level, entity_type,
+                 client=None, **kwargs):
+    """Share a container job and all run outputs with requested entities
+    """
+    client = client or APIClient()
+    if entity_type not in ['groups', 'users']:
+        raise ValueError(f"'entity_type' must be one of ['groups', 'users']. "
+                         f"Got '{entity_type}'.")
+
+    log.debug(f"Sharing object {job_id} with {entity_type} {entity_ids} at "
+              f"permission level {permission_level}.")
+    _func = getattr(client.scripts, f"put_containers_shares_{entity_type}")
+    result = _func(job_id, entity_ids, permission_level, **kwargs)
+
+    # CivisML relies on several run outputs attached to each model run.
+    # Go through and share all outputs on each run.
+    runs = client.scripts.list_containers_runs(job_id, iterator=True)
+    for run in runs:
+        log.debug(f"Sharing outputs on {job_id}, run {run.id}.")
+        outputs = client.scripts.list_containers_runs_outputs(job_id, run.id)
+        for _output in outputs:
+            if _output['object_type'] == 'File':
+                _func = getattr(client.files, f"put_shares_{entity_type}")
+                obj_permission = permission_level
+            elif _output['object_type'] == 'Project':
+                _func = getattr(client.projects, f"put_shares_{entity_type}")
+                if permission_level == 'read':
+                    # Users must be able to add to projects to use the model
+                    obj_permission = 'write'
+                else:
+                    obj_permission = permission_level
+            elif _output['object_type'] == 'JSONValue':
+                _func = getattr(client.json_values, f"put_shares_{entity_type}")
+                obj_permission = permission_level
+            else:
+                continue
+            _oid = _output['object_id']
+            # Don't send share emails for any of the run outputs.
+            _func(_oid, entity_ids, obj_permission, send_shared_email=False)
+
+    return result


### PR DESCRIPTION
A CivisML model has File and Project run outputs, each of which need to be shared to effectively share the "model". This helper will transparently handle sharing the run outputs. Include JSONValue in case a future version of CivisML uses that. The functions are patterned after the autogenerated API sharing endpoints.