### PR TITLE
Fix readme and setup.py to appease twine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `effective_n_jobs` to account for `n_jobs=None`, which is a default for the LogisticsRegression in `sklearn=0.22.x`. (#365)
 - Fixed crashing on NULL fields in `civis sql` CLI command (#366)
 - Fixed a bug related to creating a ModelPipeline from a registered model. (#369)
+- Fixed readme and setup.py to appease twine. (#373)
 
 ### Changed
 - Made repeated invocations of `civis.tests.create_client_mock` faster by caching the real APIClient that the mock spec is based on (#371)

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ The Civis API may also be directly accessed via the ``APIClient`` class.
     client = civis.APIClient()
     database = client.databases.list()
 
-See the `full documentation <https://civis-python.readthedocs.io>`_ for a more
+See the `documentation <https://civis-python.readthedocs.io>`_ for a more
 complete user guide.
 
 
@@ -219,7 +219,7 @@ Command-line Interface (CLI)
 ----------------------------
 
 After installing the Python package, you'll also have a ``civis`` command accessible from your shell. It surfaces a commandline interface to all of the regular Civis API endpoints, plus a few helpers. To get started, run ``civis --help``.
-Please see the `full documentation <https://civis-python.readthedocs.io/en/stable/cli.html>`_ for more details.
+Please see the `CLI documentation <https://civis-python.readthedocs.io/en/stable/cli.html>`_ for more details.
 
 
 Contributing

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def main():
         data_files=[(os.path.join('civis', 'tests'),
                      glob(os.path.join('civis', 'tests', '*.json')))],
         long_description=README,
+        long_description_content_type="text/x-rst",
         install_requires=[
             "pyyaml>=3.0,<=5.99 ; python_version != '3.4'",
             "pyyaml>=3.0,<=5.2 ; python_version == '3.4'",


### PR DESCRIPTION
We were not able to build distributions with `twine` for a new release, because `twine` doesn't allow duplicate references in the reStructuredText-formated README (not sure why this didn't come up before for previous releases, but I don't think we're interested in digging into this now). Also fixed is the missing `long_descritption_content_type` kwarg in `setup.py`, which `twine` threw a warning for.

With this PR, locally I tested it by building the source distribution and checking with `twine` again. Everything looks good now:

```
$ twine check dist/civis-1.13.0.tar.gz 
Checking dist/civis-1.13.0.tar.gz: PASSED
```