### PR TITLE
avoid duplicate parent job parameters when inferring joblib backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands (#359)
 ### Fixed
+- Fixed a bug related to duplicating parent job parameters when using `civis.parallel.infer_backend_factory`. (#363)
 ### Changed
 
 ## 1.12.1 - 2020-02-10
 ### Fixed
 - Fixed issue where client did not generate functions for deprecated API endpoints. (#353)
-
-- Fixed a bug related to duplicating parent job parameters when using `civis.parallel.infer_backend_factory`. (#363)
-
 ### Changed
 - Changed `ServiceClient` to raise `CivisAPIError`. (#355)
 - Updated documentation language for CivisML version. (#358)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.12.1 - 2020-02-10
 ### Fixed
 - Fixed issue where client did not generate functions for deprecated API endpoints. (#353)
+
+- Fixed a bug related to duplicating parent job parameters when using `civis.parallel.infer_backend_factory`. (#363)
+
 ### Changed
 - Changed `ServiceClient` to raise `CivisAPIError`. (#355)
 - Updated documentation language for CivisML version. (#358)

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -218,8 +218,13 @@ def infer_backend_factory(required_resources=None,
     for key in KEYS_TO_INFER:
         kwargs.setdefault(key, state[key])
 
+    # Don't include parent job params since they're added automatically
+    # in _ContainerShellExecutor.__init__.
+    filtered_params = [p for p in state.params if p['name'].upper()
+                       not in ('CIVIS_PARENT_JOB_ID', 'CIVIS_PARENT_RUN_ID')]
+
     return make_backend_factory(required_resources=state.required_resources,
-                                params=state.params,
+                                params=filtered_params,
                                 arguments=state.arguments,
                                 client=client,
                                 polling_interval=polling_interval,

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -128,7 +128,7 @@ def _test_retries_helper(num_failures, max_submit_retries,
 def test_template_submit(mock_file, mock_result, mock_pool):
     # Verify that creating child jobs from a template looks like we expect
     file_id = 17
-    mock_client = mock.Mock()
+    mock_client = create_client_mock()
     mock_file.return_value = file_id
 
     factory = civis.parallel.make_backend_template_factory(
@@ -200,7 +200,7 @@ def test_default_setup_cmd_with_repo(mock_backend):
 def test_infer_no_job_id_error(mock_make_factory, mock_job):
     # The `infer_backend_factory` should give a RuntimeError
     # if there's no CIVIS_JOB_ID in the environment.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     with mock.patch.dict('os.environ', {}, clear=True):
         with pytest.raises(RuntimeError):
@@ -211,7 +211,7 @@ def test_infer_no_job_id_error(mock_make_factory, mock_job):
 def test_infer(mock_make_factory, mock_job):
     # Verify that `infer_backend_factory` passes through
     # the expected arguments to `make_backend_factory`.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
                                         'CIVIS_RUN_ID': "test_run"}):
@@ -234,7 +234,7 @@ def test_infer(mock_make_factory, mock_job):
 @mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_new_params(mock_make_factory, mock_job):
     # Test overwriting existing job parameters with new parameters
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     new_params = [{'name': 'spam', 'type': 'fun'},
                   {'name': 'foo', 'type': 'bar'}]
@@ -250,7 +250,7 @@ def test_infer_new_params(mock_make_factory, mock_job):
 def test_infer_extra_param(mock_make_factory, mock_job):
     # Test adding a new parameter and keeping
     # the existing parameter unchanged.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     new_params = [{'name': 'foo', 'type': 'bar'}]
     with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
@@ -265,7 +265,7 @@ def test_infer_extra_param(mock_make_factory, mock_job):
 @mock.patch.object(civis.parallel, 'make_backend_factory')
 def test_infer_update_resources(mock_make_factory, mock_job):
     # Verify that users can modify requested resources for jobs.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
                                         'CIVIS_RUN_ID': "test_run"}):
@@ -280,7 +280,7 @@ def test_infer_update_resources(mock_make_factory, mock_job):
 def test_infer_update_args(mock_make_factory, mock_job):
     # Verify that users can modify the existing job's
     # arguments for sub-processes.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_job
     with mock.patch.dict('os.environ', {'CIVIS_JOB_ID': "test_job",
                                         'CIVIS_RUN_ID': "test_run"}):
@@ -296,7 +296,7 @@ def test_infer_from_custom_job(mock_make_factory, mock_job):
     # Test that `infer_backend_factory` can find needed
     # parameters if it's run inside a custom job created
     # from a template.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_custom = Response(dict(from_template_id=999, id=42,
                                 required_resources=None,
                                 params=[{'name': 'spam'}],
@@ -347,7 +347,7 @@ def test_infer_from_custom_job(mock_make_factory, mock_job):
 def test_infer_in_child_job(mock_make_factory, mock_child_job):
     # Verify that infer_backend_factory doesn't include CIVIS_PARENT_JOB_ID and
     # CIVIS_PARENT_RUN_ID since those will be automatically added later.
-    mock_client = mock.MagicMock()
+    mock_client = create_client_mock()
     mock_client.scripts.get_containers.return_value = mock_child_job
     mock_env = {
         'CIVIS_JOB_ID': "test_job",
@@ -419,7 +419,7 @@ def test_result_exception_no_result():
     # Passing the client mock as an argument instead of globally
     # patching the client tests that the _CivisBackendResult
     # uses the client object on the input CivisFuture.
-    mock_client = mock.MagicMock().APIClient()
+    mock_client = create_client_mock()
     mock_client.scripts.list_containers_runs_outputs.return_value = []
     fut = ContainerFuture(1, 2, client=mock_client)
     fut._set_api_exception(Response({'state': 'failed'}))


### PR DESCRIPTION
This addresses a bug where submitting jobs from a parallel backend from `infer_joblib_backend` failed when used in a child job where `CIVIS_PARENT_JOB_ID` and `CIVIS_PARENT_RUN_ID` were set. Those parameter names would be duplicated, which causes platform to reject the job.

I tweaked `infer_joblib_backend` because the issue pertains to use of that function.  I decided to also replace rather than append parent job parameters in ` _ContainerShellExecutor.__init__` [here](https://github.com/civisanalytics/civis-python/blob/adc87f1a8ec2c7501b611f9213054234cccc14f1/civis/futures.py#L562-L568) because the behavior there also seemed problematic.

To do:
- [x] update changelog
- [ ] should I go ahead and bump the version number?