### PR TITLE
 BUG Use APIClient method name parsing for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecate the `headers` parameter of `dataframe_to_civis` and always tell Civis
   whether the import has headers or not, rather than autodetecting. (#263, #307)
 - Set `cloudpickle` requirements to <1.2 on Python v3.4. (#309)
+- Fixed an issue in the CLI which prevented users from accessing GET /aliases/{id}
+  and simultaneously generated a warning message. (#298, #316)
 
 ### Changed
 - Loosened version requirements of `pyyaml` to include `pyyaml<=5.99`. (#293)

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -102,8 +102,8 @@ def make_operation_name(path, method, resource_name):
 
     Examples
     --------
-    >>> make_operation_name('/imports/files/{id}/runs/{run_id}', 'get', 'imports')
-    get-files-runs
+    >>> make_operation_name('/scripts/r/{id}/runs/{run_id}', 'get', 'scripts')
+    get-r-runs
     """
     path = path.lower().lstrip('/')
 

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -293,7 +293,8 @@ def add_path_commands(path, path_dict, grp, resource):
                                        help="output in JSON instead of YAML"))
 
         if cmd.name in grp.commands:
-            warn("conflicting command name: %s" % cmd.name)
+            warn('conflicting command name "%s" for path "%s"' %
+                 (cmd.name, path))
 
         grp.add_command(cmd)
 

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from civis.cli.__main__ import generate_cli, invoke
+from civis.cli.__main__ import generate_cli, invoke, make_operation_name
 from civis.compat import mock
 from civis.tests import TEST_SPEC
 
@@ -106,3 +106,14 @@ def test_parameter_case(mock_session):
         json={},
         params={'firstParameter': 'a', 'secondParameter': 'b'},
         method='WIBBLE')
+
+@pytest.mark.parametrize(
+    "path,method,resource_name,exp",
+    [('/imports/files/{id}/runs/{run_id}', 'get', 'imports', 'get-files-runs'),
+     ('/aliases/{object_type}/{alias}', 'get', 'aliases', 'get-object-type'),
+     ('/workflows/', 'get', 'workflows', 'list'),
+     ('/results/{id}/grants', 'delete', 'results', 'delete-grants'),
+     ]
+)
+def test_make_operation_name(path, method, resource_name, exp):
+    assert make_operation_name(path, method, resource_name) == exp

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -107,6 +107,7 @@ def test_parameter_case(mock_session):
         params={'firstParameter': 'a', 'secondParameter': 'b'},
         method='WIBBLE')
 
+
 @pytest.mark.parametrize(
     "path,method,resource_name,exp",
     [('/imports/files/{id}/runs/{run_id}', 'get', 'imports', 'get-files-runs'),

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -2,6 +2,8 @@ from collections import OrderedDict
 import json
 import os
 
+import pytest
+
 from civis.cli.__main__ import generate_cli, invoke
 from civis.compat import mock
 from civis.tests import TEST_SPEC
@@ -34,7 +36,9 @@ def test_generate_cli_civis(mock_retrieve_spec_dict):
         civis_spec = json.load(f, object_pairs_hook=OrderedDict)
     mock_retrieve_spec_dict.return_value = civis_spec
 
-    cli = generate_cli()
+    with pytest.warns(None) as warn_rec:
+        cli = generate_cli()
+    assert len(warn_rec) == 0
 
     # Check a regular command.
     list_runs_cmd = cli.commands['scripts'].commands['list-containers-runs']


### PR DESCRIPTION
The CLI's name parsing was failing on /aliases/{object_type}/{alias}. Switch to using the version of this function which already existed in `civis.resources`, with some small munging to account for the CLI's naming style.

Also add a test which will fail if the CLI generates other similar warnings in the future. It should stay a warning in the code, so that changes to the Civis API don't expose bugs which render the CLI unusable, but this should cause our tests to fail until we fix it.

Closes #298 .