### PR TITLE
MAINT update dependencies for CivisML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated cloudpickle and joblib dependencies. (#349)
-- CivisML uses platform aliases instead of hard-coded template IDs. (#341)
 - CivisML uses platform aliases instead of hard-coded template IDs. (#341, #347)
 - CivisML versions and pre-installed packages are documented on Zendesk instead. (#341)
 - Issue a `FutureWarning` on import for Python 2 and 3.4 users. (#333,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with pyyaml version for Python 3.4 by requiring pyyaml version <=5.2
 
 ### Changed
+- Updated cloudpickle and joblib dependencies. (#349)
 - CivisML uses platform aliases instead of hard-coded template IDs. (#341)
 - CivisML versions and pre-installed packages are documented on Zendesk instead. (#341)
 - Issue a `FutureWarning` on import for Python 2 and 3.4 users. (#333,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib>=0.11,<0.15
 pubnub>=4.0,<=4.99
-cloudpickle>=0.2,<=2 ; python_version != '3.4'
+cloudpickle>=0.2,<2 ; python_version != '3.4'
 cloudpickle<1.2 ; python_version == '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.12.0,==2.*
 jsonschema>=2.5.1,<=3
 functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
-joblib>=0.11,<=0.13
+joblib>=0.11,<0.15
 pubnub>=4.0,<=4.99
 cloudpickle>=0.2,<=1 ; python_version != '3.4'
-cloudpickle<1.2 ; python_version == '3.4'
+cloudpickle<1.3 ; python_version == '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ functools32>=3.2,<=3.99 ; python_version == '2.7'
 six>=1.10,<=1.99
 joblib>=0.11,<0.15
 pubnub>=4.0,<=4.99
-cloudpickle>=0.2,<=1 ; python_version != '3.4'
-cloudpickle<1.3 ; python_version == '3.4'
+cloudpickle>=0.2,<=2 ; python_version != '3.4'
+cloudpickle<1.2 ; python_version == '3.4'

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ def main():
             'requests>=2.12.0,==2.*',
             'jsonschema>=2.5.1,<=3',
             'six>=1.10,<=1.99',
-            'joblib>=0.11,<=0.13.99',
+            'joblib>=0.11,<=0.15',
             'pubnub>=4.0,<=4.99',
-            "cloudpickle>=0.2.0,<=1.99999 ; python_version != '3.4'",
+            "cloudpickle>=0.2.0,<2 ; python_version != '3.4'",
             "cloudpickle>=0.2.0,<1.2 ; python_version == '3.4'",
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main():
             'requests>=2.12.0,==2.*',
             'jsonschema>=2.5.1,<=3',
             'six>=1.10,<=1.99',
-            'joblib>=0.11,<=0.15',
+            'joblib>=0.11,<0.15',
             'pubnub>=4.0,<=4.99',
             "cloudpickle>=0.2.0,<2 ; python_version != '3.4'",
             "cloudpickle>=0.2.0,<1.2 ; python_version == '3.4'",


### PR DESCRIPTION
Updating `cloudpickle` and `joblib` versions following discussion in #329.

I manually tested this on Python 3.6.8 with up-to-date `cloudpickle` and `joblib` versions, and @jacksonllee did the same for Python 3.7.