### PR TITLE
ENH CLI live log tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands
 ### Fixed
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-- Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands
+- Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands (#359)
 ### Fixed
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -215,10 +215,16 @@ Then open ``docs/build/html/index.html``.
 Note that this will use your API key in the ``CIVIS_API_KEY`` environment
 variable so it will generate documentation for all the endpoints that you have access to.
 
+Command-line Interface (CLI)
+----------------------------
+
+After installing the Python package, you'll also have a ``civis`` command accessible from your shell. It surfaces a commandline interface to all of the regular Civis API endpoints, plus a few helpers. To get started, run ``civis``. You can find out more information about a command by adding a ``--help`` option, like ``civis scripts list --help``.
+
+
 Contributing
 ------------
 
-See ``CONTRIBUTING.md`` for information about contributing to this project.
+See `CONTRIBUTING.md <CONTRIBUTING.md>`_ for information about contributing to this project.
 
 
 License
@@ -226,4 +232,4 @@ License
 
 BSD-3
 
-See ``LICENSE.md`` for details.
+See `LICENSE.md <LICENSE.md>`_ for details.

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -26,7 +26,7 @@ from jsonref import JsonRef
 import yaml
 from civis.cli._cli_commands import (
     civis_ascii_art, files_download_cmd, files_upload_cmd,
-    notebooks_download_cmd, notebooks_new_cmd,
+    jobs_follow_run_logs, notebooks_download_cmd, notebooks_new_cmd,
     notebooks_up, notebooks_down, notebooks_open, sql_cmd)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis.resources._resources import parse_method_name
@@ -224,6 +224,8 @@ def add_extra_commands(cli):
     notebooks_cmd.add_command(notebooks_up)
     notebooks_cmd.add_command(notebooks_down)
     notebooks_cmd.add_command(notebooks_open)
+    jobs_cmd = cli.commands['jobs']
+    jobs_cmd.add_command(jobs_follow_run_logs)
     cli.add_command(civis_ascii_art)
 
     cli.add_command(sql_cmd)

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -26,8 +26,8 @@ from jsonref import JsonRef
 import yaml
 from civis.cli._cli_commands import (
     civis_ascii_art, files_download_cmd, files_upload_cmd,
-    jobs_follow_run_logs, notebooks_download_cmd, notebooks_new_cmd,
-    notebooks_up, notebooks_down, notebooks_open, sql_cmd)
+    jobs_follow_log, jobs_follow_run_log, notebooks_download_cmd,
+    notebooks_new_cmd, notebooks_up, notebooks_down, notebooks_open, sql_cmd)
 from civis.resources import get_api_spec, CACHED_SPEC_PATH
 from civis.resources._resources import parse_method_name
 from civis._utils import open_session
@@ -225,7 +225,8 @@ def add_extra_commands(cli):
     notebooks_cmd.add_command(notebooks_down)
     notebooks_cmd.add_command(notebooks_open)
     jobs_cmd = cli.commands['jobs']
-    jobs_cmd.add_command(jobs_follow_run_logs)
+    jobs_cmd.add_command(jobs_follow_log)
+    jobs_cmd.add_command(jobs_follow_run_log)
     cli.add_command(civis_ascii_art)
 
     cli.add_command(sql_cmd)

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -204,7 +204,7 @@ def _jobs_follow_run_log(id, run_id):
             seen_max_log_id = max(log['id'] for log in logs)
             logs.sort(key=operator.itemgetter('createdAt', 'id'))
         for log in logs:
-            print(' '.join((log['createdAt'], log['message'])))
+            print(' '.join((log['createdAt'], log['message'].rstrip())))
         # if output is a pipe, write the buffered output immediately:
         sys.stdout.flush()
         if seen_max_log_id == remote_max_log_id:

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -34,12 +34,18 @@ _CIVIS_ASCII_ART = r"""
  \   \ .'  '---'         '---" '---'
   `---`
 """
-_FOLLOW_LOG_NOTE = """
+_FOLLOW_LOG_NOTE = '''
 
-    NOTE: This command could miss some log entries from a currently-running
-    job. It does not re-fetch logs that might have been saved out of order, to
-    preserve the chronological order of the logs and without duplication.
-"""
+Outputs job run logs in the format: "datetime message\\n" where
+datetime is in ISO8601 format, like "2020-02-14T20:28:18.722Z".
+If the job is still running, this command will continue outputting logs
+until the run is done and then exit. If the run is already finished, it
+will output all the logs from that run and then exit.
+
+NOTE: This command could miss some log entries from a currently-running
+job. It does not re-fetch logs that might have been saved out of order, to
+preserve the chronological order of the logs and without duplication.
+'''
 _FOLLOW_POLL_INTERVAL_SEC = 3
 
 

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -190,7 +190,7 @@ def jobs_follow_run_log(id, run_id):
 
 def _jobs_follow_run_log(id, run_id):
     client = civis.APIClient(return_type='raw')
-    seen_max_log_id = None
+    seen_max_log_id = 0
     continue_polling = True
 
     while continue_polling:


### PR DESCRIPTION
* Adds `civis jobs follow-log` and `civis jobs follow-run-log`
* Like `tail -f` for job run logs, closely mirroring the output of run logs on the web UI

<details><summary>Demo GIFs</summary>
<p>

![demo1](https://user-images.githubusercontent.com/451345/74255486-f15ba100-4cbf-11ea-8be3-296f13b2f717.gif)

![demo2](https://user-images.githubusercontent.com/451345/74255527-fae50900-4cbf-11ea-8511-f5e76bcc26ec.gif)

</p>
</details>
