### PR TITLE
ENH Optional `name` arg in civis.io.file_to_civis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)
 
 ### Changed
-
+- Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 
 ## 1.11.0 - 2019-08-26
 ### Added

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -183,8 +183,8 @@ def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
         treated as paths to local files to open.
     name : str, optional
         The name you wish to give the file. If not given, it will be inferred
-        from the basename of `buf` (if `buf` is a string for a file path) or
-        `buf.name` (if `buf` is a file-like object).
+        from the basename of ``buf`` (if ``buf`` is a string for a file path)
+        or ``buf.name`` (if ``buf`` is a file-like object).
     api_key : DEPRECATED str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.
@@ -200,21 +200,23 @@ def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
     file_id : int
         The new Civis file ID.
 
+    Raises
+    ------
+    ValueError
+        If ``name`` is not provided and cannot be inferred from ``buf``
+
     Examples
     --------
     >>> # Upload file at a given path on the local filesystem.
     >>> file_id = file_to_civis("my_data.csv", 'my_data')
+    >>> # If not given, ``name`` will be the basename of the given file path.
+    >>> file_id = file_to_civis("foo/bar/data.csv")  # ``name`` is 'data.csv'
     >>> # Upload file which expires in 30 days
     >>> with open("my_data.csv", "r") as f:
     ...     file_id = file_to_civis(f, 'my_data')
     >>> # Upload file which never expires
     >>> with open("my_data.csv", "r") as f:
     ...     file_id = file_to_civis(f, 'my_data', expires_at=None)
-
-    Raises
-    ------
-    ValueError
-        If `name` is not provided and cannot be inferred from `buf`
 
     Notes
     -----

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -211,6 +211,11 @@ def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
     >>> with open("my_data.csv", "r") as f:
     ...     file_id = file_to_civis(f, 'my_data', expires_at=None)
 
+    Raises
+    ------
+    ValueError
+        If `name` is not provided and cannot be inferred from `buf`
+
     Notes
     -----
     If you are opening a binary file (e.g., a compressed archive) to

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -202,7 +202,7 @@ def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
 
     Raises
     ------
-    ValueError
+    TypeError
         If ``name`` is not provided and cannot be inferred from ``buf``
 
     Examples
@@ -243,7 +243,7 @@ def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
                 "`buf` is a file-like object, but its name cannot be inferred."
                 " Please provide `name` explicitly."
             )
-            raise ValueError(msg)
+            raise TypeError(msg)
 
     if isinstance(buf, six.string_types):
         with open(buf, 'rb') as f:

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -173,7 +173,7 @@ def _multipart_upload(buf, name, file_size, client, **kwargs):
 
 
 @deprecate_param('v2.0.0', 'api_key')
-def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
+def file_to_civis(buf, name=None, api_key=None, client=None, **kwargs):
     """Upload a file to Civis.
 
     Parameters
@@ -181,8 +181,10 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     buf : file-like object or str
         The file or other buffer that you wish to upload. Strings will be
         treated as paths to local files to open.
-    name : str
-        The name you wish to give the file.
+    name : str, optional
+        The name you wish to give the file. If not given, it will be inferred
+        from the basename of `buf` (if `buf` is a string for a file path) or
+        `buf.name` (if `buf` is a file-like object).
     api_key : DEPRECATED str, optional
         Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
         environment variable will be used.
@@ -224,6 +226,18 @@ def file_to_civis(buf, name, api_key=None, client=None, **kwargs):
     Small or non-seekable file-like objects will be uploaded with a
     single post.
     """
+    if name is None:
+        if isinstance(buf, six.string_types):
+            name = os.path.basename(buf)
+        elif hasattr(buf, 'name'):
+            name = buf.name
+        else:
+            msg = (
+                "`buf` is a file-like object, but its name cannot be inferred."
+                " Please provide `name` explicitly."
+            )
+            raise ValueError(msg)
+
     if isinstance(buf, six.string_types):
         with open(buf, 'rb') as f:
             return _file_to_civis(

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -477,18 +477,19 @@ def test_civis_to_file_retries(mock_requests):
          mock_civis.files.get.return_value.file_url, stream=True)
 
 
+@pytest.mark.parametrize('input_filename', ['newname', None])
 @mock.patch.object(_files, 'requests', autospec=True)
-def test_file_to_civis(mock_requests):
+def test_file_to_civis(mock_requests, input_filename):
     # Test that file_to_civis posts a Civis File with the API client
     # and calls `requests.post` on the returned URL.
     mock_civis = create_client_mock()
     civis_name, expected_id = 'newname', 137
     mock_civis.files.post.return_value.id = expected_id
     with TemporaryDirectory() as tdir:
-        fname = os.path.join(tdir, 'testfile')
+        fname = os.path.join(tdir, 'newname')
         with open(fname, 'wt') as _fout:
             _fout.write('abcdef')
-        fid = _files.file_to_civis(fname, civis_name, expires_at=None,
+        fid = _files.file_to_civis(fname, input_filename, expires_at=None,
                                    client=mock_civis)
     assert fid == expected_id
     mock_civis.files.post.assert_called_once_with(civis_name, expires_at=None)


### PR DESCRIPTION
This main issue that this PR aims to address is to avoid having to write client code like `civis.io.file_to_civis('foobar.txt', 'foobar.txt')`, where the second arg `name` is obligatory currently (as of v1.11.0) but seems unnecessary. I think it'd be perfectly reasonable to allow code like `civis.io.file_to_civis('foobar.txt')` where `name` can internally be inferred from the basename of the given file path -- this is what this PR implements.