### PR TITLE
ADD: CLI command for civis username

### DIFF
--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -25,8 +25,8 @@ import click
 from jsonref import JsonRef
 import yaml
 from civis.cli._cli_commands import (
-    civis_ascii_art, files_download_cmd, files_upload_cmd,
-    notebooks_download_cmd, notebooks_new_cmd,
+    civis_ascii_art, civis_username, files_download_cmd,
+    files_upload_cmd, notebooks_download_cmd, notebooks_new_cmd,
     notebooks_up, notebooks_down, notebooks_open, sql_cmd)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis.resources._resources import parse_method_name
@@ -225,6 +225,7 @@ def add_extra_commands(cli):
     notebooks_cmd.add_command(notebooks_down)
     notebooks_cmd.add_command(notebooks_open)
     cli.add_command(civis_ascii_art)
+    cli.add_command(civis_username)
 
     cli.add_command(sql_cmd)
 

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -242,3 +242,10 @@ def _notebooks_open(notebook_id):
 @click.command('civis', help="Print Civis")
 def civis_ascii_art():
     print(_CIVIS_ASCII_ART)
+
+
+@click.command('username', help="Print Civis username")
+def civis_username():
+    """Prints the username of the current user."""
+    client = civis.APIClient()
+    print(client.username)


### PR DESCRIPTION
I recently became aware of the CLI and the command `civis users list-me` which I now regularly use to see which CIVIS_API_KEY I have active. `list-me` returns a lot of information about my current user, but for my purposes the username would be sufficient. This PR adds a command to the CLI to print out the response from `civis.APIClient().username`