### PR TITLE
[APIC-238] Make CLI exit code nonzero when response status code != 2xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- Fixed a bug in the CLI tool which caused failed commands to exit with a 0 exit status. (#389)
 
 ### Changed
 - Added additional detail to `civis.io.dataframe_to_civis`, `civis.io.csv_to_civis`, and `civis.io.civis_file_to_table`'s docstrings on the primary key parameter. (#388)

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -162,10 +162,12 @@ def invoke(method, path, op, *args, **kwargs):
     with open_session(get_api_key(), user_agent=CLI_USER_AGENT) as sess:
         response = sess.request(**request_info)
 
-    # Print the response to stderr if there was an error.
+    # Print the response to stderr and set exit code to 1 if there was an error
     output_file = sys.stdout
+    exit_code = 0
     if response.status_code != 200:
         output_file = sys.stderr
+        exit_code = 1
 
     # Print the output, if there is any.
     # For commands such as DELETE /scripts/containers/{script_id}/runs/{id},
@@ -184,6 +186,8 @@ def invoke(method, path, op, *args, **kwargs):
         # Otherwise, do nothing.
         if response.text.strip():
             print("Error parsing response: {}".format(e), file=sys.stderr)
+
+    sys.exit(exit_code)
 
 
 def retrieve_spec_dict(api_version="1.0"):

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -165,7 +165,7 @@ def invoke(method, path, op, *args, **kwargs):
     # Print the response to stderr and set exit code to 1 if there was an error
     output_file = sys.stdout
     exit_code = 0
-    if response.status_code != 200:
+    if not (200 <= response.status_code < 300):
         output_file = sys.stderr
         exit_code = 1
 


### PR DESCRIPTION
When using the python API client CLI tool a command which fails can still exit with a 0 exit code. This can lead Platform to mark jobs which didn't successfully complete with a green checkmark or to mistakenly progress workflows when a step didn't work.

MWE:
Running 
```
civis tables post-scan some_db_id some_schema some_table
```
Generates logs:
```
2020-05-05 04:14:37 PM code: 404
2020-05-05 04:14:37 PM error: not_found
2020-05-05 04:14:37 PM errorDescription: The requested resource could not be found.
```
But the job is still marked as successful.