### PR TITLE
[SERD-1816] Service Client Error Handling

### DIFF
--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -6,7 +6,6 @@ import re
 
 from jsonref import JsonRef
 import requests
-import six
 
 from civis import APIClient
 from civis.base import CivisAPIError, Endpoint, tostr_urljoin

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -9,7 +9,7 @@ import requests
 import six
 
 from civis import APIClient
-from civis.base import Endpoint, tostr_urljoin
+from civis.base import CivisAPIError, Endpoint, tostr_urljoin
 from civis.compat import lru_cache
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
@@ -58,8 +58,7 @@ class ServiceEndpoint(Endpoint):
                                         params=params, **kwargs)
 
         if not response.ok:
-            six.raise_from(ValueError(response.text),
-                           ValueError)
+            raise CivisAPIError(response)
 
         return response
 


### PR DESCRIPTION
In SERD-1816 we are hoping to catch timeouts on our survey-toolbox service API endpoints. In order to do so, we have to raise an API error rather than a value error so we can check the response. 

cc @leeacto @ggarcia-civis for viz