### PR TITLE
ENH SQL CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Add CLI commands "sql run", "sql cmd", and "sql download". (#317)
 - Add helper function to list CivisML models. (#314)
 - Allow the base URL of the CLI to be configured through the
   `CIVIS_API_ENDPOINT` environment variable, like the civis Python module. (#312)

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -27,7 +27,8 @@ import yaml
 from civis.cli._cli_commands import (
     civis_ascii_art, files_download_cmd, files_upload_cmd,
     notebooks_download_cmd, notebooks_new_cmd,
-    notebooks_up, notebooks_down, notebooks_open)
+    notebooks_up, notebooks_down, notebooks_open,
+    sql_run_cmd, sql_cmd_cmd, sql_download_cmd)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis.resources._resources import parse_method_name
 from civis._utils import open_session
@@ -225,6 +226,13 @@ def add_extra_commands(cli):
     notebooks_cmd.add_command(notebooks_down)
     notebooks_cmd.add_command(notebooks_open)
     cli.add_command(civis_ascii_art)
+
+    sql_grp = click.Group('sql', short_help='Run SQL in Civis Platform')
+    cli.add_command(sql_grp)
+    sql_cmd = cli.commands['sql']
+    sql_cmd.add_command(sql_run_cmd)
+    sql_cmd.add_command(sql_cmd_cmd)
+    sql_cmd.add_command(sql_download_cmd)
 
 
 def configure_log_level():

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -3,7 +3,7 @@
 """
 Additional commands to add to the CLI beyond the OpenAPI spec.
 """
-
+import functools
 import os
 
 import click
@@ -68,6 +68,83 @@ def files_download_cmd(file_id, path):
     """Download a Civis File to a specified local path."""
     with open(path, 'wb') as f:
         civis_to_file(file_id, f)
+
+
+@click.command('download')
+@click.argument('database_name', type=str)
+@click.argument('file_name', type=click.Path(exists=True))
+@click.argument('output_file', type=click.Path())
+def sql_download_cmd(database_name, file_name, output_file):
+    """Download results of a query."""
+    with open(file_name, 'rt') as f:
+        sql = f.read()
+    fut = civis.io.civis_to_csv(output_file, sql, database=database_name)
+    fut.result()
+    print("Downloaded the result of the query to %s." % output_file)
+
+
+@click.command('run')
+@click.argument('database_name', type=str)
+@click.argument('file_name', type=click.Path(exists=True))
+@click.option('-n', type=int, default=100,
+              help="Display up to this many rows of the result. Max 100.")
+def sql_run_cmd(database_name, file_name, n):
+    """Run the SQL in the specified file."""
+    with open(file_name, 'rt') as f:
+        sql_cmd = f.read()
+    print('\nExecuting query...')
+    fut = civis.io.query_civis(sql_cmd, database=database_name, preview_rows=n,
+                               polling_interval=3)
+    cols, rows = fut.result()['result_columns'], fut.result()['result_rows']
+    print('...Query complete.\n')
+    print(_str_table_result(cols, rows))
+
+
+@click.command('cmd')
+@click.argument('database_name', type=str)
+@click.argument('sql_cmd', type=str, default=None, required=False)
+@click.option('-n', type=int, default=100,
+              help="Display up to this many rows of the result. Max 100.")
+def sql_cmd_cmd(database_name, sql_cmd, n):
+    """Run a SQL command."""
+    if sql_cmd is None:
+        # Read the SQL query from user input. This also allows use of a heredoc
+        lines = []
+        while True:
+            try:
+                _i = input()
+            except (KeyboardInterrupt, EOFError):
+                # The end of a heredoc produces an EOFError.
+                break
+            if not _i:
+                break
+            else:
+                lines.append(_i)
+        sql_cmd = '\n'.join(lines)
+    print('\nExecuting query...')
+    fut = civis.io.query_civis(sql_cmd, database=database_name, preview_rows=n,
+                               polling_interval=3)
+    cols, rows = fut.result()['result_columns'], fut.result()['result_rows']
+    print('...Query complete.\n')
+    print(_str_table_result(cols, rows))
+
+
+def _str_table_result(cols, rows):
+    """Turn a Civis Query result into a readable table."""
+    # Determine the maximum width of each column.
+    # First find the width of each element in each row, then find the max
+    # width in each position.
+    max_len = functools.reduce(
+        lambda x, y: [max(z) for z in zip(x, y)],
+        [[len(_v) for _v in _r] for _r in [cols] + rows])
+
+    header_str = " | ".join("{0:<{width}}".format(_v, width=_l)
+                            for _l, _v in zip(max_len, cols))
+    tb_strs = [header_str, len(header_str) * '-']
+    for row in rows:
+        tb_strs.append(" | ".join("{0:>{width}}".format(_v, width=_l)
+                                  for _l, _v in zip(max_len, row)))
+    return '\n'.join(tb_strs)
 
 
 @click.command('download')

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from civis.cli.__main__ import generate_cli, invoke, make_operation_name
+from civis.cli._cli_commands import _str_table_result
 from civis.compat import mock
 from civis.tests import TEST_SPEC
 
@@ -118,3 +119,11 @@ def test_parameter_case(mock_session):
 )
 def test_make_operation_name(path, method, resource_name, exp):
     assert make_operation_name(path, method, resource_name) == exp
+
+
+def test_str_table_result():
+    cols = ['a', 'snake!']
+    rows = [['2', '3'], ['1.1', '3.3']]
+
+    out = _str_table_result(cols, rows)
+    assert out == "a   | snake!\n------------\n  2 |      3\n1.1 |    3.3"

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -59,3 +59,27 @@ backend for your Jupyter notebooks.
 - ``civis notebooks open $NOTEBOOK_ID``
 
   Open an existing notebook (which may or may not be running) in your default browser.
+
+SQL
+---
+
+The Civis CLI allows for easy running of SQL queries on Civis Platform
+through the following commands:
+
+- ``civis sql run [-n $MAX_LINES] $DATABASE_NAME $FILE_NAME``
+
+  Read a SQL query from a text file and run it on the specified database.
+  The results of the query, if any, will be shown after it completes.
+
+- ``civis sql cmd [-n $MAX_LINES] $DATABASE_NAME [$SQL_QUERY]``
+
+  Similar to ``civis sql run``, but read query text from the command line
+  argument instead of from a file. If you do not provide a query on the
+  command line, you may type a multi-line query beneath, ending with a
+  blank line.
+
+- ``civis sql download $DATABASE_NAME $SQL_FILE_NAME $OUTPUT_FILE_NAME
+
+  Read a SQL query from a text file and run it on the specified database.
+  The complete results of the query will be downloaded to a CSV file
+  at the requested location after the query completes.


### PR DESCRIPTION
Provide options to run SQL commands through the CLI. Users can either run a command with short output from a file or from the command line, or download the results of a query.