### PR TITLE
[APIC-300] bump minimum pubnub version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+- Bump minimum pubnub version to `4.1.12` (#397)
+
 ## 1.14.2 - 2020-06-03
 ### Added
 - Added support for Python 3.8 (#391)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jsonref>=0.1,<=0.2.99
 requests>=2.12.0,==2.*
 jsonschema>=2.5.1,<=3.99
 joblib>=0.11,<0.15
-pubnub>=4.0,<=4.99
+pubnub>=4.1.12,<=4.99
 cloudpickle>=0.2,<2

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def main():
             'requests>=2.12.0,==2.*',
             'jsonschema>=2.5.1,<=3.99',
             'joblib>=0.11,<0.15',
-            'pubnub>=4.0,<=4.99',
+            'pubnub>=4.1.12,<=4.99',
             'cloudpickle>=0.2.0,<2',
         ],
         entry_points={


### PR DESCRIPTION
From the pubnub changelog, they fixed all the keyword clashes (for async and await) since the v4.1.2 released in Sept 2018. 

I don't fully understand all the reasons I ran into this issue (why an older pubnub version was pulled in on my fresh install), but it's quick change.