### PR TITLE
ENH add method to retrieve run outputs from future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Added `.outputs` method to retrieve outputs from `CivisFuture`
+  objects. (#381)
+
 ### Fixed
 
 - Fixed/relaxed version specifications for click, jsonref, and jsonschema. (#377)

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -235,7 +235,7 @@ class CivisFuture(PollableResult):
 
         Raises
         ------
-        CivisJobFailure
+        civis.base.CivisJobFailure
             If the job fails.
         """
         self.result()

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -222,7 +222,20 @@ class CivisFuture(PollableResult):
                 self._set_api_exception(exc=e)
 
     def outputs(self):
-        """Block on job completion and return a list of run outputs."""
+        """
+        Block on job completion and return a list of run outputs if the
+        job is successful.
+
+        Returns
+        -------
+        list[dict]
+            List of run outputs from a successfully completed job.
+
+        Raises
+        ------
+        CivisAPIError
+            If the job fails.
+        """
         self.result()
         outputs = self.client.jobs.list_runs_outputs(self.job_id, self.run_id)
         return outputs

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -223,8 +223,10 @@ class CivisFuture(PollableResult):
 
     def outputs(self):
         """
-        Block on job completion and return a list of run outputs if the
-        job is successful.
+        Block on job completion and return a list of run outputs.
+
+        The method will only return run outputs for successful jobs.
+        Failed jobs will raise an exception.
 
         Returns
         -------
@@ -233,7 +235,7 @@ class CivisFuture(PollableResult):
 
         Raises
         ------
-        CivisAPIError
+        CivisJobFailure
             If the job fails.
         """
         self.result()

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -54,8 +54,7 @@ class JobCompleteListener(SubscribeCallback):
 
 
 class CivisFuture(PollableResult):
-    """
-    A class for tracking future results.
+    """A class for tracking future results.
 
     This class will attempt to subscribe to a Pubnub channel to listen for
     job completion events. If you don't have access to Pubnub channels, then
@@ -222,8 +221,7 @@ class CivisFuture(PollableResult):
                 self._set_api_exception(exc=e)
 
     def outputs(self):
-        """
-        Block on job completion and return a list of run outputs.
+        """Block on job completion and return a list of run outputs.
 
         The method will only return run outputs for successful jobs.
         Failed jobs will raise an exception.

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -221,6 +221,12 @@ class CivisFuture(PollableResult):
             except Exception as e:
                 self._set_api_exception(exc=e)
 
+    def outputs(self):
+        """Block on job completion and return a list of run outputs."""
+        self.result()
+        outputs = self.client.jobs.list_runs_outputs(self.job_id, self.run_id)
+        return outputs
+
 
 class ContainerFuture(CivisFuture):
     """Encapsulates asynchronous execution of a Civis Container Script

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -183,6 +183,20 @@ class CivisFutureTests(CivisVCRTestCase):
         assert result._state == 'FINISHED'
         with pytest.raises(CivisJobFailure):
             result.result()
+        with pytest.raises(CivisJobFailure):
+            result.outputs()
+
+    def test_outputs_succeeded(self):
+        poller = mock.Mock()
+        api_result = mock.Mock()
+        api_result.state = 'succeeded'
+        mock_client = create_client_mock()
+        expected_return = [{'test': 'test_result'}]
+        mock_client.jobs.list_runs_outputs.return_value = expected_return
+
+        result = CivisFuture(poller, (1, 2), client=mock_client)
+        result._set_api_result(api_result)
+        assert result.outputs() == expected_return
 
     @mock.patch(api_import_str, return_value=civis_api_spec_channels)
     @mock.patch.object(CivisFuture, '_subscribe')


### PR DESCRIPTION
This PR adds a new method to `CivisFuture` objects, `.outputs()`, which blocks on job completion and returns the run outputs. I kept it as minimal as possible to make it generalizeable and easy to maintain, while still making it easy to maintain.

I tested the method manually on succeeded and failed container scripts using both `CivisFuture` and `ContainerFuture`, and also tested on a successful sql script. It's always challenging to add meaningful unit tests to the API client, so I'm happy for feedback on the unit testing I added.