### PR TITLE
Print NULL for `civis sql` output with Nones instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `civis jobs follow-log` and `civis jobs follow-run-log` CLI commands (#359)
 ### Fixed
 - Fixed a bug related to duplicating parent job parameters when using `civis.parallel.infer_backend_factory`. (#363)
+- Fixed crashing on NULL fields in `civis sql` CLI command (#366)
 ### Changed
 
 ## 1.12.1 - 2020-02-10

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -155,17 +155,18 @@ def sql_cmd(dbname, command, filename, output, quiet, n):
 
 def _str_table_result(cols, rows):
     """Turn a Civis Query result into a readable table."""
+    str_rows = [['NULL' if _v is None else _v for _v in row] for row in rows]
     # Determine the maximum width of each column.
     # First find the width of each element in each row, then find the max
     # width in each position.
     max_len = functools.reduce(
         lambda x, y: [max(z) for z in zip(x, y)],
-        [[len(_v) for _v in _r] for _r in [cols] + rows])
+        [[len(_v) for _v in _r] for _r in [cols] + str_rows])
 
     header_str = " | ".join("{0:<{width}}".format(_v, width=_l)
                             for _l, _v in zip(max_len, cols))
     tb_strs = [header_str, len(header_str) * '-']
-    for row in rows:
+    for row in str_rows:
         tb_strs.append(" | ".join("{0:>{width}}".format(_v, width=_l)
                                   for _l, _v in zip(max_len, row)))
     return '\n'.join(tb_strs)

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -155,7 +155,7 @@ def sql_cmd(dbname, command, filename, output, quiet, n):
 
 def _str_table_result(cols, rows):
     """Turn a Civis Query result into a readable table."""
-    str_rows = [['NULL' if _v is None else _v for _v in row] for row in rows]
+    str_rows = [['' if _v is None else _v for _v in row] for row in rows]
     # Determine the maximum width of each column.
     # First find the width of each element in each row, then find the max
     # width in each position.

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -123,7 +123,7 @@ def test_make_operation_name(path, method, resource_name, exp):
 
 def test_str_table_result():
     cols = ['a', 'snake!']
-    rows = [['2', '3'], ['1.1', '3.3']]
+    rows = [['2', '3'], ['1.1', None]]
 
     out = _str_table_result(cols, rows)
-    assert out == "a   | snake!\n------------\n  2 |      3\n1.1 |    3.3"
+    assert out == "a   | snake!\n------------\n  2 |      3\n1.1 |       "


### PR DESCRIPTION
Before this change, running `civis sql` with some cells being NULL results in this error:
```py
  File "/Users/apollak/dev/civis-python/civis/cli/_cli_commands.py", line 166, in _str_table_result
    [[len(_v) for _v in _r] for _r in [cols] + str_rows])
  File "/Users/apollak/dev/civis-python/civis/cli/_cli_commands.py", line 166, in <listcomp>
    [[len(_v) for _v in _r] for _r in [cols] + str_rows])
  File "/Users/apollak/dev/civis-python/civis/cli/_cli_commands.py", line 166, in <listcomp>
    [[len(_v) for _v in _r] for _r in [cols] + str_rows])
TypeError: object of type 'NoneType' has no len()
```