### PR TITLE
[PARO-685] Smoke tests for different CivisML alias objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with pyyaml version for Python 3.4 by requiring pyyaml version <=5.2
 
 ### Changed
-- CivisML uses platform aliases instead of hard-coded template IDs. (#341)
+- CivisML uses platform aliases instead of hard-coded template IDs. (#341, #347)
 - CivisML versions and pre-installed packages are documented on Zendesk instead. (#341)
 - Issue a `FutureWarning` on import for Python 2 and 3.4 users. (#333,
   #340)

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -337,6 +337,9 @@ def _get_template_ids_all_versions(client):
                       'reason': 'No CivisML template IDs are accessible.',
                       'content': None})
         raise CivisAPIError(r)
+    # Disallow a defaultdict in the output, so that a non-existent CivisML
+    # version as key should trigger a KeyError.
+    ids = dict(ids)
     return ids
 
 

--- a/tools/smoke_tests.py
+++ b/tools/smoke_tests.py
@@ -82,15 +82,18 @@ def main():
 
     # Test modeling.
     logger.info('Testing Civis-ML...')
-    mp = civis.ml.ModelPipeline(
-        model="sparse_logistic",
-        dependent_variable="type",
-        primary_key="index",
-        client=client
-    )
-    result = mp.train(
-        table_name="datascience.iris", database_name=database).result()
-    assert result['state'] == 'succeeded'
+    for civisml_version in (None, 'v2.2'):  # None = latest production version
+        logger.info('CivisML version: %r', civisml_version)
+        mp = civis.ml.ModelPipeline(
+            model="sparse_logistic",
+            dependent_variable="type",
+            primary_key="index",
+            client=client,
+            civisml_version=civisml_version,
+        )
+        result = mp.train(
+            table_name="datascience.iris", database_name=database).result()
+        assert result['state'] == 'succeeded'
 
     logger.info("%.1f seconds elapsed in total.", time.time() - t0)
 


### PR DESCRIPTION
This PR is a follow-up of #341, which makes strong assumptions about what CivisML alias objects exist on Civis Platform.

Before this PR, the smoke test for CivisML modeling used the default scenario of not specifying `civisml_version` for `civis.ml.ModelPipeline` (which would use the latest CivisML version in production). This PR makes the CivisML modeling smoke test also run on an explicitly specified `civisml_version` as well, which would access different CivisML alias objects than the unspecified `civisml_version` does.

While working on this PR, I uncovered a bug where `civis.ml.ModelPipeline`'s `civisml_version` param with a non-existent CivisML version did not raise the expected error of "the specified CivisML version doesn't exist". Bug fixed at 0eb8dd4.