### PR TITLE
remove python 2 deprecation warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,6 @@ Civis Platform API Python Client
    :target: https://pypi.org/project/civis/
    :alt: Supported python versions for civis-python
 
-**Deprecation Warning:** Civis will no longer support Python 2.7 or
-Python 3.4 as of April 1, 2020. The first Civis Platform API Python Client
-release made after that date will remove Python 2 support.
-
-
 Introduction
 ------------
 


### PR DESCRIPTION
This is just following up after #357 and the 1.14.x releases, to remove the outdated deprecation warning.