### PR TITLE
[CIVP-15320] Add max_file_size param to civis_to_multifile_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)
 - Fixed issue in `civis.io.read_civis_sql` when returning data that contains
   double quotes. (#328)
+- Fixed issue with pyyaml version for Python 3.4 by requiring pyyaml version <=5.2
 
 ### Changed
 - Pass `headers` and `delimiter` to Civis API endpoint for cleaning files in `civis.io.civis_file_to_table`. (#334)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added method `get_storage_host_id` to the APIClient. (#328)
 - Added debug logging to some `civis.io` functions. (#325)
+- Added new arguments to `civis.io.civis_to_multifile_csv` to expose max_file_size parameter. (#342)
 
 ### Fixed
 - Removed incorrect "optional" marker for the `sql` argument in I/O
@@ -16,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `ModelPipeline.register_pretrained_model` should persist the user-supplied
   estimator object indefinitely. (#331)
 - Fixed requirements.txt listing for `cloudpickle` -- `>=0.2`, not `<=0.2`. (#323)
-- Fixed issue in `civis.io.read_civis_sql` when returning data that contains 
+- Fixed issue in `civis.io.read_civis_sql` when returning data that contains
   double quotes. (#328)
 
 ### Changed

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -480,7 +480,7 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                            include_header=True,
                            compression='none', delimiter='|',
                            unquoted=False, prefix=None,
-                           polling_interval=None, hidden=True):
+                           polling_interval=None, hidden=True, max_file_size=None):
     """Unload the result of SQL query and return presigned urls.
 
     This function is intended for unloading large queries/tables from redshift
@@ -525,6 +525,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
         Number of seconds to wait between checks for query completion.
     hidden : bool, optional
         If ``True`` (the default), this job will not appear in the Civis UI.
+    max_file_size: int, optional
+        Maximum number of Megabytes each created file will be.
 
     Returns
     -------
@@ -586,7 +588,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                         column_delimiter=delimiter,
                         unquoted=unquoted,
                         filename_prefix=prefix,
-                        force_multifile=True)
+                        force_multifile=True,
+                        max_file_size=max_file_size)
     script_id, run_id = _sql_script(client, sql, database, job_name,
                                     credential_id, hidden,
                                     csv_settings=csv_settings)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -479,9 +479,9 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                            client=None, credential_id=None,
                            include_header=True,
                            compression='none', delimiter='|',
+                           max_file_size=None,
                            unquoted=False, prefix=None,
-                           polling_interval=None, hidden=True,
-                           max_file_size=None):
+                           polling_interval=None, hidden=True):
     """Unload the result of SQL query and return presigned urls.
 
     This function is intended for unloading large queries/tables from redshift
@@ -517,6 +517,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     delimiter: str, optional
         Which delimiter to use, if any. One of ``','``, ``'\t'``, or
         ``'|'``. Default: ``'|'``.
+    max_file_size: int, optional
+        Maximum number of Megabytes each created file will be.
     unquoted: bool, optional
         Whether or not to quote fields. Default: ``False``.
     prefix: str, optional
@@ -526,8 +528,6 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
         Number of seconds to wait between checks for query completion.
     hidden : bool, optional
         If ``True`` (the default), this job will not appear in the Civis UI.
-    max_file_size: int, optional
-        Maximum number of Megabytes each created file will be.
 
     Returns
     -------

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -480,7 +480,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
                            include_header=True,
                            compression='none', delimiter='|',
                            unquoted=False, prefix=None,
-                           polling_interval=None, hidden=True, max_file_size=None):
+                           polling_interval=None, hidden=True,
+                           max_file_size=None):
     """Unload the result of SQL query and return presigned urls.
 
     This function is intended for unloading large queries/tables from redshift

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -802,7 +802,9 @@ class ImportTests(CivisVCRTestCase):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
         max_file_size = 32
         result = civis.io.civis_to_multifile_csv(
-            sql, database='redshift-general', polling_interval=POLL_INTERVAL, max_file_size=max_file_size)
+            sql, database='redshift-general',
+            polling_interval=POLL_INTERVAL,
+            max_file_size=max_file_size)
         assert set(result.keys()) == {'entries', 'query', 'header',
                                       'delimiter', 'compression', 'unquoted'}
         assert result['query'] == sql

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -777,26 +777,6 @@ class ImportTests(CivisVCRTestCase):
                                                              'amazonaws.com/')
 
     @pytest.mark.civis_to_multifile_csv
-    @mock.patch('civis.io._tables.CivisFuture')
-    @mock.patch('civis.io._tables.civis_to_file')
-    @mock.patch('civis.io._tables._sql_script')
-    def test_civis_to_multifile_passes_client(
-            self, m_sql_script, m_civis_to_file, m_CivisFuture, *mocks):
-        """Ensure the client kwarg is passed forward."""
-        m_sql_script.return_value = (mock.MagicMock(), mock.MagicMock())
-        # We need to write some JSON into the buffer to avoid errors.
-        m_civis_to_file.side_effect = (
-            lambda _, buf, *args, **kwargs: buf.write(b'{}')
-        )
-        mock_client = mock.MagicMock()
-
-        civis.io.civis_to_multifile_csv('sql', 'db', client=mock_client)
-
-        m_civis_to_file.assert_called_once_with(
-            mock.ANY, mock.ANY, client=mock_client
-        )
-
-    @pytest.mark.civis_to_multifile_csv
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_civis_to_multifile_csv_max_file_size_followed(self, *mocks):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
@@ -817,6 +797,26 @@ class ImportTests(CivisVCRTestCase):
                                                              'amazonaws.com/')
         for entry in result['entries']:
             assert entry['size'] <= max_file_size
+
+    @pytest.mark.civis_to_multifile_csv
+    @mock.patch('civis.io._tables.CivisFuture')
+    @mock.patch('civis.io._tables.civis_to_file')
+    @mock.patch('civis.io._tables._sql_script')
+    def test_civis_to_multifile_passes_client(
+            self, m_sql_script, m_civis_to_file, m_CivisFuture, *mocks):
+        """Ensure the client kwarg is passed forward."""
+        m_sql_script.return_value = (mock.MagicMock(), mock.MagicMock())
+        # We need to write some JSON into the buffer to avoid errors.
+        m_civis_to_file.side_effect = (
+            lambda _, buf, *args, **kwargs: buf.write(b'{}')
+        )
+        mock_client = mock.MagicMock()
+
+        civis.io.civis_to_multifile_csv('sql', 'db', client=mock_client)
+
+        m_civis_to_file.assert_called_once_with(
+            mock.ANY, mock.ANY, client=mock_client
+        )
 
     @pytest.mark.transfer_table
     @mock.patch(api_import_str, return_value=civis_api_spec)

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -763,27 +763,9 @@ class ImportTests(CivisVCRTestCase):
     @mock.patch(api_import_str, return_value=civis_api_spec)
     def test_civis_to_multifile_csv(self, *mocks):
         sql = "SELECT * FROM scratch.api_client_test_fixture"
-        result = civis.io.civis_to_multifile_csv(
-            sql, database='redshift-general', polling_interval=POLL_INTERVAL)
-        assert set(result.keys()) == {'entries', 'query', 'header',
-                                      'delimiter', 'compression', 'unquoted'}
-        assert result['query'] == sql
-        assert result['header'] == ['a', 'b', 'c']
-        assert isinstance(result['entries'], list)
-        assert set(result['entries'][0].keys()) == {'id', 'name', 'size',
-                                                    'url', 'url_signed'}
-        assert result['entries'][0]['url_signed'].startswith('https://civis-'
-                                                             'console.s3.'
-                                                             'amazonaws.com/')
-
-    @pytest.mark.civis_to_multifile_csv
-    @mock.patch(api_import_str, return_value=civis_api_spec)
-    def test_civis_to_multifile_csv_max_file_size_followed(self, *mocks):
-        sql = "SELECT * FROM scratch.api_client_test_fixture"
         max_file_size = 32
         result = civis.io.civis_to_multifile_csv(
-            sql, database='redshift-general',
-            polling_interval=POLL_INTERVAL,
+            sql, database='redshift-general', polling_interval=POLL_INTERVAL,
             max_file_size=max_file_size)
         assert set(result.keys()) == {'entries', 'query', 'header',
                                       'delimiter', 'compression', 'unquoted'}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 pytest>=3.6,<4
+pyyaml>=3.0,<=5.99 ; python_version != '3.4'
+pyyaml>=3.0,<=5.2 ; python_version == '3.4'
 sphinx>=1.7.0,<2.0.0
 flake8>=3.0.4,==3.*
 mock==2.0.0 ; python_version == '2.7'

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ def main():
                      glob(os.path.join('civis', 'tests', '*.json')))],
         long_description=README,
         install_requires=[
-            'pyyaml>=3.0,<=5.99',
+            "pyyaml>=3.0,<=5.99  ; python_version != '3.4'",
+            "pyyaml>=3.0,<=5.2  ; python_version == '3.4'",
             'click>=6.0,<=7',
             'jsonref>=0.1.0,<=0.2',
             'requests>=2.12.0,==2.*',

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ def main():
                      glob(os.path.join('civis', 'tests', '*.json')))],
         long_description=README,
         install_requires=[
-            "pyyaml>=3.0,<=5.99  ; python_version != '3.4'",
-            "pyyaml>=3.0,<=5.2  ; python_version == '3.4'",
+            "pyyaml>=3.0,<=5.99 ; python_version != '3.4'",
+            "pyyaml>=3.0,<=5.2 ; python_version == '3.4'",
             'click>=6.0,<=7',
             'jsonref>=0.1.0,<=0.2',
             'requests>=2.12.0,==2.*',


### PR DESCRIPTION
**JIRA Ticket:**
[CIVP-15320](https://civisanalytics.atlassian.net/browse/CIVP-15320)

**Summary:**
Adding the max_file_size parameter to the civis.io.civis_to_multifile_csv

**Testing:**
- [x] Updated specs
- [x] Performed manual tests

Notes:
used the `civis.io.civis_to_multifile_csv` function to create files with different max file sizes and verified the file size
sql scripts are: [55697443](https://platform.civisanalytics.com/spa/#/scripts/sql/55697443) and [55697108](https://platform.civisanalytics.com/spa/#/scripts/sql/55697108)

**Additional Info:**