### PR TITLE
[PARO-685] [PARO-744] Decouple CivisML from civis-python: Use template ID aliases and move docs to Zendesk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
+- CivisML uses platform aliases instead of hard-coded template IDs. (#331)
+- CivisML versions and pre-installed packages are documented on Zendesk instead. (#331)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
-- CivisML uses platform aliases instead of hard-coded template IDs. (#331)
-- CivisML versions and pre-installed packages are documented on Zendesk instead. (#331)
+- CivisML uses platform aliases instead of hard-coded template IDs. (#332)
+- CivisML versions and pre-installed packages are documented on Zendesk instead. (#332)
 - Update the Civis logo in the Sphinx documentation. (#330)
 - Allow the `name` arg to be optional in `civis.io.file_to_civis`. (#324)
 - Refactor `civis.io.civis_file_to_table` to use a new set of Civis API endpoints for cleaning and importing CSV files. (#328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   double quotes. (#328)
 
 ### Changed
-- CivisML uses platform aliases instead of hard-coded template IDs. (#332)
-- CivisML versions and pre-installed packages are documented on Zendesk instead. (#332)
+- CivisML uses platform aliases instead of hard-coded template IDs. (#341)
+- CivisML versions and pre-installed packages are documented on Zendesk instead. (#341)
 - Pass `headers` and `delimiter` to Civis API endpoint for cleaning files in `civis.io.civis_file_to_table`. (#334)
 - Issue a `FutureWarning` on import for Python 2 users. (#333)
 - Update the Civis logo in the Sphinx documentation. (#330)

--- a/civis/ml/_helper.py
+++ b/civis/ml/_helper.py
@@ -40,11 +40,11 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     global _TEMPLATE_IDS
 
     if job_type == "train":
-        job_type_keys = ('training',)
+        job_types = ('training',)
     elif job_type == "predict":
-        job_type_keys = ('prediction',)
+        job_types = ('prediction',)
     elif job_type is None:
-        job_type_keys = ('training', 'prediction')
+        job_types = ('training', 'prediction')
     else:
         raise ValueError("Parameter 'job_type' must be None, 'train', "
                          "or 'predict'.")
@@ -56,8 +56,8 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
         _TEMPLATE_IDS = _get_template_ids_all_versions(client)
 
     template_id_list = [
-        ids[job_type_key]
-        for job_type_key in job_type_keys
+        ids[job_type]
+        for job_type in job_types
         for ids in _TEMPLATE_IDS.values()
     ]
     # Applying set() because we don't want repeated IDs

--- a/civis/ml/_helper.py
+++ b/civis/ml/_helper.py
@@ -56,8 +56,8 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
         _TEMPLATE_IDS = _get_template_ids_all_versions(client)
 
     template_id_list = [
-        ids[job_type]
-        for job_type in job_types
+        ids[_job_type]
+        for _job_type in job_types
         for ids in _TEMPLATE_IDS.values()
     ]
     # Applying set() because we don't want repeated IDs

--- a/civis/ml/_helper.py
+++ b/civis/ml/_helper.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import logging
 
 from civis import APIClient
-from civis.ml._model import _PRED_TEMPLATES
+from civis.ml._model import _get_template_ids_all_versions
 
 __all__ = ['list_models', 'put_models_shares_groups',
            'put_models_shares_users', 'delete_models_shares_groups',
@@ -11,6 +11,8 @@ log = logging.getLogger(__name__)
 
 # sentinel value for default author value
 SENTINEL = namedtuple('Sentinel', [])()
+
+_TEMPLATE_IDS = None  # To be updated by _get_template_ids_all_versions
 
 
 def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
@@ -35,22 +37,32 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     --------
     APIClient.scripts.list_custom
     """
+    global _TEMPLATE_IDS
+
     if job_type == "train":
-        template_id_list = list(_PRED_TEMPLATES.keys())
+        job_type_keys = ('training',)
     elif job_type == "predict":
-        # get a unique list of prediction ids
-        template_id_list = list(set(_PRED_TEMPLATES.values()))
+        job_type_keys = ('prediction',)
     elif job_type is None:
-        # use sets to make sure there's no duplicate ids
-        template_id_list = list(set(_PRED_TEMPLATES.keys()).union(
-                            set(_PRED_TEMPLATES.values())))
+        job_type_keys = ('training', 'prediction')
     else:
         raise ValueError("Parameter 'job_type' must be None, 'train', "
                          "or 'predict'.")
-    template_id_str = ', '.join([str(tmp) for tmp in template_id_list])
 
     if client is None:
         client = APIClient()
+
+    if _TEMPLATE_IDS is None:
+        _TEMPLATE_IDS = _get_template_ids_all_versions(client)
+
+    template_id_list = [
+        ids[job_type_key]
+        for job_type_key in job_type_keys
+        for ids in _TEMPLATE_IDS.values()
+    ]
+    # Applying set() because we don't want repeated IDs
+    # between the version-less production alias and the versioned alias.
+    template_id_str = ', '.join(str(tmp) for tmp in set(template_id_list))
 
     if author is SENTINEL:
         author = client.users.list_me().id

--- a/civis/ml/_helper.py
+++ b/civis/ml/_helper.py
@@ -12,8 +12,6 @@ log = logging.getLogger(__name__)
 # sentinel value for default author value
 SENTINEL = namedtuple('Sentinel', [])()
 
-_TEMPLATE_IDS = None  # To be updated by _get_template_ids_all_versions
-
 
 def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     """List a user's CivisML models.
@@ -37,8 +35,6 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     --------
     APIClient.scripts.list_custom
     """
-    global _TEMPLATE_IDS
-
     if job_type == "train":
         job_types = ('training',)
     elif job_type == "predict":
@@ -52,13 +48,10 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     if client is None:
         client = APIClient()
 
-    if _TEMPLATE_IDS is None:
-        _TEMPLATE_IDS = _get_template_ids_all_versions(client)
-
     template_id_list = [
         ids[_job_type]
         for _job_type in job_types
-        for ids in _TEMPLATE_IDS.values()
+        for ids in _get_template_ids_all_versions(client).values()
     ]
     # Applying set() because we don't want repeated IDs
     # between the version-less production alias and the versioned alias.

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     HAS_SKLEARN = False
 
-from civis import APIClient, find, find_one, __version__
+from civis import APIClient, find, find_one
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.compat import FileNotFoundError, TemporaryDirectory

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -289,7 +289,8 @@ def _get_job_type_version(alias):
         job_type = match_special.group(1)
         version = match_special.group(2)
     else:
-        msg = '"%r" does not look like a CivisML alias'
+        msg = ('Unable to parse the job type and version '
+               'from the CivisML alias "%r"')
         raise ValueError(msg % alias)
 
     return job_type, version
@@ -321,7 +322,15 @@ def _get_template_ids_all_versions(client):
         lambda: {'training': None, 'prediction': None, 'registration': None}
     )
     for alias_obj in civisml_template_alias_objects:
-        job_type, version = _get_job_type_version(alias_obj.alias)
+        try:
+            job_type, version = _get_job_type_version(alias_obj.alias)
+        except ValueError:
+            msg = (
+                '%r looks like a CivisML alias for the prefix "civis-civisml-"'
+                ', but it is impossible to parse its job type and version'
+            )
+            log.debug(msg % alias_obj)
+            continue
         ids[version][job_type] = alias_obj.object_id
     if not ids:
         r = Response({'status_code': 404,

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -308,11 +308,20 @@ def _get_template_ids(civisml_version, client):
         ids = _TEMPLATE_IDS[civisml_version]
     except KeyError:
         msg = (
-            '%r is an invalid CivisML version. Valid versions are in the '
-            'form of "v2.3", "v2.2", etc., '
-            'or simply None for the latest production version.'
+            '"{civisml_version}" is an invalid CivisML version. '
+            'Either this version does not exist, or you do not have access '
+            'to this version. '
+            'Versions accessible to you are {{{accessible_versions}}}, '
+            'as well as `None` for the latest production version.'
+        ).format(
+            civisml_version=civisml_version,
+            accessible_versions=', '.join(
+                '"%s"' % v
+                # Don't include None, or else it would crash sorted()
+                for v in sorted(v for v in _TEMPLATE_IDS.keys() if v)
+            )
         )
-        raise ValueError(msg % civisml_version)
+        raise ValueError(msg)
     return ids['training'], ids['prediction'], ids['registration']
 
 

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -274,20 +274,20 @@ def _get_job_type_version(alias):
     str
         CivisML version, e.g., "v2.2".
     """
+    # A version-less alias for production, e.g., "civis-civisml-training"
     match_production = re.search(r'\Acivis-civisml-(\w+)\Z', alias)
+    # A versioned alias, e.g., "civis-civisml-training-v2-3"
     match_v = re.search(r'\Acivis-civisml-(\w+)-v(\d+)-(\d+)\Z', alias)
+    # A special-version alias, e.g., "civis-civisml-training-dev"
     match_special = re.search(r'\Acivis-civisml-(\w+)-(\S+[^-])\Z', alias)
 
     if match_production:
-        # A production alias, e.g., "civis-civisml-training"
         job_type = match_production.group(1)
         version = None
     elif match_v:
-        # A versioned alias, e.g., "civis-civisml-training-v2-3"
         job_type = match_v.group(1)
         version = 'v%s.%s' % match_v.group(2, 3)
     elif match_special:
-        # A special-version alias, "civis-civisml-training-dev"
         job_type = match_special.group(1)
         version = match_special.group(2)
     else:
@@ -308,7 +308,7 @@ def _get_template_ids_all_versions(client):
     Returns
     -------
     Dict[str, Dict[str, int]]
-        Mapping between versions (e.g., "v2.2") and template Ids for the given
+        Mapping between versions (e.g., "v2.2") and template IDs for the given
         version (e.g., {'training': 1, 'prediction': 2, 'registration': 3}).
     """
     template_alias_objects = client.aliases.list(

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -258,6 +258,20 @@ def _show_civisml_warnings(warn_list):
 
 
 def _get_job_type_version(alias):
+    """Derive the job type and version from the given alias.
+
+    Parameters
+    ----------
+    alias : str
+        CivisML alias
+
+    Returns
+    -------
+    str
+        Job type, one of {training, prediction, registration}.
+    str
+        CivisML version, e.g., "v2.2".
+    """
     match_production = re.search(r'\Acivis-civisml-(\w+)\Z', alias)
     match_v = re.search(r'\Acivis-civisml-(\w+)-v(\d+)-(\d+)\Z', alias)
     match_special = re.search(r'\Acivis-civisml-(\w+)-(\S+[^-])\Z', alias)
@@ -282,6 +296,19 @@ def _get_job_type_version(alias):
 
 
 def _get_template_ids_all_versions(client):
+    """Get templates IDs for all accessible CivisML versions.
+
+    Parameters
+    ----------
+    client : APIClient
+        Civis API client object
+
+    Returns
+    -------
+    Dict[str, Dict[str, int]]
+        Mapping between versions (e.g., "v2.2") and template Ids for the given
+        version (e.g., {'training': 1, 'prediction': 2, 'registration': 3}).
+    """
     template_alias_objects = client.aliases.list(
         object_type='template_script', iterator=True
     )
@@ -301,6 +328,24 @@ def _get_template_ids_all_versions(client):
 
 
 def _get_template_ids(civisml_version, client):
+    """Get template IDs for the specified CivisML version.
+
+    Parameters
+    ----------
+    civisml_version : str
+        CivisML version
+    client : APIClient
+        Civis API client object
+
+    Returns
+    -------
+    int
+        Template ID for training
+    int
+        Template ID for prediction
+    int
+        Template ID for pre-trained model registration
+    """
     global _TEMPLATE_IDS
     if _TEMPLATE_IDS is None:
         _TEMPLATE_IDS = _get_template_ids_all_versions(client)

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -269,7 +269,7 @@ def _get_job_type_version(alias):
     elif match_v:
         # A versioned alias, e.g., "civis-civisml-training-v2-3"
         job_type = match_v.group(1)
-        version = '%s.%s' % match_v.group(2, 3)
+        version = 'v%s.%s' % match_v.group(2, 3)
     elif match_special:
         # A special-version alias, "civis-civisml-training-dev"
         job_type = match_special.group(1)
@@ -309,7 +309,7 @@ def _get_template_ids(civisml_version, client):
     except KeyError:
         msg = (
             '%r is an invalid CivisML version. Valid versions are in the '
-            'form of "2.3", "2.2", etc., '
+            'form of "v2.3", "v2.2", etc., '
             'or simply None for the latest production version.'
         )
         raise ValueError(msg % civisml_version)
@@ -958,8 +958,8 @@ class ModelPipeline:
             msg = (
                 'No registration template ID is available. '
                 'Pre-trained model registration is available for CivisML '
-                'v2.2 (for which `civisml_version` would be "2.2") or above, '
-                'but you have specified CivisML version %r'
+                'v2.2 (for which `civisml_version` would be "v2.2") or above, '
+                'but you have specified CivisML version "%r"'
             )
             raise ValueError(msg % civisml_version)
         container = client.scripts.post_custom(

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -260,7 +260,7 @@ def _show_civisml_warnings(warn_list):
 def _get_job_type_version(alias):
     match_production = re.search(r'\Acivis-civisml-(\w+)\Z', alias)
     match_v = re.search(r'\Acivis-civisml-(\w+)-v(\d+)-(\d+)\Z', alias)
-    match_special = re.search(r'\Acivis-civisml-(\w+)-(\w+)\Z', alias)
+    match_special = re.search(r'\Acivis-civisml-(\w+)-(\S+[^-])\Z', alias)
 
     if match_production:
         # A production alias, e.g., "civis-civisml-training"

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -2,10 +2,11 @@
 """
 import builtins
 from builtins import super
-from collections import namedtuple
+import collections
 import json
 import logging
 import os
+import re
 import shutil
 import six
 import tempfile
@@ -32,21 +33,9 @@ __all__ = ['ModelFuture', 'ModelError', 'ModelPipeline']
 log = logging.getLogger(__name__)
 
 # sentinel value for default primary key value
-SENTINEL = namedtuple('Sentinel', [])()
+SENTINEL = collections.namedtuple('Sentinel', [])()
 
-# Map training template to prediction template so that we
-# always use a compatible version for predictions.
-_PRED_TEMPLATES = {11219: 11220,  # v2.2
-                   11221: 11220,  # v2.2 registration
-                   10582: 10583,  # v2.1
-                   9968: 9969,    # v2.0
-                   9112: 9113,    # v1.1
-                   8387: 8388,    # v1.0
-                   7020: 7021,    # v0.5
-                   }
-_CIVISML_TEMPLATE = None  # CivisML training template to use
-REGISTRATION_TEMPLATES = [11221,  # v2.2
-                          ]
+_TEMPLATE_IDS = None  # To be updated by _get_template_ids_all_versions
 
 
 class ModelError(RuntimeError):
@@ -266,6 +255,65 @@ def _show_civisml_warnings(warn_list):
         except Exception:  # NOQA
             warn_str = "Remote warning from CivisML:\n" + warn_str
             warnings.warn(warn_str, RuntimeWarning)
+
+
+def _get_job_type_version(alias):
+    match_production = re.search(r'\Acivis-civisml-(\w+)\Z', alias)
+    match_v = re.search(r'\Acivis-civisml-(\w+)-v(\d+)-(\d+)\Z', alias)
+    match_special = re.search(r'\Acivis-civisml-(\w+)-(\w+)\Z', alias)
+
+    if match_production:
+        # A production alias, e.g., "civis-civisml-training"
+        job_type = match_production.group(1)
+        version = None
+    elif match_v:
+        # A versioned alias, e.g., "civis-civisml-training-v2-3"
+        job_type = match_v.group(1)
+        version = '%s.%s' % match_v.group(2, 3)
+    elif match_special:
+        # A special-version alias, "civis-civisml-training-dev"
+        job_type = match_special.group(1)
+        version = match_special.group(2)
+    else:
+        msg = '"%r" does not look like a CivisML alias'
+        raise ValueError(msg % alias)
+
+    return job_type, version
+
+
+def _get_template_ids_all_versions(client):
+    template_alias_objects = client.aliases.list(
+        object_type='template_script', iterator=True
+    )
+    civisml_template_alias_objects = find(
+        template_alias_objects,
+        alias=lambda alias: alias.startswith('civis-civisml-')
+    )
+    ids = collections.defaultdict(
+        lambda: {'training': None, 'prediction': None, 'registration': None}
+    )
+    for alias_obj in civisml_template_alias_objects:
+        job_type, version = _get_job_type_version(alias_obj.alias)
+        ids[version][job_type] = alias_obj.object_id
+    if not ids:
+        raise CivisAPIError('No CivisML template IDs are accessible.')
+    return ids
+
+
+def _get_template_ids(civisml_version, client):
+    global _TEMPLATE_IDS
+    if _TEMPLATE_IDS is None:
+        _TEMPLATE_IDS = _get_template_ids_all_versions(client)
+    try:
+        ids = _TEMPLATE_IDS[civisml_version]
+    except KeyError:
+        msg = (
+            '%r is an invalid CivisML version. Valid versions are in the '
+            'form of "2.3", "2.2", etc., '
+            'or simply None for the latest production version.'
+        )
+        raise ValueError(msg % civisml_version)
+    return ids['training'], ids['prediction'], ids['registration']
 
 
 class ModelFuture(ContainerFuture):
@@ -665,6 +713,9 @@ class ModelPipeline:
     etl : Estimator, optional
         Custom ETL estimator which overrides the default ETL, and
         is run before training and validation.
+    civisml_version : str, optional
+        CivisML version to use for training and prediction.
+        If not provided, the latest version in production is used.
 
     Methods
     -------
@@ -723,32 +774,6 @@ class ModelPipeline:
     --------
     civis.ml.ModelFuture
     """
-    def _get_template_ids(self, client):
-        """Determine which version of CivisML to use.
-
-        Select the most recent template to which the user has access.
-        Used for internal or limited releases of new CivisML versions.
-        """
-        global _CIVISML_TEMPLATE
-        if _CIVISML_TEMPLATE is None:
-            for t_id in sorted(_PRED_TEMPLATES)[::-1]:
-                if t_id in REGISTRATION_TEMPLATES:
-                    continue
-                try:
-                    # Check that we can access the template
-                    client.templates.get_scripts(id=t_id)
-                    client.templates.get_scripts(id=_PRED_TEMPLATES[t_id])
-                except CivisAPIError:
-                    continue
-                else:
-                    # Store the template ID so we don't need to repeat
-                    # these API calls in this session.
-                    _CIVISML_TEMPLATE = t_id
-                    break
-            else:
-                raise RuntimeError("Unable to find a CivisML template.")
-        return _CIVISML_TEMPLATE, _PRED_TEMPLATES[_CIVISML_TEMPLATE]
-
     def __init__(self, model, dependent_variable,
                  primary_key=None, parameters=None,
                  cross_validation_parameters=None, model_name=None,
@@ -756,7 +781,7 @@ class ModelPipeline:
                  cpu_requested=None, memory_requested=None,
                  disk_requested=None, notifications=None,
                  dependencies=None, git_token_name=None, verbose=False,
-                 etl=None):
+                 etl=None, civisml_version=None):
         self.model = model
         self._input_model = model  # In case we need to modify the input
         if isinstance(dependent_variable, six.string_types):
@@ -784,8 +809,8 @@ class ModelPipeline:
         self._client = client
         self.train_result_ = None
 
-        template_ids = self._get_template_ids(self._client)
-        self.train_template_id, self.predict_template_id = template_ids
+        template_ids = _get_template_ids(civisml_version, self._client)
+        self.train_template_id, self.predict_template_id, _ = template_ids
 
         self.etl = etl
         if self.train_template_id < 9968 and self.etl is not None:
@@ -801,8 +826,6 @@ class ModelPipeline:
     def __setstate__(self, state):
         self.__dict__ = state
         self._client = APIClient()
-        template_ids = self._get_template_ids(self._client)
-        self.train_template_id, self.predict_template_id = template_ids
 
     @classmethod
     def register_pretrained_model(cls, model, dependent_variable=None,
@@ -810,7 +833,7 @@ class ModelPipeline:
                                   model_name=None, dependencies=None,
                                   git_token_name=None,
                                   skip_model_check=False, verbose=False,
-                                  client=None):
+                                  client=None, civisml_version=None):
         """Use a fitted scikit-learn model with CivisML scoring
 
         Use this function to set up your own fitted scikit-learn-compatible
@@ -862,6 +885,9 @@ class ModelPipeline:
         client : :class:`~civis.APIClient`, optional
             If not provided, an :class:`~civis.APIClient` object will be
             created from the :envvar:`CIVIS_API_KEY`.
+        civisml_version : str, optional
+            CivisML version to use.
+            If not provided, the latest version in production is used.
 
         Returns
         -------
@@ -871,6 +897,7 @@ class ModelPipeline:
         --------
         This example assumes that you already have training data
         ``X`` and ``y``, where ``X`` is a :class:`~pandas.DataFrame`.
+
         >>> from civis.ml import ModelPipeline
         >>> from sklearn.linear_model import Lasso
         >>> est = Lasso().fit(X, y)
@@ -926,7 +953,15 @@ class ModelPipeline:
                                  .format(git_token_name))
             args['GIT_CRED'] = creds[0].id
 
-        template_id = max(REGISTRATION_TEMPLATES)
+        _, _, template_id = _get_template_ids(civisml_version, client)
+        if template_id is None:
+            msg = (
+                'No registration template ID is available. '
+                'Pre-trained model registration is available for CivisML '
+                'v2.2 (for which `civisml_version` would be "2.2") or above, '
+                'but you have specified CivisML version %r'
+            )
+            raise ValueError(msg % civisml_version)
         container = client.scripts.post_custom(
             from_template_id=template_id,
             name=model_name,
@@ -977,9 +1012,13 @@ class ModelPipeline:
         >>> model.train_result_.metrics['roc_auc']
         0.843
         """
+        global _TEMPLATE_IDS
+
         train_job_id = int(train_job_id)  # Convert np.int to int
         if client is None:
             client = APIClient()
+        if _TEMPLATE_IDS is None:
+            _TEMPLATE_IDS = _get_template_ids_all_versions(client)
         train_run_id = _decode_train_run(train_job_id, train_run_id, client)
         try:
             fut = ModelFuture(train_job_id, train_run_id, client=client)
@@ -1040,17 +1079,11 @@ class ModelPipeline:
 
         # Set prediction template corresponding to training template
         template_id = int(container['from_template_id'])
-        p_id = _PRED_TEMPLATES.get(template_id)
-        if p_id is None:
-            warnings.warn('Model %s was trained with a newer version of '
-                          'CivisML than is available in the API client '
-                          'version %s. Please update your API client version. '
-                          'Attempting to use an older version of the '
-                          'prediction code. Prediction will either fail '
-                          'immediately or succeed.'
-                          % (train_job_id, __version__), RuntimeWarning)
-            p_id = max([v for k, v in _PRED_TEMPLATES.items()
-                        if k not in REGISTRATION_TEMPLATES])
+        ids = find_one(
+            _TEMPLATE_IDS.values(),
+            lambda ids: ids['training'] == template_id
+        )
+        p_id = ids['prediction']
         klass.predict_template_id = p_id
 
         return klass

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -28,6 +28,8 @@ from civis.base import CivisAPIError, CivisJobFailure
 from civis.compat import FileNotFoundError, TemporaryDirectory
 import civis.io as cio
 from civis.futures import ContainerFuture
+from civis.response import Response
+
 
 __all__ = ['ModelFuture', 'ModelError', 'ModelPipeline']
 log = logging.getLogger(__name__)
@@ -323,7 +325,10 @@ def _get_template_ids_all_versions(client):
         job_type, version = _get_job_type_version(alias_obj.alias)
         ids[version][job_type] = alias_obj.object_id
     if not ids:
-        raise CivisAPIError('No CivisML template IDs are accessible.')
+        r = Response({'status_code': 404,
+                      'reason': 'No CivisML template IDs are accessible.',
+                      'content': None})
+        raise CivisAPIError(r)
     return ids
 
 

--- a/civis/ml/tests/test_helper.py
+++ b/civis/ml/tests/test_helper.py
@@ -6,6 +6,7 @@ from civis.ml import (list_models, put_models_shares_groups,
                       put_models_shares_users, delete_models_shares_groups,
                       delete_models_shares_users)
 from civis.ml import _helper as helper
+from civis.ml.tests import test_model
 from civis.tests.mocks import create_client_mock
 
 
@@ -17,6 +18,7 @@ def test_list_models_bad_job_type():
 def test_list_models():
     resp = [Response({'id': 2834, 'name': 'RFC model'})]
     m_client = create_client_mock()
+    m_client.aliases.list.return_value = test_model.TEST_TEMPLATE_ID_ALIAS_OBJECTS  # noqa
     m_client.scripts.list_custom.return_value = resp
     out = list_models(job_type='train', client=m_client)
     assert out == resp

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -726,27 +726,27 @@ def test__get_template_ids_all_versions():
     assert actual_template_ids == expected_template_ids
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @pytest.mark.parametrize(
     'version, train_id, predict_id, register_id',
     [(version, ids['training'], ids['prediction'], ids['registration'])
      for version, ids in TEST_TEMPLATE_IDS.items()]
 )
 def test__get_template_ids(version, train_id, predict_id, register_id):
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     actual_train_id, actual_predict_id, actual_register_id = (
         _model._get_template_ids(version, mock.ANY)
     )
     assert actual_train_id == train_id
     assert actual_predict_id == predict_id
     assert actual_register_id == register_id
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 def test__get_template_ids_invalid_version():
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     with pytest.raises(ValueError):
         _model._get_template_ids('not_a_version', mock.ANY)
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
 #####################################
@@ -761,29 +761,29 @@ def mp_setup():
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 def test_modelpipeline_etl_init_err():
     # If users don't have access to >= v2.0 temlates, then passing
     # `etl` to a new ModelPipeline should produce a NotImplementedError.
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.MagicMock()
     with pytest.raises(NotImplementedError):
         _model.ModelPipeline(LogisticRegression(), 'test',
                              etl=LogisticRegression(),
                              client=mock_client)
-    _model._TEMPLATE_IDS = None  # clean up
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor_errors(mock_future):
     # catch 404 error if model isn't found and throw ValueError
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.Mock()
     response = namedtuple('Reponse', ['content', 'response', 'reason',
                                       'status_code'])(False, None, None, 404)
     mock_future.side_effect = CivisAPIError(response)
     with pytest.raises(ValueError):
         _model.ModelPipeline.from_existing(1, 1, client=mock_client)
-    _model._TEMPLATE_IDS = None  # clean up
 
 
 def _container_response_stub(from_template_id=8387):
@@ -823,9 +823,10 @@ def _container_response_stub(from_template_id=8387):
                          ))
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor(mock_future):
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.Mock()
     mock_client.scripts.get_containers.return_value = \
         container = _container_response_stub(TRAIN_ID_PROD)
@@ -853,12 +854,12 @@ def test_modelpipeline_classmethod_constructor(mock_future):
     deps = container.arguments.get('DEPENDENCIES', None)
     assert mp.dependencies == deps.split() if deps else None
     assert mp.git_token_name == 'Token'
-    _model._TEMPLATE_IDS = None  # clean up
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor_defaults(mock_future):
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     del container_response_stub.arguments['PARAMS']
     del container_response_stub.arguments['CVPARAMS']
@@ -870,15 +871,15 @@ def test_modelpipeline_classmethod_constructor_defaults(mock_future):
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
     assert mp.cv_params == {}
     assert mp.parameters == {}
-    _model._TEMPLATE_IDS = None  # clean up
 
 
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 def test_modelpipeline_classmethod_constructor_nonint_id():
     # Verify that we can still JSON-serialize job and run IDs even
     # if they're entered in a non-JSON-able format.
     # We need to turn them into JSON to set them as script arguments.
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = setup_client_mock(1, 2)
     container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     mock_client.scripts.get_containers.return_value = container_response_stub
@@ -889,9 +890,10 @@ def test_modelpipeline_classmethod_constructor_nonint_id():
     out = json.dumps({'job': mp.train_result_.job_id,
                       'run': mp.train_result_.run_id})
     assert out == '{"job": 1, "run": 2}' or out == '{"run": 2, "job": 1}'
-    _model._TEMPLATE_IDS = None  # clean up
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @pytest.mark.parametrize(
     'train_id, predict_id',
     [(TRAIN_ID_PROD, PREDICT_ID_PROD), (TRAIN_ID_OLD, PREDICT_ID_OLD)],
@@ -901,13 +903,11 @@ def test_modelpipeline_classmethod_constructor_old_version(
         mock_future, train_id, predict_id):
     # Test that we select the correct prediction template for different
     # versions of a training job.
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = setup_client_mock()
     mock_client.scripts.get_containers.return_value = \
         _container_response_stub(from_template_id=train_id)
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
     assert mp.predict_template_id == predict_id
-    _model._TEMPLATE_IDS = None  # clean up
 
 
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
@@ -921,12 +921,13 @@ def test_modelpipeline_train(mock_ccr, mp_setup):
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @mock.patch.object(_model, "APIClient", mock.Mock())
 @mock.patch.object(_model.cio, "file_to_civis")
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
 def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
     # Provide a model as a pre-made model and make sure we can train.
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_f2c.return_value = -21
 
     est = LogisticRegression()
@@ -937,7 +938,6 @@ def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
     assert 'res' == mp.train(file_id=7)
     assert mp.train_result_ == 'res'
     assert mock_f2c.call_count == 1  # Called once to store input Estimator
-    _model._TEMPLATE_IDS = None  # clean up
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
@@ -1076,6 +1076,8 @@ def test_modelpipeline_predict_value_too_much_input_error(mp_setup):
     assert str(exc.value) == "Provide a single source of data."
 
 
+@mock.patch.object(_model, '_get_template_ids_all_versions',
+                   mock.Mock(return_value=TEST_TEMPLATE_IDS))
 @mock.patch.object(_model, "APIClient", mock.Mock())
 @pytest.mark.parametrize(
     'version, train_id, predict_id',
@@ -1086,7 +1088,6 @@ def test_modelpipeline_pickling_preserves_template_ids(
         version, train_id, predict_id):
     # Test that pickling a ModelPipeline object preserves the template IDs
     # that have already been set during object instantiation.
-    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     with TemporaryDirectory() as temp_dir:
         mp = _model.ModelPipeline('wf', 'dv', civisml_version=version)
 
@@ -1105,4 +1106,3 @@ def test_modelpipeline_pickling_preserves_template_ids(
         # After unpickling, the template IDs should remain.
         assert mp_unpickled.train_template_id == train_id
         assert mp_unpickled.predict_template_id == predict_id
-    _model._TEMPLATE_IDS = None  # clean up

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -2,7 +2,6 @@ from builtins import super
 from collections import namedtuple
 from concurrent.futures import CancelledError
 from six import StringIO
-import functools
 import json
 import os
 import pickle
@@ -694,15 +693,6 @@ def test_metrics_prediction(mock_file_id_from_run_output):
 ###############################################
 # Tests of utilities for CivisML template IDs #
 ###############################################
-def set_up_test_template_ids(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
-        func(*args, **kwargs)
-        _model._TEMPLATE_IDS = None  # clean up
-    return wrapper
-
-
 @pytest.mark.parametrize(
     'alias, expected_job_type, expected_version',
     [
@@ -736,25 +726,27 @@ def test__get_template_ids_all_versions():
     assert actual_template_ids == expected_template_ids
 
 
-@set_up_test_template_ids
 @pytest.mark.parametrize(
     'version, train_id, predict_id, register_id',
     [(version, ids['training'], ids['prediction'], ids['registration'])
      for version, ids in TEST_TEMPLATE_IDS.items()]
 )
 def test__get_template_ids(version, train_id, predict_id, register_id):
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     actual_train_id, actual_predict_id, actual_register_id = (
         _model._get_template_ids(version, mock.ANY)
     )
     assert actual_train_id == train_id
     assert actual_predict_id == predict_id
     assert actual_register_id == register_id
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
-@set_up_test_template_ids
 def test__get_template_ids_invalid_version():
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     with pytest.raises(ValueError):
         _model._get_template_ids('not_a_version', mock.ANY)
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
 #####################################
@@ -768,28 +760,30 @@ def mp_setup():
     return mp
 
 
-@set_up_test_template_ids
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
 def test_modelpipeline_etl_init_err():
     # If users don't have access to >= v2.0 temlates, then passing
     # `etl` to a new ModelPipeline should produce a NotImplementedError.
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.MagicMock()
     with pytest.raises(NotImplementedError):
         _model.ModelPipeline(LogisticRegression(), 'test',
                              etl=LogisticRegression(),
                              client=mock_client)
+    _model._TEMPLATE_IDS = None  # clean up
 
 
-@set_up_test_template_ids
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor_errors(mock_future):
     # catch 404 error if model isn't found and throw ValueError
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.Mock()
     response = namedtuple('Reponse', ['content', 'response', 'reason',
                                       'status_code'])(False, None, None, 404)
     mock_future.side_effect = CivisAPIError(response)
     with pytest.raises(ValueError):
         _model.ModelPipeline.from_existing(1, 1, client=mock_client)
+    _model._TEMPLATE_IDS = None  # clean up
 
 
 def _container_response_stub(from_template_id=8387):
@@ -829,9 +823,9 @@ def _container_response_stub(from_template_id=8387):
                          ))
 
 
-@set_up_test_template_ids
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor(mock_future):
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = mock.Mock()
     mock_client.scripts.get_containers.return_value = \
         container = _container_response_stub(TRAIN_ID_PROD)
@@ -859,11 +853,12 @@ def test_modelpipeline_classmethod_constructor(mock_future):
     deps = container.arguments.get('DEPENDENCIES', None)
     assert mp.dependencies == deps.split() if deps else None
     assert mp.git_token_name == 'Token'
+    _model._TEMPLATE_IDS = None  # clean up
 
 
-@set_up_test_template_ids
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor_defaults(mock_future):
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     del container_response_stub.arguments['PARAMS']
     del container_response_stub.arguments['CVPARAMS']
@@ -875,14 +870,15 @@ def test_modelpipeline_classmethod_constructor_defaults(mock_future):
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
     assert mp.cv_params == {}
     assert mp.parameters == {}
+    _model._TEMPLATE_IDS = None  # clean up
 
 
-@set_up_test_template_ids
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
 def test_modelpipeline_classmethod_constructor_nonint_id():
     # Verify that we can still JSON-serialize job and run IDs even
     # if they're entered in a non-JSON-able format.
     # We need to turn them into JSON to set them as script arguments.
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = setup_client_mock(1, 2)
     container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     mock_client.scripts.get_containers.return_value = container_response_stub
@@ -893,9 +889,9 @@ def test_modelpipeline_classmethod_constructor_nonint_id():
     out = json.dumps({'job': mp.train_result_.job_id,
                       'run': mp.train_result_.run_id})
     assert out == '{"job": 1, "run": 2}' or out == '{"run": 2, "job": 1}'
+    _model._TEMPLATE_IDS = None  # clean up
 
 
-@set_up_test_template_ids
 @pytest.mark.parametrize(
     'train_id, predict_id',
     [(TRAIN_ID_PROD, PREDICT_ID_PROD), (TRAIN_ID_OLD, PREDICT_ID_OLD)],
@@ -905,11 +901,13 @@ def test_modelpipeline_classmethod_constructor_old_version(
         mock_future, train_id, predict_id):
     # Test that we select the correct prediction template for different
     # versions of a training job.
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_client = setup_client_mock()
     mock_client.scripts.get_containers.return_value = \
         _container_response_stub(from_template_id=train_id)
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
     assert mp.predict_template_id == predict_id
+    _model._TEMPLATE_IDS = None  # clean up
 
 
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
@@ -923,12 +921,12 @@ def test_modelpipeline_train(mock_ccr, mp_setup):
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
-@set_up_test_template_ids
 @mock.patch.object(_model, "APIClient", mock.Mock())
 @mock.patch.object(_model.cio, "file_to_civis")
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
 def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
     # Provide a model as a pre-made model and make sure we can train.
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     mock_f2c.return_value = -21
 
     est = LogisticRegression()
@@ -939,6 +937,7 @@ def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
     assert 'res' == mp.train(file_id=7)
     assert mp.train_result_ == 'res'
     assert mock_f2c.call_count == 1  # Called once to store input Estimator
+    _model._TEMPLATE_IDS = None  # clean up
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
@@ -1077,7 +1076,6 @@ def test_modelpipeline_predict_value_too_much_input_error(mp_setup):
     assert str(exc.value) == "Provide a single source of data."
 
 
-@set_up_test_template_ids
 @mock.patch.object(_model, "APIClient", mock.Mock())
 @pytest.mark.parametrize(
     'version, train_id, predict_id',
@@ -1088,6 +1086,7 @@ def test_modelpipeline_pickling_preserves_template_ids(
         version, train_id, predict_id):
     # Test that pickling a ModelPipeline object preserves the template IDs
     # that have already been set during object instantiation.
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     with TemporaryDirectory() as temp_dir:
         mp = _model.ModelPipeline('wf', 'dv', civisml_version=version)
 
@@ -1106,3 +1105,4 @@ def test_modelpipeline_pickling_preserves_template_ids(
         # After unpickling, the template IDs should remain.
         assert mp_unpickled.train_template_id == train_id
         assert mp_unpickled.predict_template_id == predict_id
+    _model._TEMPLATE_IDS = None  # clean up

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -39,32 +39,29 @@ import pytest
 from civis.ml import _model
 
 
-LATEST_TRAIN_TEMPLATE = 11219
-LATEST_PRED_TEMPLATE = 11220
-
+TRAIN_ID_PROD, PREDICT_ID_PROD = 654, 321
+TRAIN_ID_OLD, PREDICT_ID_OLD = 123, 456
 TEST_TEMPLATE_ID_ALIAS_OBJECTS = [
     # Version-less aliases for the latest production code.
-    Response(dict(alias='civis-civisml-training', object_id=123)),
-    Response(dict(alias='civis-civisml-prediction', object_id=456)),
+    Response(dict(alias='civis-civisml-training', object_id=TRAIN_ID_PROD)),
+    Response(dict(alias='civis-civisml-prediction', object_id=PREDICT_ID_PROD)),  # noqa
     Response(dict(alias='civis-civisml-registration', object_id=789)),
-    # Versioned aliases
-    Response(dict(alias='civis-civisml-training-v2-3', object_id=123)),
-    Response(dict(alias='civis-civisml-prediction-v2-3', object_id=456)),
+    # Versioned aliases. Pretend that v2.3 is the latest production version.
+    Response(dict(alias='civis-civisml-training-v2-3', object_id=TRAIN_ID_PROD)),  # noqa
+    Response(dict(alias='civis-civisml-prediction-v2-3', object_id=PREDICT_ID_PROD)),  # noqa
     Response(dict(alias='civis-civisml-registration-v2-3', object_id=789)),
     # Versioned aliases. Versions older than v2.2 don't have registration ID.
-    Response(dict(alias='civis-civisml-training-v1-4', object_id=135)),
-    Response(dict(alias='civis-civisml-prediction-v1-4', object_id=791)),
+    Response(dict(alias='civis-civisml-training-v1-4', object_id=TRAIN_ID_OLD)),  # noqa
+    Response(dict(alias='civis-civisml-prediction-v1-4', object_id=PREDICT_ID_OLD)),  # noqa
     # Other special versions, e.g., "dev"
     Response(dict(alias='civis-civisml-training-dev', object_id=345)),
     Response(dict(alias='civis-civisml-prediction-dev', object_id=678)),
     Response(dict(alias='civis-civisml-registration-dev', object_id=901)),
 ]
-TEST_TEMPLATE_IDS = {
-    # Key `None` from the version-less alias, for the latest production version
-    None: {'training': 123, 'prediction': 456, 'registration': 789},
-    '2.3': {'training': 123, 'prediction': 456, 'registration': 789},
-    # Pre-trained model registration is available for CivisML v2.2 or above
-    '1.4': {'training': 135, 'prediction': 791, 'registration': None},
+TEST_TEMPLATE_IDS = {  # Must match TEST_TEMPLATE_ID_ALIAS_OBJECTS
+    None: {'training': TRAIN_ID_PROD, 'prediction': PREDICT_ID_PROD, 'registration': 789},  # noqa
+    '2.3': {'training': TRAIN_ID_PROD, 'prediction': PREDICT_ID_PROD, 'registration': 789},  # noqa
+    '1.4': {'training': TRAIN_ID_OLD, 'prediction': PREDICT_ID_OLD, 'registration': None},  # noqa
     'dev': {'training': 345, 'prediction': 678, 'registration': 901},
 }
 
@@ -742,44 +739,33 @@ def test__get_template_ids(
 @pytest.fixture
 def mp_setup():
     mock_api = setup_client_mock()
+    mock_api.aliases.list.return_value = TEST_TEMPLATE_ID_ALIAS_OBJECTS
     mp = _model.ModelPipeline('wf', 'dv', client=mock_api)
     return mp
 
 
+def set_global_template_ids(func):
+    def wrapper(*args, **kwargs):
+        _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
+        func(*args, **kwargs)
+        # clean up
+        _model._TEMPLATE_IDS = None
+    return wrapper
+
+
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
+@set_global_template_ids
 def test_modelpipeline_etl_init_err():
     # If users don't have access to >= v2.0 temlates, then passing
     # `etl` to a new ModelPipeline should produce a NotImplementedError.
     mock_client = mock.MagicMock()
-    r = Response({'content': None, 'status_code': 9999, 'reason': None})
-
-    def pre_2p0_template(id=None, **kwargs):
-        if id > 9113:
-            raise CivisAPIError(r)
-        return {}
-    mock_client.templates.get_scripts.side_effect = pre_2p0_template
     with pytest.raises(NotImplementedError):
         _model.ModelPipeline(LogisticRegression(), 'test',
                              etl=LogisticRegression(),
                              client=mock_client)
-    # clean up
-    _model._CIVISML_TEMPLATE = None
 
 
-@pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
-def test_modelpipeline_init_newest():
-    _model._CIVISML_TEMPLATE = None
-    mock_client = mock.MagicMock()
-    mock_client.templates.get_scripts.return_value = {}
-    etl = LogisticRegression()
-    mp = _model.ModelPipeline(LogisticRegression(), 'test', etl=etl,
-                              client=mock_client)
-    assert mp.etl == etl
-    assert mp.train_template_id == LATEST_TRAIN_TEMPLATE
-    # clean up
-    _model._CIVISML_TEMPLATE = None
-
-
+@set_global_template_ids
 @mock.patch.object(_model, 'ModelFuture')
 def test_modelpipeline_classmethod_constructor_errors(mock_future):
     # catch 404 error if model isn't found and throw ValueError
@@ -791,8 +777,7 @@ def test_modelpipeline_classmethod_constructor_errors(mock_future):
         _model.ModelPipeline.from_existing(1, 1, client=mock_client)
 
 
-@pytest.fixture()
-def container_response_stub(from_template_id=8387):
+def _container_response_stub(from_template_id=8387):
     arguments = {
         'MODEL': 'sparse_logistic',
         'TARGET_COLUMN': 'brushes_teeth_much',
@@ -829,12 +814,12 @@ def container_response_stub(from_template_id=8387):
                          ))
 
 
+@set_global_template_ids
 @mock.patch.object(_model, 'ModelFuture')
-def test_modelpipeline_classmethod_constructor(mock_future,
-                                               container_response_stub):
+def test_modelpipeline_classmethod_constructor(mock_future):
     mock_client = mock.Mock()
     mock_client.scripts.get_containers.return_value = \
-        container = container_response_stub
+        container = _container_response_stub(TRAIN_ID_PROD)
     mock_client.credentials.get.return_value = Response({'name': 'Token'})
 
     resources = {'REQUIRED_CPU': 1000,
@@ -861,9 +846,10 @@ def test_modelpipeline_classmethod_constructor(mock_future,
     assert mp.git_token_name == 'Token'
 
 
+@set_global_template_ids
 @mock.patch.object(_model, 'ModelFuture')
-def test_modelpipeline_classmethod_constructor_defaults(
-        mock_future, container_response_stub):
+def test_modelpipeline_classmethod_constructor_defaults(mock_future):
+    container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     del container_response_stub.arguments['PARAMS']
     del container_response_stub.arguments['CVPARAMS']
     mock_client = mock.Mock()
@@ -876,29 +862,15 @@ def test_modelpipeline_classmethod_constructor_defaults(
     assert mp.parameters == {}
 
 
-@mock.patch.object(_model, 'ModelFuture', mock.Mock())
-def test_modelpipeline_classmethod_constructor_future_train_version():
-    # Test handling attempts to restore a model created with a newer
-    # version of CivisML.
-    cont = container_response_stub(LATEST_TRAIN_TEMPLATE + 1000)
-    mock_client = mock.Mock()
-    mock_client.scripts.get_containers.return_value = cont
-    mock_client.credentials.get.return_value = Response({'name': 'Token'})
-
-    # test everything is working fine
-    with pytest.warns(RuntimeWarning):
-        mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
-    exp_p_id = _model._PRED_TEMPLATES[LATEST_TRAIN_TEMPLATE]
-    assert mp.predict_template_id == exp_p_id
-
-
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
+@set_global_template_ids
 def test_modelpipeline_classmethod_constructor_nonint_id():
     # Verify that we can still JSON-serialize job and run IDs even
     # if they're entered in a non-JSON-able format.
     # We need to turn them into JSON to set them as script arguments.
     mock_client = setup_client_mock(1, 2)
-    mock_client.scripts.get_containers.return_value = container_response_stub()
+    container_response_stub = _container_response_stub(TRAIN_ID_PROD)
+    mock_client.scripts.get_containers.return_value = container_response_stub
 
     mp = _model.ModelPipeline.from_existing(np.int64(1), np.int64(2),
                                             client=mock_client)
@@ -908,21 +880,21 @@ def test_modelpipeline_classmethod_constructor_nonint_id():
     assert out == '{"job": 1, "run": 2}' or out == '{"run": 2, "job": 1}'
 
 
+@set_global_template_ids
 @mock.patch.object(_model, 'ModelFuture', autospec=True)
 def test_modelpipeline_classmethod_constructor_old_version(mock_future):
     # Test that we select the correct prediction template for different
     # versions of a training job.
     mock_client = setup_client_mock()
-    mock_client.scripts.get_containers.return_value = \
-        container_response_stub(from_template_id=8387)
-    mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
-    assert mp.predict_template_id == 8388, "Predict template v1.0"
 
-    # v0.5 training
-    mock_client.scripts.get_containers.return_value = \
-        container_response_stub(from_template_id=7020)
-    mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
-    assert mp.predict_template_id == 7021, "Predict template v0.5"
+    # For whatever reason, pytest.mark.parametrize doesn't play nice with
+    # the generic set_global_template_ids decorator
+    for train_id, predict_id in ((TRAIN_ID_PROD, PREDICT_ID_PROD),
+                                 (TRAIN_ID_OLD, PREDICT_ID_OLD)):
+        mock_client.scripts.get_containers.return_value = \
+            _container_response_stub(from_template_id=train_id)
+        mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
+        assert mp.predict_template_id == predict_id
 
 
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
@@ -936,6 +908,7 @@ def test_modelpipeline_train(mock_ccr, mp_setup):
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
+@set_global_template_ids
 @mock.patch.object(_model, "APIClient", mock.Mock())
 @mock.patch.object(_model.cio, "file_to_civis")
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
@@ -954,12 +927,14 @@ def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
-@mock.patch.object(_model, "APIClient", mock.Mock())
+@mock.patch.object(_model, "_get_template_ids")
 @mock.patch.object(_model.cio, "file_to_civis")
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
-def test_modelpipeline_train_custom_etl(mock_ccr, mock_f2c, mp_setup):
+def test_modelpipeline_train_custom_etl(mock_ccr, mock_f2c, mock_template_ids):
     # Provide a custom ETL estimator and make sure we can train.
     mock_api = setup_client_mock()
+    # training template ID 11111 >= 9968 for the etl arg to work
+    mock_template_ids.return_value = 11111, 22222, 33333
     etl = LogisticRegression()
     mp = _model.ModelPipeline('wf', 'dv', client=mock_api, etl=etl)
     mock_f2c.return_value = -21
@@ -984,7 +959,7 @@ def test_modelpipeline_train_df(mock_ccr, mock_stash, mp_setup):
     train_data = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
     assert 'res' == mp.train(train_data)
     mock_stash.assert_called_once_with(
-        train_data, LATEST_TRAIN_TEMPLATE, client=mock.ANY)
+        train_data, TRAIN_ID_PROD, client=mock.ANY)
     assert mp.train_result_ == 'res'
 
 

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -1076,6 +1076,7 @@ def test_modelpipeline_predict_value_too_much_input_error(mp_setup):
     assert str(exc.value) == "Provide a single source of data."
 
 
+@mock.patch.object(_model, "APIClient", mock.Mock())
 @pytest.mark.parametrize(
     'version, train_id, predict_id',
     [('v2.3', TRAIN_ID_PROD, PREDICT_ID_PROD),
@@ -1087,8 +1088,7 @@ def test_modelpipeline_pickling_preserves_template_ids(
     # that have already been set during object instantiation.
     _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
     with TemporaryDirectory() as temp_dir:
-        mp = _model.ModelPipeline('wf', 'dv',
-                                  civisml_version=version, client=mock.ANY)
+        mp = _model.ModelPipeline('wf', 'dv', civisml_version=version)
 
         # Before pickling, make sure the template IDs are set as expected
         assert mp.train_template_id == train_id

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -699,12 +699,23 @@ def test_metrics_prediction(mock_file_id_from_run_output):
         ('civis-civisml-training', 'training', None),
         ('civis-civisml-training-v2-3', 'training', 'v2.3'),
         ('civis-civisml-training-dev', 'training', 'dev'),
+        ('civis-civisml-training-foo-bar', 'training', 'foo-bar'),
     ],
 )
 def test__get_job_type_version(alias, expected_job_type, expected_version):
     actual_job_type, actual_version = _model._get_job_type_version(alias)
     assert actual_job_type == expected_job_type
     assert actual_version == expected_version
+
+
+@pytest.mark.parametrize(
+    'invalid_alias',
+    ['foobar', 'civis-civisml', 'civis-civisml-', 'civis-civisml-training-',
+     'civis-civisml-training-foobar-']
+)
+def test__get_job_type_version_invalid_alias(invalid_alias):
+    with pytest.raises(ValueError):
+        _model._get_job_type_version(invalid_alias)
 
 
 def test__get_template_ids_all_versions():

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -742,6 +742,13 @@ def test__get_template_ids(version, train_id, predict_id, register_id):
     _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
+def test__get_template_ids_invalid_version():
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
+    with pytest.raises(ValueError):
+        _model._get_template_ids('not_a_version', mock.ANY)
+    _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
+
+
 #####################################
 # Tests of ModelPipeline below here #
 #####################################

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -60,8 +60,8 @@ TEST_TEMPLATE_ID_ALIAS_OBJECTS = [
 ]
 TEST_TEMPLATE_IDS = {  # Must match TEST_TEMPLATE_ID_ALIAS_OBJECTS
     None: {'training': TRAIN_ID_PROD, 'prediction': PREDICT_ID_PROD, 'registration': 789},  # noqa
-    '2.3': {'training': TRAIN_ID_PROD, 'prediction': PREDICT_ID_PROD, 'registration': 789},  # noqa
-    '1.4': {'training': TRAIN_ID_OLD, 'prediction': PREDICT_ID_OLD, 'registration': None},  # noqa
+    'v2.3': {'training': TRAIN_ID_PROD, 'prediction': PREDICT_ID_PROD, 'registration': 789},  # noqa
+    'v1.4': {'training': TRAIN_ID_OLD, 'prediction': PREDICT_ID_OLD, 'registration': None},  # noqa
     'dev': {'training': 345, 'prediction': 678, 'registration': 901},
 }
 
@@ -697,7 +697,7 @@ def test_metrics_prediction(mock_file_id_from_run_output):
     'alias, expected_job_type, expected_version',
     [
         ('civis-civisml-training', 'training', None),
-        ('civis-civisml-training-v2-3', 'training', '2.3'),
+        ('civis-civisml-training-v2-3', 'training', 'v2.3'),
         ('civis-civisml-training-dev', 'training', 'dev'),
     ],
 )
@@ -715,21 +715,19 @@ def test__get_template_ids_all_versions():
     assert actual_template_ids == expected_template_ids
 
 
-def test__get_template_ids():
+@pytest.mark.parametrize(
+    'version, train_id, predict_id, register_id',
+    [(version, ids['training'], ids['prediction'], ids['registration'])
+     for version, ids in TEST_TEMPLATE_IDS.items()]
+)
+def test__get_template_ids(version, train_id, predict_id, register_id):
     _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS
-    # For whatever reason, pytest.mark.parametrize doesn't play nice with
-    # the generic set_global_template_ids decorator
-    versions_ids = [
-        (version, ids['training'], ids['prediction'], ids['registration'])
-        for version, ids in TEST_TEMPLATE_IDS.items()
-    ]
-    for v, expected_train_id, expected_predict_id, expected_register_id in versions_ids:  # noqa
-        actual_train_id, actual_predict_id, actual_register_id = (
-            _model._get_template_ids(v, mock.ANY)
-        )
-        assert actual_train_id == expected_train_id
-        assert actual_predict_id == expected_predict_id
-        assert actual_register_id == expected_register_id
+    actual_train_id, actual_predict_id, actual_register_id = (
+        _model._get_template_ids(version, mock.ANY)
+    )
+    assert actual_train_id == train_id
+    assert actual_predict_id == predict_id
+    assert actual_register_id == register_id
     _model._TEMPLATE_IDS = TEST_TEMPLATE_IDS  # clean up
 
 
@@ -1062,8 +1060,8 @@ def test_modelpipeline_predict_value_too_much_input_error(mp_setup):
 
 @pytest.mark.parametrize(
     'version, train_id, predict_id',
-    [('2.3', TRAIN_ID_PROD, PREDICT_ID_PROD),
-     ('1.4', TRAIN_ID_OLD, PREDICT_ID_OLD)],
+    [('v2.3', TRAIN_ID_PROD, PREDICT_ID_PROD),
+     ('v1.4', TRAIN_ID_OLD, PREDICT_ID_OLD)],
 )
 def test_modelpipeline_pickling_preserves_template_ids(
         version, train_id, predict_id):

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -11,7 +11,7 @@ API for interoperability with other platforms and to allow you to leverage
 resources in the open-source software community when creating machine learning models.
 
 
-Optional dependencies
+Optional Dependencies
 =====================
 
 You do not need any external libraries installed to use CivisML, but
@@ -411,9 +411,10 @@ To share your models, use the functions
 - :func:`~civis.ml.delete_models_shares_users`
 - :func:`~civis.ml.delete_models_shares_groups`
 
+To find out what models a user has, use :func:`~civis.ml.list_models`.
 
-Object reference
-================
+Object and Function Reference
+=============================
 
 .. autoclass:: civis.ml.ModelPipeline
 	       :members:
@@ -422,3 +423,9 @@ Object reference
 .. autoclass:: civis.ml.ModelFuture
 	       :members:
 	       :inherited-members:
+
+.. autofunction:: civis.ml.put_models_shares_users
+.. autofunction:: civis.ml.put_models_shares_groups
+.. autofunction:: civis.ml.delete_models_shares_users
+.. autofunction:: civis.ml.delete_models_shares_groups
+.. autofunction:: civis.ml.list_models

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -130,13 +130,8 @@ the pre-defined ones. Create the object and pass it as the ``model`` parameter
 of the :class:`~civis.ml.ModelPipeline`. Your model must follow the
 scikit-learn API, and you will need to include any dependencies as
 :ref:`custom-dependencies` if they are not already installed in
-CivisML. Preinstalled libraries available for your use include:
-
-- `scikit-learn <http://scikit-learn.org>`_ v0.19.1
-- `glmnet <https://github.com/civisanalytics/python-glmnet>`_ v2.0.0
-- `xgboost <http://xgboost.readthedocs.io>`_ v0.6a2
-- `muffnn <https://github.com/civisanalytics/muffnn>`_ v1.2.0
-- `civisml-extensions <https://github.com/civisanalytics/civisml-extensions>`_ v.0.1.6
+CivisML. Please check `here <https://civis.zendesk.com/hc/en-us/articles/360000260011-CivisML>`_
+for the available pre-installed libraries and their versions.
 
 When you're assembling your own model, remember that you'll have to make certain that
 either you add a missing value imputation step or that your data doesn't have any
@@ -290,6 +285,19 @@ A simple example of how to do this with API looks as follows
 
 Note, installing private dependencies with submodules is not supported.
 
+.. _civisml-versions:
+
+CivisML Versions
+----------------
+
+By default, CivisML uses its latest version in production.
+Under special circumstances, if you would like a specific version
+(e.g., an older version),
+:class:`~civis.ml.ModelPipeline` (both its constructor and the class method
+:meth:`civis.ml.ModelPipeline.register_pretrained_model`) has the optional
+parameter ``civisml_version`` that accepts a string, e.g., ``'v2.3'``
+for CivisML v2.3. Please see `here <https://civis.zendesk.com/hc/en-us/articles/360000260011-CivisML>`_
+for the list of CivisML versions.
 
 Asynchronous Execution
 ======================


### PR DESCRIPTION
This PR decouples CivisML from civis-python with respect to the following:
* PARO-685: Use template ID aliases, so that a new CivisML release doesn't require a new civis-python release anymore.
* PARO-744: Document CivisML dependency versions on Zendesk rather than in civis-python's Sphinx docs, so that we can update Zendesk independently when CivisML is updated for the modeling dependencies (civis-python's Sphinx docs don't update unless a new civis-python release is made).

@stephen-hoover You are the appointed reviewer, since I think you're the person who has thought about the use of aliases for this scenario the most.