### PR TITLE
ENH parse_service_api_spec outside of serviceclient object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `table_columns` parameter to `civis.io.civis_file_to_table`, `civis.io.dataframe_to_civis`, and `civis.io.csv_to_civis` (#379)
 
 ### Fixed
-
+- No longer require ServiceClient to be instantiated to parse a
+  service api spec. (#382)
 - Fixed/relaxed version specifications for click, jsonref, and jsonschema. (#377)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `table_columns` parameter to `civis.io.civis_file_to_table`, `civis.io.dataframe_to_civis`, and `civis.io.csv_to_civis` (#379)
 
 ### Fixed
-- No longer require ServiceClient to be instantiated to parse a
-  service api spec. (#382)
 - Fixed/relaxed version specifications for click, jsonref, and jsonschema. (#377)
 
 ### Removed
 
 - Removed support for Python 2.7 and 3.4. (#378)
+
+### Changed
+- No longer require ServiceClient to be instantiated to parse a
+  service api spec. (#382)
+
 
 ## 1.13.1 - 2020-03-06
 ### Added

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -58,8 +58,10 @@ def parse_service_api_spec(api_spec, root_path=None):
     api_spec : OrderedDict
         The Civis Service API specification to parse.  References should be
         resolved before passing, typically using jsonref.JsonRef().
-
-
+    root_path : str, optional
+        An additional path for APIs that are not hosted on the service's
+        root level. An example root_path would be '/api' for an app with
+        resource endpoints that all begin with '/api'.
     """
     paths = api_spec['paths']
     classes = {}

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -134,52 +134,33 @@ def test_service_endpoint():
     assert se._client == service_client_mock
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
-@mock.patch('civis.service_client.ServiceClient.get_base_url')
-def test_parse_service_path(url_mock, classes_mock, mock_operations):
-    url_mock.return_value = MOCK_URL
-    classes_mock.return_value = {}
-    sc = ServiceClient(MOCK_SERVICE_ID)
-
+def test_parse_service_path(mock_operations):
     mock_path = '/some-resource/sub-resource/{id}'
-    base_path, methods = _parse_service_path(mock_path, mock_operations,
-                                             service_client=sc)
+    base_path, methods = _parse_service_path(mock_path, mock_operations)
 
     assert base_path == "some_resource"
     assert 'get_sub_resource' in methods[0]
 
     mock_path = '/some-resource/{id}'
-    base_path, methods = _parse_service_path(mock_path, mock_operations,
-                                             service_client=sc)
+    base_path, methods = _parse_service_path(mock_path, mock_operations)
 
     assert base_path == "some_resource"
     assert 'get' in methods[0]
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
-@mock.patch('civis.service_client.ServiceClient.get_base_url')
-def test_parse_path__with_root(url_mock, classes_mock, mock_operations):
-    url_mock.return_value = MOCK_URL
-    classes_mock.return_value = {}
-    sc = ServiceClient(MOCK_SERVICE_ID, root_path='/some-resource')
+def test_parse_path__with_root(mock_operations):
+    root_path = '/some-resource'
 
     mock_path = '/some-resource/sub-resource/{id}'
     base_path, methods = _parse_service_path(mock_path, mock_operations,
-                                             service_client=sc)
+                                             root_path=root_path)
 
     assert base_path == "sub_resource"
     assert 'get' in methods[0]
 
 
-@mock.patch('civis.service_client.ServiceClient.generate_classes_maybe_cached')
-@mock.patch('civis.service_client.ServiceClient.get_base_url')
-def test_parse_service_api_spec(url_mock, classes_mock, mock_swagger):
-    url_mock.return_value = MOCK_URL
-    classes_mock.return_value = {}
-
-    sc = ServiceClient(MOCK_SERVICE_ID)
-
-    classes = parse_service_api_spec(mock_swagger, service_client=sc)
+def test_parse_service_api_spec(mock_swagger):
+    classes = parse_service_api_spec(mock_swagger)
     assert 'some_resources' in classes
 
 


### PR DESCRIPTION
This PR moves API spec parsing for services outside of the `ServiceClient` object. This allows a user to parse a spec without an API key.