### PR TITLE
BUG container->custom in run_template

### DIFF
--- a/civis/tests/test_jobs.py
+++ b/civis/tests/test_jobs.py
@@ -39,7 +39,7 @@ def mock_client_single_json_output():
             }
         )
     ]
-    mock_client.scripts.list_containers_runs_outputs.return_value = mock_output
+    mock_client.scripts.list_custom_runs_outputs.return_value = mock_output
     return mock_client
 
 
@@ -64,7 +64,7 @@ def mock_client_multiple_json_output():
             }
         ),
     ]
-    mock_client.scripts.list_containers_runs_outputs.return_value = mock_output
+    mock_client.scripts.list_custom_runs_outputs.return_value = mock_output
     return mock_client
 
 
@@ -81,7 +81,7 @@ def mock_client_no_json_output():
             }
         )
     ]
-    mock_client.scripts.list_containers_runs_outputs.return_value = mock_output
+    mock_client.scripts.list_custom_runs_outputs.return_value = mock_output
     return mock_client
 
 

--- a/civis/utils/_jobs.py
+++ b/civis/utils/_jobs.py
@@ -83,7 +83,7 @@ def run_template(id, arguments, JSONValue=False, client=None):
         client.scripts.get_custom_runs, (job.id, run.id), client=client
     )
     fut.result()
-    outputs = client.scripts.list_containers_runs_outputs(job.id, run.id)
+    outputs = client.scripts.list_custom_runs_outputs(job.id, run.id)
     if JSONValue:
         json_output = [
             o.value for o in outputs if o.object_type == "JSONValue"


### PR DESCRIPTION
The `list_container` command works when the Custom script is running from a Container script template, but it fails for templates of other types of scripts (e.g. Python or R).