### PR TITLE
339 3.4 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
-- Issue a `FutureWarning` on import for Python 2 users. (#333)
+- Issue a `FutureWarning` on import for Python 2 and 3.4 users. (#333,
+  #340)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ Civis API Python Client
    :target: https://pypi.org/project/civis/
    :alt: Supported python versions for civis-python
 
-**Deprecation Warning:** Civis will no longer support Python 2.7 as of
-April 1, 2020. The first Civis API Python Client release made after
-that date will remove Python 2 support.
+**Deprecation Warning:** Civis will no longer support Python 2.7 or
+Python 3.4 as of April 1, 2020. The first Civis API Python Client
+release made after that date will remove Python 2 support.
 
 
 Introduction

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -12,7 +12,7 @@ if six.PY2:
     warnings.warn("Support for Python 2 is deprecated and will be "
                   "removed in the next version release after "
                   "April 1, 2020.", FutureWarning)
-if version_info.major == 3 & version_info.minor == 4:
+if version_info.major == 3 and version_info.minor == 4:
     warnings.warn("Support for Python 3.4 is deprecated and will be "
                   "removed in the next version release after "
                   "April 1, 2020.", FutureWarning)

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import six
+from sys import version_info
 import warnings
 
 from civis._version import __version__
@@ -8,7 +9,11 @@ from civis.civis import APIClient, find, find_one
 from civis import io, ml, parallel, utils
 
 if six.PY2:
-    warnings.warn("Support for Python 2 is deprecated will be "
+    warnings.warn("Support for Python 2 is deprecated and will be "
+                  "removed in the next version release after "
+                  "April 1, 2020.", FutureWarning)
+if version_info.major == 3 & version_info.minor == 4:
+    warnings.warn("Support for Python 3.4 is deprecated and will be "
                   "removed in the next version release after "
                   "April 1, 2020.", FutureWarning)
 


### PR DESCRIPTION
Adds a `FutureWarning` that Python 3.4 will be deprecated along with Python 2. Closes #339. I considered adding 3.5 to the list, since it's reaching EOL in 2020, but I figured it's better to be conservative about dropping support.

I don't know of a way to test that this code works within pytest (see discussion in #333 ), but I've attached screenshots confirming that the warning is issued in 3.4 and not in 3.6.
![image](https://user-images.githubusercontent.com/11319980/71633330-3082d680-2bd9-11ea-9203-0fb3d85e7956.png)
![image](https://user-images.githubusercontent.com/11319980/71633333-34165d80-2bd9-11ea-91ea-1e36e8b9827a.png)

