### PR TITLE
Add additional detail on primary_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+- Added additional detail to `civis.io.dataframe_to_civis`, `civis.io.csv_to_civis`, and `civis.io.civis_file_to_table`'s docstrings on the primary key parameter.
+
 ## 1.14.1 - 2020-04-22
 ### Fixed
 - Fixed a bug in the `ServiceClient` where the API root path was not passed when generating classes. (#384)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-- Added additional detail to `civis.io.dataframe_to_civis`, `civis.io.csv_to_civis`, and `civis.io.civis_file_to_table`'s docstrings on the primary key parameter.
+- Added additional detail to `civis.io.dataframe_to_civis`, `civis.io.csv_to_civis`, and `civis.io.civis_file_to_table`'s docstrings on the primary key parameter. (#388)
 
 ## 1.14.1 - 2020-04-22
 ### Fixed

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -681,7 +681,8 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
         credential will be used.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
-        uniquely identify a record. If existing_table_rows is "upsert", this
+        uniquely identify a record. These columns must not contain null values.
+        If existing_table_rows is "upsert", this
         field is required. Note that this is true regardless of whether the
         destination database itself requires a primary key.
     last_modified_keys: list[str], optional
@@ -816,7 +817,8 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
         or not the first row contains headers.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
-        uniquely identify a record. If existing_table_rows is "upsert", this
+        uniquely identify a record. These columns must not contain null values.
+        If existing_table_rows is "upsert", this
         field is required. Note that this is true regardless of whether the
         destination database itself requires a primary key.
     last_modified_keys: list[str], optional
@@ -940,7 +942,8 @@ def civis_file_to_table(file_id, database, table, client=None,
         columns regardless if there are more columns in the table.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
-        uniquely identify a record. If existing_table_rows is "upsert", this
+        uniquely identify a record. These columns must not contain null values.
+        If existing_table_rows is "upsert", this
         field is required. Note that this is true regardless of whether the
         destination database itself requires a primary key.
     last_modified_keys: list[str], optional


### PR DESCRIPTION
In this PR, we explicitly note in the import methods in the `civis.io` module that primary key columns cannot be null. We are concurrently updating the API documentation to reflect this as well.