### PR TITLE
[APIC-273] Add Table Columns Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Added `table_columns` parameter to `civis.io.civis_file_to_table`, `civis.io.dataframe_to_civis`, and `civis.io.csv_to_civis` (#379)
+
 ### Fixed
 
 - Fixed/relaxed version specifications for click, jsonref, and jsonschema. (#377)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1024,11 +1024,11 @@ def civis_file_to_table(file_id, database, table, client=None,
                                      headers, delimiter, hidden)
 
     (cleaned_file_ids, headers, compression, delimiter,
-     cleaning_table_columns) = _process_cleaning_results(
+     cleaned_table_columns) = _process_cleaning_results(
         cleaning_futures, client, headers, need_table_columns, delimiter
     )
 
-    table_columns = table_columns or cleaning_table_columns
+    table_columns = table_columns or cleaned_table_columns
 
     source = dict(file_ids=cleaned_file_ids)
     destination = dict(schema=schema, table=table, remote_host_id=db_id,

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1016,9 +1016,8 @@ def civis_file_to_table(file_id, database, table, client=None,
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    need_table_columns = (table_columns is None
-                          or not table_exists
-                          or existing_table_rows == 'drop')
+    need_table_columns = ((not table_exists or existing_table_rows == 'drop')
+                          and table_columns is None)
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1002,7 +1002,8 @@ def civis_file_to_table(file_id, database, table, client=None,
     if schema is None:
         raise ValueError("Provide a schema as part of the `table` input.")
     if table_columns is not None and not isinstance(table_columns, list):
-        raise ValueError("Provide table_columns as a list of dictionaries with keys of `name` and `sqlType`.")
+        raise ValueError("Provide table_columns as a list of dictionaries"
+                         " with keys of `name` and `sqlType`.")
     db_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
     if delimiter is not None:  # i.e. it was provided as an argument

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1016,10 +1016,9 @@ def civis_file_to_table(file_id, database, table, client=None,
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    if not table_columns:
-        need_table_columns = not table_exists or existing_table_rows == 'drop'
-    else:
-        need_table_columns = False
+    need_table_columns = (table_columns is None
+                          or not table_exists
+                          or existing_table_rows == 'drop')
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)
@@ -1029,8 +1028,7 @@ def civis_file_to_table(file_id, database, table, client=None,
         cleaning_futures, client, headers, need_table_columns, delimiter
     )
 
-    if not table_columns:
-        table_columns = cleaning_table_columns
+    table_columns = table_columns or cleaning_table_columns
 
     source = dict(file_ids=cleaned_file_ids)
     destination = dict(schema=schema, table=table, remote_host_id=db_id,

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -662,8 +662,9 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in the source file.
-        Each dictionary should have keys for column "name" and "sqlType"
+        An list of dictionaries corresponding to the columns in
+        the source file. Each dictionary should have keys
+        for column "name" and "sqlType"
     headers : bool, optional [DEPRECATED]
         Whether or not the first row of the file should be treated as
         headers. The default, ``None``, attempts to autodetect whether
@@ -802,8 +803,9 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in the source file.
-        Each dictionary should have keys for column "name" and "sqlType"
+        An list of dictionaries corresponding to the columns in
+        the source file. Each dictionary should have keys
+        for column "name" and "sqlType"
     delimiter : string, optional
         The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
     headers : bool, optional
@@ -930,8 +932,9 @@ def civis_file_to_table(file_id, database, table, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in the source file.
-        Each dictionary should have keys for column "name" and "sqlType"
+        An list of dictionaries corresponding to the columns in
+        the source file. Each dictionary should have keys
+        for column "name" and "sqlType"
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
         uniquely identify a record. If existing_table_rows is "upsert", this
@@ -1013,7 +1016,10 @@ def civis_file_to_table(file_id, database, table, client=None,
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    need_table_columns = (not table_exists or existing_table_rows == 'drop') and not table_columns
+    if not table_columns:
+        need_table_columns = not table_exists or existing_table_rows == 'drop'
+    else:
+        need_table_columns = False
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1001,6 +1001,8 @@ def civis_file_to_table(file_id, database, table, client=None,
         file_id = [file_id]
     if schema is None:
         raise ValueError("Provide a schema as part of the `table` input.")
+    if table_columns is not None and not isinstance(table_columns, list):
+        raise ValueError("Provide table_columns as a list of dictionaries with keys of `name` and `sqlType`.")
     db_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
     if delimiter is not None:  # i.e. it was provided as an argument

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1001,9 +1001,6 @@ def civis_file_to_table(file_id, database, table, client=None,
         file_id = [file_id]
     if schema is None:
         raise ValueError("Provide a schema as part of the `table` input.")
-    if table_columns is not None and not isinstance(table_columns, list):
-        raise ValueError("Provide table_columns as a list of dictionaries"
-                         " with keys of `name` and `sqlType`.")
     db_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
     if delimiter is not None:  # i.e. it was provided as an argument

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -662,9 +662,10 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in
+        A list of dictionaries corresponding to the columns in
         the source file. Each dictionary should have keys
-        for column "name" and "sqlType"
+        for column "name" and "sqlType". The import will only copy these
+        columns regardless if there are more columns in the table.
     headers : bool, optional [DEPRECATED]
         Whether or not the first row of the file should be treated as
         headers. The default, ``None``, attempts to autodetect whether
@@ -803,9 +804,10 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in
+        A list of dictionaries corresponding to the columns in
         the source file. Each dictionary should have keys
-        for column "name" and "sqlType"
+        for column "name" and "sqlType". The import will only copy these
+        columns regardless if there are more columns in the table.
     delimiter : string, optional
         The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
     headers : bool, optional
@@ -932,9 +934,10 @@ def civis_file_to_table(file_id, database, table, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        An list of dictionaries corresponding to the columns in
+        A list of dictionaries corresponding to the columns in
         the source file. Each dictionary should have keys
-        for column "name" and "sqlType"
+        for column "name" and "sqlType". The import will only copy these
+        columns regardless if there are more columns in the table.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
         uniquely identify a record. If existing_table_rows is "upsert", this

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -194,6 +194,7 @@ class ImportTests(CivisVCRTestCase):
             existing_table_rows='truncate',
             diststyle=None, distkey=None,
             sortkey1=None, sortkey2=None,
+            table_columns=None,
             delimiter=",", headers=None,
             primary_keys=None,
             last_modified_keys=None,
@@ -377,6 +378,106 @@ class ImportTests(CivisVCRTestCase):
             'execution': 'immediate',
             'loosen_types': False,
             'table_columns': mock_columns,
+            'redshift_destination_options': {
+                'diststyle': None, 'distkey': None,
+                'sortkeys': [None, None]
+            }
+
+        }
+        self.mock_client.imports.post_files_csv.assert_called_once_with(
+            {'file_ids': [mock_cleaned_file_id]},
+            {
+                'schema': 'scratch',
+                'table': 'api_client_test_fixture',
+                'remote_host_id': 42,
+                'credential_id': 713,
+                'primary_keys': None,
+                'last_modified_keys': None
+            },
+            True,
+            **expected_kwargs
+        )
+
+    @pytest.mark.civis_file_to_table
+    @mock.patch('civis.io._tables._process_cleaning_results')
+    @mock.patch('civis.io._tables._run_cleaning')
+    def test_civis_file_to_table_table_doesnt_exist_provide_table_columns(
+            self,
+            m_run_cleaning,
+            m_process_cleaning_results,
+            _m_get_api_spec
+    ):
+        table = "scratch.api_client_test_fixture"
+        database = 'redshift-general'
+        mock_file_id = 1234
+        mock_cleaned_file_id = 1235
+        mock_import_id = 8675309
+
+        self.mock_client.imports.post_files_csv.return_value\
+            .id = mock_import_id
+        self.mock_client.get_database_id.return_value = 42
+        self.mock_client.default_credential = 713
+
+        self.mock_client.get_table_id.side_effect = ValueError('no table')
+        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'}]
+        m_process_cleaning_results.return_value = (
+            [mock_cleaned_file_id],
+            True,  # headers
+            'gzip',  # compression
+            'comma',  # delimiter
+            None  # table_columns
+        )
+        m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
+
+        with mock.patch.object(
+                civis.io._tables, 'run_job',
+                spec_set=True) as m_run_job:
+
+            run_job_future = mock.MagicMock(
+                spec=civis.futures.CivisFuture,
+                job_id=123,
+                run_id=234
+            )
+
+            m_run_job.return_value = run_job_future
+
+            result = civis.io.civis_file_to_table(
+                mock_file_id, database, table,
+                existing_table_rows='truncate',
+                table_columns=table_columns,
+                delimiter=',',
+                headers=True,
+                client=self.mock_client
+            )
+
+            assert result is run_job_future
+            m_run_job.assert_called_once_with(mock_import_id,
+                                              client=self.mock_client,
+                                              polling_interval=None)
+
+        m_run_cleaning.assert_called_once_with(
+            [mock_file_id], self.mock_client, True, False, 'comma', True
+        )
+        m_process_cleaning_results.assert_called_once_with(
+            [mock.sentinel.cleaning_future],
+            self.mock_client,
+            True,
+            False,
+            'comma'
+        )
+
+        expected_name = 'CSV import to scratch.api_client_test_fixture'
+        expected_kwargs = {
+            'name': expected_name,
+            'max_errors': None,
+            'existing_table_rows': 'truncate',
+            'hidden': True,
+            'column_delimiter': 'comma',
+            'compression': 'gzip',
+            'escaped': False,
+            'execution': 'immediate',
+            'loosen_types': False,
+            'table_columns': table_columns,
             'redshift_destination_options': {
                 'diststyle': None, 'distkey': None,
                 'sortkeys': [None, None]
@@ -755,6 +856,7 @@ class ImportTests(CivisVCRTestCase):
             max_errors=None, existing_table_rows="truncate",
             diststyle=None, distkey=None,
             sortkey1=None, sortkey2=None,
+            table_columns=None,
             delimiter=',',
             primary_keys=None,
             last_modified_keys=None,

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -461,8 +461,8 @@ class ImportTests(CivisVCRTestCase):
         m_process_cleaning_results.assert_called_once_with(
             [mock.sentinel.cleaning_future],
             self.mock_client,
-            False,
             True,
+            False,
             'comma'
         )
 

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -456,13 +456,13 @@ class ImportTests(CivisVCRTestCase):
                                               polling_interval=None)
 
         m_run_cleaning.assert_called_once_with(
-            [mock_file_id], self.mock_client, True, False, 'comma', True
+            [mock_file_id], self.mock_client, False, True, 'comma', True
         )
         m_process_cleaning_results.assert_called_once_with(
             [mock.sentinel.cleaning_future],
             self.mock_client,
-            True,
             False,
+            True,
             'comma'
         )
 


### PR DESCRIPTION
**JIRA Ticket:**
[APIC-273](https://civisanalytics.atlassian.net/browse/APIC-273)

**Summary:**
Adding the table_columns parameter to io methods.

**Testing:**
- [x] Updated specs
- [x] Performed manual tests

Manual Tests
- [x] import to a pre-existing table with non-drop mode and table columns not specified [Job 70574228](https://platform.civisanalytics.com/spa/jobs/70574228)
- [x] import to pre-existing table with existing_table_rows=drop and table columns not specified [Job 70573579](https://platform.civisanalytics.com/spa/jobs/70573579)
- [x] import to pre-existing table with existing_table_rows=drop and table columns specified [Job 70572994](https://platform.civisanalytics.com/spa/jobs/70572994)
- [x] import to non-existent table with table columns specified [Job 70455477](https://platform.civisanalytics.com/spa/jobs/70455477)
- [x] multiple file import using `civis_file_to_table` [Job 70579238](https://platform.civisanalytics.com/spa/jobs/70579238)


Notes:

**Additional Info:**