### PR TITLE
DEP Remove file_id deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Added additional detail to `civis.io.dataframe_to_civis`, `civis.io.csv_to_civis`, and `civis.io.civis_file_to_table`'s docstrings on the primary key parameter. (#388)
 - Made polling threads for Civis futures be daemon threads so that Python processes will shut down properly in Python 3.8 (#391)
+- Removed deprecation warning on the `file_id` parameter of `civis.io.civis_file_to_table`. The parameter name will be kept in v2. (#360, #393)
 
 ## 1.14.1 - 2020-04-22
 ### Fixed

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -889,7 +889,6 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     return fut
 
 
-@deprecate_param('v2.0.0', 'file_id')
 def civis_file_to_table(file_id, database, table, client=None,
                         max_errors=None, existing_table_rows="fail",
                         diststyle=None, distkey=None,
@@ -908,8 +907,7 @@ def civis_file_to_table(file_id, database, table, client=None,
     Parameters
     ----------
     file_id : int or list[int]
-        Civis file ID or a list of Civis file IDs. Reference by name to this
-        argument is deprecated, as the name will change in v2.0.0.
+        Civis file ID or a list of Civis file IDs.
     database : str or int
         Upload data into this database. Can be the database name or ID.
     table : str

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pytest==5.*
 pyyaml>=3.0,<=5.99
 sphinx>=1.7.0,<2.0.0
-flake8>=3.0.4,<3.8
+flake8>=3.0.4,==3.*
 pytest-cov>=2.4.0,==2.*
 vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pytest==5.*
 pyyaml>=3.0,<=5.99
 sphinx>=1.7.0,<2.0.0
-flake8>=3.0.4,==3.*
+flake8>=3.0.4,<3.8
 pytest-cov>=2.4.0,==2.*
 vcrpy>=1.11.0,<=1.11.99
 vcrpy-unittest==0.1.6


### PR DESCRIPTION
There was no way for users to avoid this deprecation warning when calling `civis.io.civis_file_to_table`, and it was also triggered by other functions which called `civis_file_to_table` (such as `dataframe_to_civis`). The original thought had been to replace the singular `file_id` parameter with a plural `file_ids` parameter in v2, but per discussion in #360, the singular will be acceptable.

Closes #360.