### PR TITLE
[PARO-745] register_pretrained_model should keep estimator indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added debug logging to some `civis.io` functions. (#325)
 
 ### Fixed
+- `ModelPipeline.register_pretrained_model` should persist the user-supplied
+  estimator object indefinitely. (#331)
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)
 - Fixed issue in `civis.io.read_civis_sql` when returning data that contains 
   double quotes. (#328)

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -830,6 +830,8 @@ class ModelPipeline:
             The model object. This must be a fitted scikit-learn compatible
             Estimator object, or else the integer Civis File ID of a
             pickle or joblib-serialized file which stores such an object.
+            If an Estimator object is provided, it will be uploaded to the
+            Civis Files endpoint and set to be available indefinitely.
         dependent_variable : string or List[str], optional
             The dependent variable of the training dataset.
             For a multi-target problem, this should be a list of
@@ -902,8 +904,8 @@ class ModelPipeline:
                     # NB: Using the name "estimator.pkl" means that
                     # CivisML doesn't need to copy this input to a file
                     # with a different name.
-                    model_file_id = cio.file_to_civis(_fout, 'estimator.pkl',
-                                                      client=client)
+                    model_file_id = cio.file_to_civis(
+                        _fout, 'estimator.pkl', expires_at=None, client=client)
             finally:
                 shutil.rmtree(tempdir)
 


### PR DESCRIPTION
`ModelPipeline.register_pretrained_model` should keep the user-supplied estimator indefinitely on the Civis Files endpoint.