### PR TITLE
[APIC-278] bugfix root path in parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.14.1 - 2020-04-22
+### Fixed
+- Fixed a bug in the `ServiceClient` where the API root path was not passed when generating classes. (#384)
+
 ## 1.14.0 - 2020-04-22
 ### Added
 - Added `.outputs` method to retrieve outputs from `CivisFuture`

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -176,7 +176,7 @@ class ServiceClient():
         warnings.warn("This method is deprecated and will be removed in "
                       "v2.0.0. Use the `_parse_service_path` function "
                       "instead.")
-        return _parse_service_path(path, operations, root_path=self.root_path)
+        return _parse_service_path(path, operations, root_path=self._root_path)
 
     def parse_api_spec(self, api_spec):
         warnings.warn("This method is deprecated and will be removed in "

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -199,7 +199,7 @@ class ServiceClient():
     def generate_classes(self):
         raw_spec = self.get_api_spec()
         spec = JsonRef.replace_refs(raw_spec)
-        return parse_service_api_spec(spec)
+        return parse_service_api_spec(spec, root_path=self._root_path)
 
     def get_base_url(self):
         service = _get_service(self)
@@ -219,5 +219,5 @@ class ServiceClient():
                 msg = "cache must be an OrderedDict or str, given {}"
                 raise ValueError(msg.format(type(cache)))
             spec = JsonRef.replace_refs(raw_spec)
-            classes = parse_service_api_spec(spec)
+            classes = parse_service_api_spec(spec, root_path=self._root_path)
         return classes

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -192,9 +192,11 @@ def test_generate_classes(url_mock, api_spec_mock,
     parse_mock.return_value = {'class': mock_class_function}
     url_mock.return_value = MOCK_URL
 
-    sc = ServiceClient(MOCK_SERVICE_ID)
+    sc = ServiceClient(MOCK_SERVICE_ID, root_path='/foo')
 
     classes = sc.generate_classes()
+    parse_mock.assert_called_once_with(api_spec_mock.return_value,
+                                       root_path='/foo')
 
     assert 'class' in classes
 
@@ -209,11 +211,18 @@ def test_generate_classes_maybe_cached(url_mock, api_spec_mock,
     parse_mock.return_value = {'class': mock_class_function}
     url_mock.return_value = MOCK_URL
 
-    sc = ServiceClient(MOCK_SERVICE_ID)
+    sc = ServiceClient(MOCK_SERVICE_ID, root_path='/foo')
 
     mock_spec_str = str(json.dumps(mock_swagger))
     mock_spec = json.JSONDecoder(object_pairs_hook=OrderedDict).decode(mock_spec_str)  # noqa: E501
     classes = sc.generate_classes_maybe_cached(mock_spec)
+
+    parse_mock.assert_has_calls([
+        # the call from generate_classes_maybe_cached in ServiceClient.__init__
+        mock.call({}, root_path='/foo'),
+        # the call from generate_classes_maybe_cached in this test
+        mock.call(mock_spec, root_path='/foo')
+    ])
 
     assert 'class' in classes
 


### PR DESCRIPTION
This PR fixes a bug in civis-python 1.14.0 that breaks autospec generation. The issue arises because the root path is not passed to the parsing function when generating classes. This PR also replaces an undefined variable with the defined variable in a now deprecated function.