### PR TITLE
[Serd-1694] service client

### DIFF
--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -6,4 +6,4 @@ from civis.service_client import ServiceClient
 from civis import io, ml, parallel, utils
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
-           "ml", "parallel", "utils", "ServiceClient"]
+           "ml", "parallel", "ServiceClient", "utils"]

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
 from civis import io, ml, parallel, utils
+from civis.service_client import ServiceClient
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
-           "ml", "parallel", "utils"]
+           "ml", "parallel", "utils", "ServiceClient"]

--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
-from civis import io, ml, parallel, utils
 from civis.service_client import ServiceClient
+from civis import io, ml, parallel, utils
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
            "ml", "parallel", "utils", "ServiceClient"]

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -409,7 +409,7 @@ def parse_method_name(verb, path):
 def parse_method(verb, operation, path):
     """ Generate a python function from a specification of that function."""
     summary = operation["summary"]
-    params = operation["parameters"]
+    params = operation.get("parameters", [])
     responses = operation["responses"]
     deprecated = operation.get('deprecated', False)
     if 'deprecated' in summary.lower() or deprecated:

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -6,10 +6,10 @@ from jsonref import JsonRef
 import requests
 import six
 
-from civis import APIClient
 from civis.base import Endpoint, CivisAPIError, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
+from civis import APIClient
 
 
 def auth_service_session(session, service_id):

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from collections import OrderedDict
+import json
 import re
 
 from jsonref import JsonRef
@@ -100,12 +101,13 @@ class ServiceClient():
             list-like responses and a :class:`pandas:pandas.Series` for
             single a json response.
         local_api_spec : collections.OrderedDict or string, optional
-            The methods on this class are dynamically built from the Service API
-            specification, which can be retrieved from the /endpoints endpoint.
-            When local_api_spec is None, the default, this specification is
-            downloaded the first time APIClient is instantiated. Alternatively,
-            a local cache of the specification may be passed as either an
-            OrderedDict or a filename which points to a json file.
+            The methods on this class are dynamically built from the Service
+            API specification, which can be retrieved from the /endpoints
+            endpoint. When local_api_spec is None, the default, this
+            specification is downloaded the first time APIClient is
+            instantiated. Alternatively, a local cache of the specification
+            may be passed as either an OrderedDict or a filename which
+            points to a json file.
         """
         if return_type not in ['snake', 'raw', 'pandas']:
             raise ValueError("Return type must be one of 'snake', 'raw', "

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -134,6 +134,6 @@ class ServiceClient():
             service = client.services.get(self._service_id)
         except CivisAPIError as err:
             msg = ('There was an issue '
-                   'finding service with ID {}.').format(service_id)
+                   'finding service with ID {}.').format(self._service_id)
             six.raise_from(ValueError(msg), err)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -31,19 +31,18 @@ def auth_service_session(session, service_id):
 class ServiceEndpoint(Endpoint):
 
     def __init__(self, session_kwargs, client,
-                 return_type='civis', root_path=None):
+                 return_type='civis'):
         self._session_kwargs = session_kwargs
         self._return_type = return_type
         self._client = client
-        self._root_path = root_path
 
     def _build_path(self, path):
         if not path:
             return self._client._base_url
-        if not self._root_path:
+        if not self._client._root_path:
             return tostr_urljoin(self._client._base_url, path.strip("/"))
         return tostr_urljoin(self._client._base_url,
-                             self._root_path.strip("/"),
+                             self._client._root_path.strip("/"),
                              path.strip("/"))
 
     def _make_request(self, method, path=None, params=None, data=None,
@@ -82,8 +81,7 @@ class ServiceClient():
             classes = self.generate_classes()
         for class_name, klass in classes.items():
             setattr(self, class_name, klass(self._session_kwargs, client=self,
-                                            return_type=return_type,
-                                            root_path=root_path))
+                                            return_type=return_type))
 
     def parse_path(self, path, operations):
         """ Parse an endpoint into a class where each valid http request

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -2,31 +2,28 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 import re
-import warnings
 
 from jsonref import JsonRef
 import requests
 import six
 
 from civis import APIClient
-from civis.base import Endpoint, CivisAPIError, tostr_urljoin
+from civis.base import Endpoint, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
 
 
-def _get_service(service_id):
-    try:
-        client = APIClient()
-        service = client.services.get(service_id)
-    except CivisAPIError as err:
-        msg = ('There was an issue '
-               'finding service with ID {}.').format(service_id)
-        six.raise_from(ValueError(msg), err)
+def _get_service(client):
+    if client._api_key:
+        api_client = APIClient(client._api_key)
+    else:
+        api_client = APIClient()
+    service = api_client.services.get(client._service_id)
     return service
 
 
-def auth_service_session(session, service_id):
-    service = _get_service(service_id)
+def auth_service_session(session, client):
+    service = _get_service(client)
     auth_url = service['current_deployment']['displayUrl']
     # Make request for adding Authentication Cookie to session
     session.get(auth_url)
@@ -34,9 +31,8 @@ def auth_service_session(session, service_id):
 
 class ServiceEndpoint(Endpoint):
 
-    def __init__(self, session_kwargs, client,
+    def __init__(self, client,
                  return_type='civis'):
-        self._session_kwargs = session_kwargs
         self._return_type = return_type
         self._client = client
 
@@ -54,7 +50,7 @@ class ServiceEndpoint(Endpoint):
         url = self._build_path(path)
 
         with requests.Session() as sess:
-            auth_service_session(sess, self._client._service_id)
+            auth_service_session(sess, self._client)
             with self._lock:
                 response = sess.request(method, url, json=data,
                                         params=params, **kwargs)
@@ -68,23 +64,52 @@ class ServiceEndpoint(Endpoint):
 
 class ServiceClient():
 
-    def __init__(self, service_id, root_path=None, swagger_path="/endpoints"):
-        return_type = 'snake'
-        self._session_kwargs = {}
+    def __init__(self, service_id, root_path=None,
+                 swagger_path="/endpoints", api_key=None,
+                 return_type='snake'):
+        """Create an API Client from a Civis service.
+
+        Parameters
+        ----------
+        service_id : str, required
+            The Id for the service that will be used to generate the client.
+        root_path : str, optional
+            An additional path for APIs that are not hosted on the service's
+            root level. An example root_path would be '/api' for an app with
+            resource endpoints that all begin with '/api'.
+        swagger_path : str, optional
+            The endpoint path that will be used to download the API Spec.
+            The default value is '/endpoints' but another common path
+            might be '/spec'. The API Spec must be compliant with Swagger
+            2.0 standards.
+        api_key : str, optional
+            Your API key obtained from the Civis Platform. If not given, the
+            client will use the :envvar:`CIVIS_API_KEY` environment variable.
+            This API key will need to be authorized to access the service
+            used for the client.
+        return_type : str, optional
+            The following types are implemented:
+
+            - ``'raw'`` Returns the raw :class:`requests:requests.Response`
+            object.
+            - ``'snake'`` Returns a :class:`civis.response.Response` object
+            for the json-encoded content of a response. This maps the
+            top-level json keys to snake_case.
+            - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
+            list-like responses and a :class:`pandas:pandas.Series` for
+            single a json response.
+        """
+        if return_type not in ['snake', 'raw', 'pandas']:
+            raise ValueError("Return type must be one of 'snake', 'raw', "
+                             "'pandas'")
+        self._api_key = api_key
         self._service_id = service_id
         self._base_url = self.get_base_url()
         self._root_path = root_path
         self._swagger_path = swagger_path
-        # Catch deprecation warnings from generate_classes_maybe_cached and
-        # the functions it calls until the `resources` argument is removed.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=FutureWarning,
-                module='civis')
-            classes = self.generate_classes()
+        classes = self.generate_classes()
         for class_name, klass in classes.items():
-            setattr(self, class_name, klass(self._session_kwargs, client=self,
+            setattr(self, class_name, klass(client=self,
                                             return_type=return_type))
 
     def parse_path(self, path, operations):
@@ -122,7 +147,7 @@ class ServiceClient():
         swagger_url = self._base_url + self._swagger_path
 
         with requests.Session() as sess:
-            auth_service_session(sess, self._service_id)
+            auth_service_session(sess, self)
             response = sess.get(swagger_url)
             response.raise_for_status()
         spec = response.json(object_pairs_hook=OrderedDict)
@@ -134,5 +159,5 @@ class ServiceClient():
         return self.parse_api_spec(spec)
 
     def get_base_url(self):
-        service = _get_service(self._service_id)
+        service = _get_service(self)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,4 +1,3 @@
-import civis
 from collections import OrderedDict
 import re
 import warnings
@@ -7,6 +6,7 @@ from jsonref import JsonRef
 import requests
 import six
 
+from civis import APIClient
 from civis.base import Endpoint, CivisAPIError, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
@@ -14,7 +14,8 @@ from civis._utils import to_camelcase
 
 def auth_service_session(session, service_id):
     try:
-        service = civis.APIClient().services.get(service_id)
+        client = APIClient()
+        service = client.services.get(service_id)
     except CivisAPIError as err:
         msg = ('There was an issue '
                'finding service with ID {}.').format(service_id)
@@ -130,7 +131,7 @@ class ServiceClient():
 
     def get_base_url(self):
         try:
-            client = civis.APIClient()
+            client = APIClient()
             service = client.services.get(self._service_id)
         except CivisAPIError as err:
             msg = ('There was an issue '

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -7,22 +7,18 @@ import warnings
 from jsonref import JsonRef
 import six
 
-from civis.base import Endpoint, CivisAPIError, CivisAPIKeyError, tostr_urljoin
+from civis.base import Endpoint, CivisAPIError, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
-
-from openapi_spec_validator import validate_v2_spec
 
 
 def auth_service_session(session, service_id):
     try:
         service = civis.APIClient().services.get(service_id)
     except CivisAPIError as err:
-        if err.status_code == 404:
-            msg = 'There was an issue finding service {}.'.format(service_id)
-            six.raise_from(ValueError(msg), err)
-        else:
-            raise
+        msg = ('There was an issue '
+               'finding service with ID {}.').format(service_id)
+        six.raise_from(ValueError(msg), err)
 
     auth_url = service['current_deployment']['displayUrl']
     # Make request for adding Authentication Cookie to session
@@ -83,8 +79,8 @@ class ServiceClient():
             classes = self.generate_classes()
         for class_name, klass in classes.items():
             setattr(self, class_name, klass(self._session_kwargs, client=self,
-                                          return_type=return_type,
-                                          root_path=root_path))
+                                            return_type=return_type,
+                                            root_path=root_path))
 
     def parse_path(self, path, operations):
         """ Parse an endpoint into a class where each valid http request
@@ -125,12 +121,6 @@ class ServiceClient():
             response = sess.get(swagger_url)
             response.raise_for_status()
         spec = response.json(object_pairs_hook=OrderedDict)
-        try:
-            validate_v2_spec(spec)
-        except:
-            msg = ('There was an issue validating your API spec. '
-                   'Ensure it complies with Swagger 2.0')
-            six.raise_from(ValueError(msg), ValueError)
         return spec
 
     def generate_classes(self):
@@ -143,9 +133,7 @@ class ServiceClient():
             client = civis.APIClient()
             service = client.services.get(self._service_id)
         except CivisAPIError as err:
-            if err.status_code == 404:
-                msg = ('There is no Civis Service with '
-                       'ID {}!'.format(self._service_id))
-                six.raise_from(ValueError(msg), err)
-            raise
+            msg = ('There was an issue '
+                   'finding service with ID {}.').format(service_id)
+            six.raise_from(ValueError(msg), err)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -14,7 +14,7 @@ from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
 
 
-def auth_service_session(session, service_id):
+def _get_service(service_id):
     try:
         client = APIClient()
         service = client.services.get(service_id)
@@ -22,7 +22,11 @@ def auth_service_session(session, service_id):
         msg = ('There was an issue '
                'finding service with ID {}.').format(service_id)
         six.raise_from(ValueError(msg), err)
+    return service
 
+
+def auth_service_session(session, service_id):
+    service = _get_service(service_id)
     auth_url = service['current_deployment']['displayUrl']
     # Make request for adding Authentication Cookie to session
     session.get(auth_url)
@@ -130,11 +134,5 @@ class ServiceClient():
         return self.parse_api_spec(spec)
 
     def get_base_url(self):
-        try:
-            client = APIClient()
-            service = client.services.get(self._service_id)
-        except CivisAPIError as err:
-            msg = ('There was an issue '
-                   'finding service with ID {}.').format(self._service_id)
-            six.raise_from(ValueError(msg), err)
+        service = _get_service(self._service_id)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -41,7 +41,7 @@ class ServiceEndpoint(Endpoint):
     def _build_path(self, path):
         if not path:
             return self._client._base_url
-        if self._root_path is None:
+        if not self._root_path:
             return tostr_urljoin(self._client._base_url, path.strip("/"))
         return tostr_urljoin(self._client._base_url,
                              self._root_path.strip("/"),
@@ -130,7 +130,7 @@ class ServiceClient():
         except:
             msg = ('There was an issue validating your API spec. '
                    'Ensure it complies with Swagger 2.0')
-                six.raise_from(ValueError(msg), ValueError)
+            six.raise_from(ValueError(msg), ValueError)
         return spec
 
     def generate_classes(self):

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,10 +1,10 @@
 import civis
 from collections import OrderedDict
 import re
-import requests
 import warnings
 
 from jsonref import JsonRef
+import requests
 import six
 
 from civis.base import Endpoint, CivisAPIError, tostr_urljoin

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -55,13 +55,9 @@ class ServiceEndpoint(Endpoint):
                 response = sess.request(method, url, json=data,
                                         params=params, **kwargs)
 
-        if response.status_code == 401:
-            auth_error = response.headers["www-authenticate"]
-            six.raise_from(CivisAPIKeyError(auth_error),
-                           CivisAPIError(response))
-
         if not response.ok:
-            raise CivisAPIError(response)
+            six.raise_from(ValueError(response.text),
+                           ValueError)
 
         return response
 

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,0 +1,142 @@
+import civis
+from collections import OrderedDict
+import re
+import six
+import warnings
+
+from jsonref import JsonRef
+import requests
+
+from civis.base import Endpoint, CivisAPIError, CivisAPIKeyError, tostr_urljoin
+from civis.resources._resources import parse_method
+from civis._utils import to_camelcase
+
+
+def auth_service_session(session, service_id):
+    # civis api error?
+    service = civis.APIClient().services.get(service_id)
+    auth_url = service['current_deployment']['displayUrl']
+    # Make request for Authentication Cookie
+    session.get(auth_url)
+
+
+class ServiceEndpoint(Endpoint):
+
+    def __init__(self, session_kwargs, client,
+                 return_type='civis', root_path=None):
+        self._session_kwargs = session_kwargs
+        self._return_type = return_type
+        self._client = client
+        self._root_path = root_path
+
+    def _build_path(self, path):
+        if not path:
+            return self._client._base_url
+        if self._root_path is None:
+            return tostr_urljoin(self._client._base_url, path.strip("/"))
+        return tostr_urljoin(self._client._base_url,
+                             self._root_path.strip("/"),
+                             path.strip("/"))
+
+    def _make_request(self, method, path=None, params=None, data=None,
+                      **kwargs):
+        url = self._build_path(path)
+
+        with requests.Session() as sess:
+            auth_service_session(sess, self._client._service_id)
+            with self._lock:
+                response = sess.request(method, url, json=data,
+                                        params=params, **kwargs)
+
+        if response.status_code == 401:
+            auth_error = response.headers["www-authenticate"]
+            six.raise_from(CivisAPIKeyError(auth_error),
+                           CivisAPIError(response))
+
+        if not response.ok:
+            raise CivisAPIError(response)
+
+        return response
+
+
+class ServiceClient():
+
+    def __init__(self, service_id, root_path=None, swagger_path="/endpoints"):
+        return_type = 'snake'
+        self._session_kwargs = {}
+        self._service_id = service_id
+        self._base_url = self.get_base_url()
+        self._root_path = root_path
+        self._swagger_path = swagger_path
+        # Catch deprecation warnings from generate_classes_maybe_cached and
+        # the functions it calls until the `resources` argument is removed.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=FutureWarning,
+                module='civis')
+            classes = self.generate_classes()
+        for class_name, cls in classes.items():
+            setattr(self, class_name, cls(self._session_kwargs, client=self,
+                                          return_type=return_type,
+                                          root_path=root_path))
+
+    def parse_path(self, path, operations):
+        """ Parse an endpoint into a class where each valid http request
+        on that endpoint is converted into a convenience function and
+        attached to the class as a method.
+        """
+        if self._root_path is not None:
+            path = path.replace(self._root_path, '')
+        path = path.strip('/')
+        modified_base_path = re.sub("-", "_", path.split('/')[0].lower())
+        methods = []
+        for verb, op in operations.items():
+            method = parse_method(verb, op, path)
+            if method is None:
+                continue
+            methods.append(method)
+        return modified_base_path, methods
+
+    def parse_api_spec(self, api_spec):
+        paths = api_spec['paths']
+        classes = {}
+        for path, ops in paths.items():
+            base_path, methods = self.parse_path(path, ops)
+            class_name = to_camelcase(base_path)
+            if methods and classes.get(base_path) is None:
+                classes[base_path] = type(str(class_name),
+                                          (ServiceEndpoint,),
+                                          {})
+            for method_name, method in methods:
+                setattr(classes[base_path], method_name, method)
+        return classes
+
+    def get_api_spec(self):
+        swagger_url = self._base_url + self._swagger_path
+
+        # add swagger validation ?
+
+        with requests.Session() as sess:
+            auth_service_session(sess, self._service_id)
+            response = sess.get(swagger_url)
+            response.raise_for_status()
+        spec = response.json(object_pairs_hook=OrderedDict)
+        return spec
+
+    def generate_classes(self):
+        raw_spec = self.get_api_spec()
+        spec = JsonRef.replace_refs(raw_spec)
+        return self.parse_api_spec(spec)
+
+    def get_base_url(self):
+        try:
+            client = civis.APIClient()
+            service = client.services.get(self._service_id)
+        except CivisAPIError as api_err:
+            if api_err.status_code == 404:
+                msg = ('There is no Civis Service with '
+                       'ID {}!'.format(self._service_id))
+                six.raise_from(ValueError(msg), api_err)
+            raise
+        return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import OrderedDict
 import re
 import warnings
@@ -6,10 +8,10 @@ from jsonref import JsonRef
 import requests
 import six
 
+from civis import APIClient
 from civis.base import Endpoint, CivisAPIError, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
-from civis import APIClient
 
 
 def auth_service_session(session, service_id):

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -213,7 +213,7 @@ def test_generate_classes(url_mock, api_spec_mock,
 @mock.patch('civis.service_client.ServiceClient.get_api_spec')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_generate_classes_maybe_cached(url_mock, api_spec_mock,
-                          parse_mock, mock_swagger):
+                                       parse_mock, mock_swagger):
     api_spec_mock.return_value = {}
     mock_class_function = (lambda client, return_type: "return")
     parse_mock.return_value = {'class': mock_class_function}

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -2,9 +2,9 @@ from collections import OrderedDict
 import json
 
 
+from civis import response
 from civis.base import CivisAPIError
 from civis.service_client import ServiceClient, ServiceEndpoint
-from civis import response
 import pytest
 from unittest import mock
 

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -111,7 +111,7 @@ def test_service_client(mock_civis, classes_mock):
     assert sc._session_kwargs == {}
     assert sc._service_id == mock_service_id
     assert sc._base_url == mock_survey_url
-    assert sc._root_path == None
+    assert sc._root_path is None
     assert sc._swagger_path == spec_endpoint
 
     # Custom root path

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -1,0 +1,254 @@
+from collections import OrderedDict
+import json
+
+from civis.service_client import ServiceClient, ServiceEndpoint
+
+from civis import response
+from civis.base import CivisAPIError
+import pytest
+from unittest import mock
+
+mock_service_id = 1
+
+mock_survey_url = "www.survey-url.com"
+
+
+@pytest.fixture
+def mock_swagger():
+    return {
+            "info": {
+                "title": "Test API Client",
+                "version": "1.0"
+            },
+            "paths": {
+                "/some-resources": {
+                    "get": {
+                        "description": "",
+                        "responses": {
+                            "200": {
+                                "description": "Returns a list",
+                            }
+                        },
+                        "summary": "List Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    }
+                },
+                "/some-resources/{id}": {
+                    "get": {
+                        "description": "",
+                        "responses": {
+                            "200": {
+                                "description": "Returns a Resource",
+                            }
+                        },
+                        "summary": "Get Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    },
+                    "patch": {
+                        "description": "",
+                        "parameters": [
+                            {
+                                "description": "The id of the Resource",
+                                "in": "path",
+                                "name": "id",
+                                "required": True,
+                                "type": "integer"
+                            },
+                            {
+                                "description": "The fields and values to edit",
+                                "in": "body",
+                                "name": "body",
+                                "required": True,
+                                "schema": {
+                                    "properties": {
+                                        "field": {
+                                            "description": "a property value",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Edits Resource",
+                            }
+                        },
+                        "summary": "Patch Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    }
+                }
+            },
+            "swagger": "2.0"
+            }
+
+
+@pytest.fixture
+def mock_operations():
+    ops_json = mock_swagger["paths"]["/some-resources"]
+    mock_ops_str = str(ops_json).replace('\'', '\"')
+    mock_operations = json.JSONDecoder(object_pairs_hook=OrderedDict).decode(mock_ops_str)  # noqa: E501
+    return mock_operations
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_path(mock_civis, classes_mock, mock_operations):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+    sc = ServiceClient(mock_service_id)
+
+    mock_path = '/some-resource/sub-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "some_resource"
+    assert 'get_sub_resource' in methods[0]
+
+    mock_path = '/some-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "some_resource"
+    assert 'get' in methods[0]
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_path__with_root(mock_civis, classes_mock, mock_operations):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+    sc = ServiceClient(mock_service_id, root_path='/some-resource')
+
+    mock_path = '/some-resource/sub-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "sub_resource"
+    assert 'get' in methods[0]
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_api_spec(mock_civis, classes_mock, mock_swagger):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    classes = sc.parse_api_spec(mock_swagger)
+    assert 'some_resources' in classes
+
+
+@mock.patch('civis.service_client.requests.Session.get')
+@mock.patch('civis.service_client.auth_service_session')
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_api_spec(mock_civis, classes_mock,
+                      auth_session_mock, mock_response, mock_swagger):
+    mock_response.return_value = mock.Mock(ok=True)
+    mock_response.return_value.json.return_value = mock_swagger
+
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    spec = sc.get_api_spec()
+    assert spec == mock_swagger
+
+
+@mock.patch('civis.service_client.setattr')
+@mock.patch('civis.service_client.ServiceClient.parse_api_spec')
+@mock.patch('civis.service_client.ServiceClient.get_api_spec')
+@mock.patch('civis.service_client.civis')
+def test_generate_classes(mock_civis, api_spec_mock,
+                          parse_mock, setattr_mock, mock_swagger):
+    setattr_mock.return_value = {}
+    api_spec_mock.return_value = {}
+    mock_class_function = (lambda s, client, return_type, root_path: '/api')
+    parse_mock.return_value = {'class': mock_class_function}
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+
+    sc = ServiceClient(mock_service_id)
+
+    classes = sc.generate_classes()
+
+    assert 'class' in classes
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_base_url(mock_civis, classes_mock):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    assert sc._base_url == mock_survey_url
+    mock_client.services.get.assert_called_once_with(mock_service_id)
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_base_url__not_found(mock_civis, classes_mock):
+
+    err_resp = response.Response({
+        'status_code': 404,
+        'error': 'not_found',
+        'errorDescription': 'The requested resource could not be found.',
+        'content': True})
+    err_resp.json = lambda: err_resp.json_data
+
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.side_effect = CivisAPIError(err_resp)
+    classes_mock.return_value = {}
+
+    with pytest.raises(ValueError) as excinfo:
+        ServiceClient(mock_service_id)
+
+    expected_error = f'There is no Civis Service with ID {mock_service_id}!'
+    assert str(excinfo.value) == expected_error
+
+
+def test_build_path():
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock)
+    path = se._build_path('/resources')
+
+    assert path == 'www.service_url.com/resources'
+
+
+def test_build_path__with_root():
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock, root_path='/api')
+    path = se._build_path('/resources')
+
+    assert path == 'www.service_url.com/api/resources'
+
+
+@mock.patch('civis.service_client.requests.Session.request')
+@mock.patch('civis.service_client.auth_service_session')
+@mock.patch('civis.service_client.ServiceClient.get_base_url')
+def test_make_request(mock_base_url, auth_mock, request_mock):
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock)
+
+    expected_value = [{'id': 1, 'url': 'www.survey_url.com/1'},
+                      {'id': 2, 'url': 'www.survey_url.com/2'}]
+
+    request_mock.return_value = mock.Mock(ok=True)
+    request_mock.return_value.json = expected_value
+
+    response = se._make_request('get', 'resources/resources')
+
+    assert response.json == expected_value

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -106,7 +106,7 @@ def test_service_client(url_mock, classes_mock):
 
     spec_endpoint = "/endpoints"
 
-    assert sc._api_key == None
+    assert sc._api_key is None
     assert sc._service_id == MOCK_SERVICE_ID
     assert sc._base_url == MOCK_URL
     assert sc._root_path is None

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -106,11 +106,13 @@ def test_service_client(mock_civis, classes_mock):
 
     sc = ServiceClient(mock_service_id)
 
+    spec_endpoint = "/endpoint"
+
     assert sc._session_kwargs == {}
     assert sc._service_id == mock_service_id
     assert sc._base_url == mock_survey_url
     assert sc._root_path == None
-    assert sc._swagger_path == "/endpoints"
+    assert sc._swagger_path == spec_endpoint
 
     # Custom root path
     sc = ServiceClient(mock_service_id, root_path='/api')

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -106,7 +106,7 @@ def test_service_client(mock_civis, classes_mock):
 
     sc = ServiceClient(mock_service_id)
 
-    spec_endpoint = "/endpoint"
+    spec_endpoint = "/endpoints"
 
     assert sc._session_kwargs == {}
     assert sc._service_id == mock_service_id
@@ -242,7 +242,8 @@ def test_get_base_url__not_found(mock_civis, classes_mock):
     with pytest.raises(ValueError) as excinfo:
         ServiceClient(mock_service_id)
 
-    expected_error = f'There is no Civis Service with ID {mock_service_id}!'
+    expected_error = ('There was an issue '
+                      'finding service with ID {}.').format(mock_service_id)
     assert str(excinfo.value) == expected_error
 
 

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -91,7 +91,7 @@ def mock_swagger():
 @pytest.fixture
 def mock_operations(mock_swagger):
     ops_json = mock_swagger["paths"]["/some-resources"]
-    mock_ops_str = str(ops_json).replace('\'', '\"')
+    mock_ops_str = str(json.dumps(ops_json))
     mock_operations = json.JSONDecoder(object_pairs_hook=OrderedDict).decode(mock_ops_str)  # noqa: E501
     return mock_operations
 
@@ -221,7 +221,9 @@ def test_generate_classes_maybe_cached(url_mock, api_spec_mock,
 
     sc = ServiceClient(MOCK_SERVICE_ID)
 
-    classes = sc.generate_classes_maybe_cached(mock_swagger)
+    mock_spec_str = str(json.dumps(mock_swagger))
+    mock_spec = json.JSONDecoder(object_pairs_hook=OrderedDict).decode(mock_spec_str)  # noqa: E501
+    classes = sc.generate_classes_maybe_cached(mock_spec)
 
     assert 'class' in classes
 

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -121,6 +121,15 @@ def test_service_client(url_mock, classes_mock):
     assert sc._swagger_path == "/spec"
 
 
+def test_service_endpoint():
+    service_client_mock = mock.Mock()
+    se = ServiceEndpoint({}, service_client_mock)
+
+    assert se._session_kwargs == {}
+    assert se._return_type == 'civis'
+    assert se._client == service_client_mock
+
+
 @mock.patch('civis.service_client.ServiceClient.generate_classes')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_parse_path(url_mock, classes_mock, mock_operations):
@@ -191,7 +200,7 @@ def test_get_api_spec(url_mock, classes_mock,
 def test_generate_classes(url_mock, api_spec_mock,
                           parse_mock, mock_swagger):
     api_spec_mock.return_value = {}
-    mock_class_function = (lambda s, client, return_type, root_path: '/api')
+    mock_class_function = (lambda s, client, return_type: "return")
     parse_mock.return_value = {'class': mock_class_function}
     url_mock.return_value = mock_survey_url
 
@@ -218,7 +227,6 @@ def test_get_base_url(mock_client, classes_mock):
 @mock.patch('civis.service_client.ServiceClient.generate_classes')
 @mock.patch('civis.service_client.APIClient')
 def test_get_base_url__not_found(mock_client, classes_mock):
-
     err_resp = response.Response({
         'status_code': 404,
         'error': 'not_found',
@@ -238,7 +246,8 @@ def test_get_base_url__not_found(mock_client, classes_mock):
 
 
 def test_build_path():
-    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    service_client_mock = mock.Mock(_base_url='www.service_url.com',
+                                    _root_path=None)
     se = ServiceEndpoint({}, service_client_mock)
     path = se._build_path('/resources')
 
@@ -246,8 +255,9 @@ def test_build_path():
 
 
 def test_build_path__with_root():
-    service_client_mock = mock.Mock(_base_url='www.service_url.com')
-    se = ServiceEndpoint({}, service_client_mock, root_path='/api')
+    service_client_mock = mock.Mock(_base_url='www.service_url.com',
+                                    _root_path='/api')
+    se = ServiceEndpoint({}, service_client_mock)
     path = se._build_path('/resources')
 
     assert path == 'www.service_url.com/api/resources'

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -1,12 +1,11 @@
 from collections import OrderedDict
 import json
 
-
 from civis import response
 from civis.base import CivisAPIError
+from civis.compat import mock
 from civis.service_client import ServiceClient, ServiceEndpoint
 import pytest
-from unittest import mock
 
 mock_service_id = 0
 

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -106,6 +106,7 @@ def test_service_client(url_mock, classes_mock):
 
     spec_endpoint = "/endpoints"
 
+    assert sc._api_key == None
     assert sc._service_id == MOCK_SERVICE_ID
     assert sc._base_url == MOCK_URL
     assert sc._root_path is None
@@ -118,6 +119,10 @@ def test_service_client(url_mock, classes_mock):
     # Custom Swagger path
     sc = ServiceClient(MOCK_SERVICE_ID, swagger_path='/spec')
     assert sc._swagger_path == "/spec"
+
+    # Passed in API Key
+    sc = ServiceClient(MOCK_SERVICE_ID, api_key="this_is_an_API_key")
+    assert sc._api_key == "this_is_an_API_key"
 
 
 def test_service_endpoint():

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -96,7 +96,7 @@ def mock_operations(mock_swagger):
     return mock_operations
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_service_client(url_mock, classes_mock):
     url_mock.return_value = MOCK_URL
@@ -128,7 +128,7 @@ def test_service_endpoint():
     assert se._client == service_client_mock
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_parse_path(url_mock, classes_mock, mock_operations):
     url_mock.return_value = MOCK_URL
@@ -148,7 +148,7 @@ def test_parse_path(url_mock, classes_mock, mock_operations):
     assert 'get' in methods[0]
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_parse_path__with_root(url_mock, classes_mock, mock_operations):
     url_mock.return_value = MOCK_URL
@@ -162,7 +162,7 @@ def test_parse_path__with_root(url_mock, classes_mock, mock_operations):
     assert 'get' in methods[0]
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_parse_api_spec(url_mock, classes_mock, mock_swagger):
     url_mock.return_value = MOCK_URL
@@ -176,7 +176,7 @@ def test_parse_api_spec(url_mock, classes_mock, mock_swagger):
 
 @mock.patch('civis.service_client.requests.Session.get')
 @mock.patch('civis.service_client.auth_service_session')
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.ServiceClient.get_base_url')
 def test_get_api_spec(url_mock, classes_mock,
                       auth_session_mock, mock_response, mock_swagger):
@@ -209,7 +209,24 @@ def test_generate_classes(url_mock, api_spec_mock,
     assert 'class' in classes
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.parse_api_spec')
+@mock.patch('civis.service_client.ServiceClient.get_api_spec')
+@mock.patch('civis.service_client.ServiceClient.get_base_url')
+def test_generate_classes_maybe_cached(url_mock, api_spec_mock,
+                          parse_mock, mock_swagger):
+    api_spec_mock.return_value = {}
+    mock_class_function = (lambda client, return_type: "return")
+    parse_mock.return_value = {'class': mock_class_function}
+    url_mock.return_value = MOCK_URL
+
+    sc = ServiceClient(MOCK_SERVICE_ID)
+
+    classes = sc.generate_classes_maybe_cached(mock_swagger)
+
+    assert 'class' in classes
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client._get_service')
 def test_get_base_url(get_service_mock, classes_mock):
     get_service_mock.return_value = {'current_url': MOCK_URL}
@@ -221,7 +238,7 @@ def test_get_base_url(get_service_mock, classes_mock):
     get_service_mock.assert_called_once_with(sc)
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.APIClient')
 def test_get_service(mock_client, classes_mock):
     classes_mock.return_value = {}
@@ -232,7 +249,7 @@ def test_get_service(mock_client, classes_mock):
     assert service == expected_service
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
 @mock.patch('civis.service_client.APIClient')
 def test_get_service__not_found(mock_client, classes_mock):
     classes_mock.return_value = {}

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
 import json
 
-from civis.service_client import ServiceClient, ServiceEndpoint
 
-from civis import response
 from civis.base import CivisAPIError
+from civis.service_client import ServiceClient, ServiceEndpoint
+from civis import response
 import pytest
 from unittest import mock
 

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -191,13 +191,11 @@ def test_get_api_spec(mock_civis, classes_mock,
     assert spec == mock_swagger
 
 
-@mock.patch('civis.service_client.setattr')
 @mock.patch('civis.service_client.ServiceClient.parse_api_spec')
 @mock.patch('civis.service_client.ServiceClient.get_api_spec')
 @mock.patch('civis.service_client.civis')
 def test_generate_classes(mock_civis, api_spec_mock,
-                          parse_mock, setattr_mock, mock_swagger):
-    setattr_mock.return_value = {}
+                          parse_mock, mock_swagger):
     api_spec_mock.return_value = {}
     mock_class_function = (lambda s, client, return_type, root_path: '/api')
     parse_mock.return_value = {'class': mock_class_function}


### PR DESCRIPTION
Adding ServiceClient() method which takes a service id, optional base path (default is None), and optional swagger endpoint (default is '/endpoints'), then creates a client from the api spec and endpoints.

A lot of the work is being done in the helper functions and Endpoint class for the original APIClient, but small changes were needed in a few cases (mostly in regards to the url and making requests). These changes are overridden by the ServiceClient and ServiceEndpoint class.