### PR TITLE
DEP deprecation warning in readme and on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
-- Issue a `DeprecationWarning` on import for Python 2 users. (#333)
+- Issue a `FutureWarning` on import for Python 2 users. (#333)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
+- Issue a `DeprecationWarning` on import for Python 2 users. (#333)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,9 @@ Civis API Python Client
    :target: https://pypi.org/project/civis/
    :alt: Supported python versions for civis-python
 
-**Deprecation Warning:** The Civis API Python Client will no longer
-support Python 2.7 as of version 1.13.0.
+**Deprecation Warning:** Civis will no longer support Python 2.7 as of
+April 1, 2020. The first Civis API Python Client release made after
+that date will remove Python 2 support.
 
 
 Introduction

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,9 @@ Civis API Python Client
    :target: https://pypi.org/project/civis/
    :alt: Supported python versions for civis-python
 
+**Deprecation Warning:** The Civis API Python Client will no longer
+support Python 2.7 as of version 1.13.0.
+
 
 Introduction
 ------------

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -10,7 +10,7 @@ from civis import io, ml, parallel, utils
 if six.PY2:
     warnings.warn("Support for Python 2 is deprecated will be "
                   "removed in the next version release after "
-                  "April 1, 2020.", DeprecationWarning)
+                  "April 1, 2020.", FutureWarning)
 
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -1,8 +1,17 @@
 from __future__ import absolute_import
 
+import six
+import warnings
+
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
 from civis import io, ml, parallel, utils
+
+if six.PY2:
+    warnings.warn("Support for Python 2 is deprecated will be "
+                  "removed in the next version release after "
+                  "April 1, 2020.", DeprecationWarning)
+
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
            "ml", "parallel", "utils"]


### PR DESCRIPTION
This PR adds a note in the README that Python 2 will no longer be supported as of April 1, 2020. The Python client will also issue a warning to Python 2 users when imported. I've attached an image below of what this looks like. One wrinkle here is that interpreters ignore deprecation warnings by default, so this doesn't show up unless the user disables that default. I don't know that there's a good way around this problem.

I initially tried writing a unit test for this, but I couldn't get it to pass, I think because pytest imports the library as it's setting up the tests. The warning did show up in the pytest warning summary, but was not captured in the unit test. I confirmed manually that the warning issues for Python 2 and does not issue for Python 3.

Closes #332 .

![image](https://user-images.githubusercontent.com/11319980/71130086-b6a12500-21b6-11ea-9fd3-ac3e7f77313b.png)
