### PR TITLE
ENH more informative error for expired files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Raise a more informative exception when calling `file_to_dataframe`
-  on an expired file. (#335)
+  on an expired file. (#337)
 - `ModelPipeline.register_pretrained_model` should persist the user-supplied
   estimator object indefinitely. (#331)
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added debug logging to some `civis.io` functions. (#325)
 
 ### Fixed
+- Raise a more informative exception when calling `file_to_dataframe`
+  on an expired file. (#335)
 - `ModelPipeline.register_pretrained_model` should persist the user-supplied
   estimator object indefinitely. (#331)
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)
@@ -16,13 +18,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
+- Pass `headers` and `delimiter` to Civis API endpoint for cleaning files in `civis.io.civis_file_to_table`. (#334)
 - Issue a `FutureWarning` on import for Python 2 users. (#333)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)
 - Added new arguments to `civis.io.civis_file_to_table` to expose additional functionality from new Civis API endpoints. (#328)
 - Added new arguments from `civis.io.civis_file_to_table` to `dataframe_to_civis` and `csv_to_civis` methods. (#328)
-- Pass `headers` and `delimiter` to Civis API endpoint for cleaning files in `civis.io.civis_file_to_table`. (#334)
 
 ## 1.11.0 - 2019-08-26
 ### Added

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -470,6 +470,10 @@ def file_to_dataframe(file_id, compression='infer', client=None,
     client = APIClient() if client is None else client
     file_info = client.files.get(file_id)
     file_url = file_info.file_url
+    if not file_url:
+        raise ValueError(
+            "File url does not exist for file {}. File may be expired.".format(
+                file_id))
     file_name = file_info.name
     if compression == 'infer':
         comp_exts = {'.gz': 'gzip', '.xz': 'xz', '.bz2': 'bz2', '.zip': 'zip'}

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -471,9 +471,9 @@ def file_to_dataframe(file_id, compression='infer', client=None,
     file_info = client.files.get(file_id)
     file_url = file_info.file_url
     if not file_url:
-        raise ValueError(
-            "File url does not exist for file {}. File may be expired.".format(
-                file_id))
+        raise EmptyResultError('Unable to locate file {}. If it previously '
+                               'existed, it may have '
+                               'expired.'.format(file_id))
     file_name = file_info.name
     if compression == 'infer':
         comp_exts = {'.gz': 'gzip', '.xz': 'xz', '.bz2': 'bz2', '.zip': 'zip'}

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -910,6 +910,18 @@ def test_file_id_from_run_output_platform_error():
 
 @pytest.mark.file_to_dataframe
 @pytest.mark.skipif(not has_pandas, reason="pandas not installed")
+def test_file_to_dataframe_expired():
+    m_client = mock.Mock()
+    url = None
+    m_client.files.get.return_value = Response({'name': 'spam.csv',
+                                                'file_url': url})
+    expected_err = "File url does not exist for file 121. File may be expired."
+    with pytest.raises(ValueError, match=expected_err):
+        civis.io.file_to_dataframe(121, client=m_client)
+
+
+@pytest.mark.file_to_dataframe
+@pytest.mark.skipif(not has_pandas, reason="pandas not installed")
 def test_file_to_dataframe_infer():
     m_client = mock.Mock()
     url = 'url'

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -19,7 +19,7 @@ import civis
 from civis.io import _files
 from civis.compat import mock, FileNotFoundError, TemporaryDirectory
 from civis.response import Response
-from civis.base import CivisAPIError, CivisImportError
+from civis.base import CivisAPIError, CivisImportError, EmptyResultError
 from civis.resources._resources import get_api_spec, generate_classes
 from civis.tests.testcase import (CivisVCRTestCase,
                                   cassette_dir,
@@ -915,8 +915,9 @@ def test_file_to_dataframe_expired():
     url = None
     m_client.files.get.return_value = Response({'name': 'spam.csv',
                                                 'file_url': url})
-    expected_err = "File url does not exist for file 121. File may be expired."
-    with pytest.raises(ValueError, match=expected_err):
+    expected_err = 'Unable to locate file 121. If it previously ' + \
+        'existed, it may have expired.'
+    with pytest.raises(EmptyResultError, match=expected_err):
         civis.io.file_to_dataframe(121, client=m_client)
 
 


### PR DESCRIPTION
Raise a more informative exception when calling `civis.io.file_to_dataframe` on a file with no url (which likely means the file is expired). I went with a `ValueError` here but could change it if a different exception would be easier to understand. This error check is pre-empting a `ValueError`, since the error comes from reading a csv from `None`.

Closes #336.