### PR TITLE
[PARO-685] DOC update language for CivisML version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed issue where client did not generate functions for deprecated API endpoints. (#353)
 ### Changed
-- Updated documentation language for CivisML version. (#357)
+- Updated documentation language for CivisML version. (#358)
 
 ## 1.12.0 - 2020-01-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed issue where client did not generate functions for deprecated API endpoints. (#353)
 ### Changed
+- Updated documentation language for CivisML version. (#357)
 
 ## 1.12.0 - 2020-01-14
 ### Added

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -291,8 +291,8 @@ CivisML Versions
 ----------------
 
 By default, CivisML uses its latest version in production.
-Under special circumstances, if you would like a specific version
-(e.g., an older version),
+If you would like a specific version
+(e.g., for a production pipeline where pinning the CivisML version is desirable),
 :class:`~civis.ml.ModelPipeline` (both its constructor and the class method
 :meth:`civis.ml.ModelPipeline.register_pretrained_model`) has the optional
 parameter ``civisml_version`` that accepts a string, e.g., ``'v2.3'``


### PR DESCRIPTION
The documentation for the CivisML version implies that the major use of the `civisml_version` parameter (added in #341) is to use an older version of CivisML, which seems slightly misleading. I'm updating the docs to clarify that it's about pinning the version for production work as a more probable use case.

The parallel PR for civis-r is https://github.com/civisanalytics/civis-r/pull/225