### PR TITLE
handle deprecated endpoints

### DIFF
--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -421,7 +421,6 @@ def parse_method(verb, operation, path):
     summary = operation["summary"]
     params = operation.get("parameters", [])
     responses = operation["responses"]
-    deprecated = operation.get('deprecated', False)
     deprecation_warning = operation.get("x-deprecation-warning", None)
     if 'deprecated' in summary.lower():
         return None

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -132,6 +132,16 @@ def docs_from_properties(properties, level=0):
     return docs
 
 
+def deprecated_notice(deprecation_warning):
+    """ Return a doc string element for the deprecation notice. The
+    doc string can be an empty string if the warning is None
+    """
+    if deprecation_warning is None:
+        return ""
+
+    return "Deprecation warning!\n------------------\n" + deprecation_warning
+
+
 def doc_from_responses(responses):
     """ Return a doc string element from a responses object. The
     doc string describes the returned objects of a function.
@@ -412,12 +422,14 @@ def parse_method(verb, operation, path):
     params = operation.get("parameters", [])
     responses = operation["responses"]
     deprecated = operation.get('deprecated', False)
-    if 'deprecated' in summary.lower() or deprecated:
+    deprecation_warning = operation.get("x-deprecation-warning", None)
+    if 'deprecated' in summary.lower():
         return None
 
     args, param_doc = parse_params(params, summary, verb)
     response_doc = doc_from_responses(responses)
-    docs = join_doc_elements(param_doc, response_doc)
+    deprecation_notice = deprecated_notice(deprecation_warning)
+    docs = join_doc_elements(deprecation_notice, param_doc, response_doc)
     name = parse_method_name(verb, path)
 
     method = create_method(args, verb, name, path, docs)

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -126,6 +126,18 @@ def test_docs_from_properties():
     assert sorted(y) == sorted(['    - a : string', '    - b : integer'])
 
 
+def test_deprecated_notice():
+    deprecation_warning = "This endpoint is no longer supported. Please use the following:"
+    notice = deprecated_notice(deprecation_warning)
+
+    assert "Deprecation warning!" in notice
+    assert deprecation_warning in notice
+
+
+def test_deprecated_notice_handles_none():
+    assert _resources.deprecated_notice(None) == ""
+
+
 def test_doc_from_responses():
     responses = OrderedDict([('200', OrderedDict([('description', 'success'), ('schema', OrderedDict([('type', 'array'), ('items', OrderedDict([('type', 'object'), ('properties', OrderedDict([('id', OrderedDict([('description', 'The ID of the credential.'), ('type', 'integer')])), ('name', OrderedDict([('description', 'The name identifying the credential'), ('type', 'string')])), ('type', OrderedDict([('description', "The credential's type."), ('type', 'string')])), ('username', OrderedDict([('description', 'The username for the credential.'), ('type', 'string')])), ('description', OrderedDict([('description', 'A long description of the credential.'), ('type', 'string')])), ('owner', OrderedDict([('description', 'The name of the user who this credential belongs to.'), ('type', 'string')])), ('remoteHostId', OrderedDict([('description', 'The ID of the remote host associated with this credential.'), ('type', 'integer')])), ('remoteHostName', OrderedDict([('description', 'The name of the remote host associated with this credential.'), ('type', 'string')])), ('createdAt', OrderedDict([('description', 'The creation time for this credential.'), ('type', 'string'), ('format', 'time')])), ('updatedAt', OrderedDict([('description', 'The last modification time for this credential.'), ('type', 'string'), ('format', 'time')]))]))]))]))]))])  # noqa: E501
     x = _resources.doc_from_responses(responses)

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -127,8 +127,8 @@ def test_docs_from_properties():
 
 
 def test_deprecated_notice():
-    deprecation_warning = "This endpoint is no longer supported. Please use the following:"
-    notice = deprecated_notice(deprecation_warning)
+    deprecation_warning = "This endpoint is no longer supported"
+    notice = _resources.deprecated_notice(deprecation_warning)
 
     assert "Deprecation warning!" in notice
     assert deprecation_warning in notice


### PR DESCRIPTION
One thing to note:
- We'll have code that asserts that an endpoint must have both `deprecated` and `warning` set, not one or the other.


This PR will close #345.