### PR TITLE
account for when n_jobs is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands (#359)
 ### Fixed
 - Fixed a bug related to duplicating parent job parameters when using `civis.parallel.infer_backend_factory`. (#363)
+- Fixed `effective_n_jobs` to account for `n_jobs=None`, which is a default for the LogisticsRegression in `sklearn=0.22.x`. (#365)
 ### Changed
 
 ## 1.12.1 - 2020-02-10

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -831,6 +831,8 @@ class _CivisBackend(ParallelBackendBase):
                                                     **self.executor_kwargs)
 
     def effective_n_jobs(self, n_jobs):
+        if n_jobs is None:
+            n_jobs = 1
         if n_jobs == -1:
             n_jobs = _ALL_JOBS
         if n_jobs <= 0:


### PR DESCRIPTION
`sklearn==0.22.0` sets the default for `n_jobs` to `None` for `LogisticRegression` models https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression

This is a breaking change from `0.19.x` which set it to 1. The `joblib` library accounts for this already in a recent bug fix but we don't in our custom backend. Here's the fix. 