### PR TITLE
Speed up repeated invocations of create_client_mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug related to creating a ModelPipeline from a registered model. (#369)
 
 ### Changed
+- Made repeated invocations of `civis.tests.create_client_mock` faster by caching the real APIClient that the mock spec is based on (#371)
 
 ## 1.12.1 - 2020-02-10
 ### Fixed

--- a/civis/tests/mocks.py
+++ b/civis/tests/mocks.py
@@ -3,7 +3,7 @@
 import os
 
 from civis import APIClient
-from civis.compat import mock
+from civis.compat import lru_cache, mock
 
 
 TEST_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -27,15 +27,21 @@ def create_client_mock(cache=TEST_SPEC):
         error if any method calls have non-existent / misspelled parameters
     """
     # Create a client from the cache. We'll use this for auto-speccing.
-    real_client = APIClient(local_api_spec=cache, api_key='none')
-    real_client._feature_flags = {'noflag': None}
-    if hasattr(real_client, 'channels'):
-        # Deleting "channels" causes the client to fall back on
-        # regular polling for completion, which greatly eases testing.
-        delattr(real_client, 'channels')
+    real_client = _real_client(cache)
 
     # Prevent the client from trying to talk to the real API when autospeccing
     with mock.patch('requests.Session', mock.MagicMock):
         mock_client = mock.create_autospec(real_client, spec_set=True)
 
     return mock_client
+
+
+@lru_cache(maxsize=1)
+def _real_client(local_api_spec):
+    real_client = APIClient(local_api_spec=local_api_spec, api_key='none')
+    real_client._feature_flags = {'noflag': None}
+    if hasattr(real_client, 'channels'):
+        # Deleting "channels" causes the client to fall back on
+        # regular polling for completion, which greatly eases testing.
+        delattr(real_client, 'channels')
+    return real_client


### PR DESCRIPTION
* Calling create_client_mock() repeatedly takes about a second each time it's called. This is because calling APIClient(local_api_spec=...) creates new resource classes from the endpoints JSON every time, instead of using the normal resource cache like it does when calling APIClient() without a local_api_spec.

Total test time on Travis (this PR is on top, previous build is bottom):
![Screen Shot 2020-03-05 at 12 02 03 PM](https://user-images.githubusercontent.com/451345/76005547-2df27500-5ed9-11ea-9c93-bb1ca1ea601b.png)

Not sure if this deserves a changelog entry?