### PR TITLE
[APIC-305] Require sql_type for every column when table_columns is provided

### DIFF
--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1027,11 +1027,11 @@ def civis_file_to_table(file_id, database, table, client=None,
     except ValueError:
         table_exists = False
 
-    table_columns_valid = True
+    sql_types_provided = True
     if table_columns:
         sql_type_cnt = sum(1 for col in table_columns if col.get('sql_type'))
         if sql_type_cnt == 0:
-            table_columns_valid = False
+            sql_types_provided = False
         elif sql_type_cnt != len(table_columns):
             error_message = 'Some table columns ' \
                            'have a sql type provided, ' \
@@ -1042,7 +1042,7 @@ def civis_file_to_table(file_id, database, table, client=None,
     # and perform necessary file cleaning
     need_table_columns = ((not table_exists or existing_table_rows == 'drop')
                           and
-                          (table_columns is None or not table_columns_valid))
+                          (table_columns is None or not sql_types_provided))
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -662,10 +662,13 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     headers : bool, optional [DEPRECATED]
         Whether or not the first row of the file should be treated as
         headers. The default, ``None``, attempts to autodetect whether
@@ -805,10 +808,13 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     delimiter : string, optional
         The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
     headers : bool, optional
@@ -934,10 +940,13 @@ def civis_file_to_table(file_id, database, table, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
         uniquely identify a record. These columns must not contain null values.

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1026,13 +1026,17 @@ def civis_file_to_table(file_id, database, table, client=None,
         table_exists = True
     except ValueError:
         table_exists = False
-    
+
     table_columns_valid = True
     if table_columns:
         table_columns_valid = True if table_columns[0]['sql_type'] else False
-        for i in range (0, len(table_columns)-1):
-            if not table_columns[i]['sql_type'] == table_columns[i+1]['sql_type']:
-                raise ValueError('Some table columns do not have a sql type provided')
+        for i in range(0, len(table_columns)-1):
+            thisSqlType = table_columns[i]['sql_type']
+            nextSqlType = table_columns[i+1]['sql_type']
+            if not thisSqlType == nextSqlType:
+                error_message = 'Some table columns do not ' \
+                                'have a sql type provided'
+                raise ValueError(error_message)
                 break
 
     # Use Preprocess endpoint to get the table columns as needed

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1038,6 +1038,7 @@ def civis_file_to_table(file_id, database, table, client=None,
                                 'have a sql type provided, ' \
                                 'but others do not.'
                 raise ValueError(error_message)
+        print(str(table_columns_valid))
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1031,19 +1031,18 @@ def civis_file_to_table(file_id, database, table, client=None,
     if table_columns:
         table_columns_valid = True if table_columns[0]['sql_type'] else False
         for i in range(0, len(table_columns)-1):
-            thisSqlType = table_columns[i]['sql_type']
-            nextSqlType = table_columns[i+1]['sql_type']
-            if not thisSqlType == nextSqlType:
-                error_message = 'Some table columns do not ' \
-                                'have a sql type provided'
+            this_sql_type = table_columns[i]['sql_type']
+            next_sql_type = table_columns[i+1]['sql_type']
+            if not this_sql_type == next_sql_type:
+                error_message = 'Some table columns ' \
+                                'have a sql type provided, ' \
+                                'but others do not.'
                 raise ValueError(error_message)
-                break
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    need_table_columns = (((not table_exists or existing_table_rows == 'drop')
-                          and table_columns is None)
-                          or not table_columns_valid)
+    need_table_columns = ((not table_exists or existing_table_rows == 'drop')
+                          and (table_columns is None or not table_columns_valid))
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)
@@ -1053,7 +1052,7 @@ def civis_file_to_table(file_id, database, table, client=None,
         cleaning_futures, client, headers, need_table_columns, delimiter
     )
 
-    table_columns = table_columns or cleaned_table_columns
+    table_columns = cleaned_table_columns if need_table_columns else table_columns
 
     source = dict(file_ids=cleaned_file_ids)
     destination = dict(schema=schema, table=table, remote_host_id=db_id,

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1026,19 +1026,20 @@ def civis_file_to_table(file_id, database, table, client=None,
         table_exists = True
     except ValueError:
         table_exists = False
+    
+    table_columns_valid = True
+    if table_columns:
+        table_columns_valid = True if table_columns[0]['sql_type'] else False
+        for i in range (0, len(table_columns)-1):
+            if not table_columns[i]['sql_type'] == table_columns[i+1]['sql_type']:
+                raise ValueError('Some table columns do not have a sql type provided')
+                break
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    table_columns_have_sql = True
-    if table_columns:
-        for col in table_columns:
-            if not col['sql_type']:
-                table_columns_have_sql = False
-                break
-
     need_table_columns = (((not table_exists or existing_table_rows == 'drop')
                           and table_columns is None)
-                          or not table_columns_have_sql)
+                          or not table_columns_valid)
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1033,7 +1033,7 @@ def civis_file_to_table(file_id, database, table, client=None,
         for i in range(0, len(table_columns)-1):
             this_sql_type = table_columns[i]['sql_type']
             next_sql_type = table_columns[i+1]['sql_type']
-            if (not this_sql_type) == bool(next_sql_type):
+            if (not this_sql_type) == (next_sql_type):
                 error_message = 'Some table columns ' \
                                 'have a sql type provided, ' \
                                 'but others do not.'

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1029,15 +1029,14 @@ def civis_file_to_table(file_id, database, table, client=None,
 
     table_columns_valid = True
     if table_columns:
-        table_columns_valid = True if table_columns[0]['sql_type'] else False
-        for i in range(0, len(table_columns)-1):
-            this_sql_type = table_columns[i]['sql_type']
-            next_sql_type = table_columns[i+1]['sql_type']
-            if (not this_sql_type) == (next_sql_type):
-                error_message = 'Some table columns ' \
-                                'have a sql type provided, ' \
-                                'but others do not.'
-                raise ValueError(error_message)
+        sql_type_cnt = sum(1 for col in table_columns if col.get('sql_type'))
+        if sql_type_cnt == 0:
+            table_columns_valid = False
+        elif sql_type_cnt != len(table_columns):
+            error_message = 'Some table columns ' \
+                           'have a sql type provided, ' \
+                           'but others do not.'
+            raise ValueError(error_message)
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1042,7 +1042,8 @@ def civis_file_to_table(file_id, database, table, client=None,
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
     need_table_columns = ((not table_exists or existing_table_rows == 'drop')
-                          and (table_columns is None or not table_columns_valid))
+                          and
+                          (table_columns is None or not table_columns_valid))
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)
@@ -1052,7 +1053,8 @@ def civis_file_to_table(file_id, database, table, client=None,
         cleaning_futures, client, headers, need_table_columns, delimiter
     )
 
-    table_columns = cleaned_table_columns if need_table_columns else table_columns
+    table_columns = (cleaned_table_columns if need_table_columns
+                     else table_columns)
 
     source = dict(file_ids=cleaned_file_ids)
     destination = dict(schema=schema, table=table, remote_host_id=db_id,

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1037,7 +1037,8 @@ def civis_file_to_table(file_id, database, table, client=None,
                 break
 
     need_table_columns = (((not table_exists or existing_table_rows == 'drop')
-                          and table_columns is None) or not table_columns_have_sql)
+                          and table_columns is None)
+                          or not table_columns_have_sql)
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1029,8 +1029,15 @@ def civis_file_to_table(file_id, database, table, client=None,
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning
-    need_table_columns = ((not table_exists or existing_table_rows == 'drop')
-                          and table_columns is None)
+    table_columns_have_sql = True
+    if table_columns:
+        for col in table_columns:
+            if not col['sql_type']:
+                table_columns_have_sql = False
+                break
+
+    need_table_columns = (((not table_exists or existing_table_rows == 'drop')
+                          and table_columns is None) or not table_columns_have_sql)
 
     cleaning_futures = _run_cleaning(file_id, client, need_table_columns,
                                      headers, delimiter, hidden)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1033,12 +1033,11 @@ def civis_file_to_table(file_id, database, table, client=None,
         for i in range(0, len(table_columns)-1):
             this_sql_type = table_columns[i]['sql_type']
             next_sql_type = table_columns[i+1]['sql_type']
-            if not this_sql_type == next_sql_type:
+            if (not this_sql_type) == bool(next_sql_type):
                 error_message = 'Some table columns ' \
                                 'have a sql type provided, ' \
                                 'but others do not.'
                 raise ValueError(error_message)
-        print(str(table_columns_valid))
 
     # Use Preprocess endpoint to get the table columns as needed
     # and perform necessary file cleaning

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -401,6 +401,107 @@ class ImportTests(CivisVCRTestCase):
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')
+    def test_civis_file_to_table_table_exists_sql_type_missing(
+            self,
+            m_run_cleaning,
+            m_process_cleaning_results,
+            _m_get_api_spec
+    ):
+        table = "scratch.api_client_test_fixture"
+        database = 'redshift-general'
+        mock_file_id = 1234
+        mock_cleaned_file_id = 1235
+        mock_import_id = 8675309
+
+        self.mock_client.imports.post_files_csv.return_value\
+            .id = mock_import_id
+        self.mock_client.get_database_id.return_value = 42
+        self.mock_client.default_credential = 713
+
+        self.mock_client.get_table_id.side_effect = ValueError('no table')
+        table_columns = [{'name': 'a', 'sql_type': 'INT'},
+                         {'name': 'b', 'sql_type': ''}]
+        m_process_cleaning_results.return_value = (
+            [mock_cleaned_file_id],
+            True,  # headers
+            'gzip',  # compression
+            'comma',  # delimiter
+            table_columns  # table_columns
+        )
+        m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
+
+        with mock.patch.object(
+                civis.io._tables, 'run_job',
+                spec_set=True) as m_run_job:
+
+            run_job_future = mock.MagicMock(
+                spec=civis.futures.CivisFuture,
+                job_id=123,
+                run_id=234
+            )
+
+            m_run_job.return_value = run_job_future
+
+            result = civis.io.civis_file_to_table(
+                mock_file_id, database, table,
+                existing_table_rows='truncate',
+                delimiter=',',
+                headers=True,
+                client=self.mock_client,
+                table_columns=table_columns
+            )
+
+            assert result is run_job_future
+            m_run_job.assert_called_once_with(mock_import_id,
+                                              client=self.mock_client,
+                                              polling_interval=None)
+
+        m_run_cleaning.assert_called_once_with(
+            [mock_file_id], self.mock_client, True, True, 'comma', True
+        )
+        m_process_cleaning_results.assert_called_once_with(
+            [mock.sentinel.cleaning_future],
+            self.mock_client,
+            True,
+            True,
+            'comma'
+        )
+
+        expected_name = 'CSV import to scratch.api_client_test_fixture'
+        expected_kwargs = {
+            'name': expected_name,
+            'max_errors': None,
+            'existing_table_rows': 'truncate',
+            'hidden': True,
+            'column_delimiter': 'comma',
+            'compression': 'gzip',
+            'escaped': False,
+            'execution': 'immediate',
+            'loosen_types': False,
+            'table_columns': table_columns,
+            'redshift_destination_options': {
+                'diststyle': None, 'distkey': None,
+                'sortkeys': [None, None]
+            }
+
+        }
+        self.mock_client.imports.post_files_csv.assert_called_once_with(
+            {'file_ids': [mock_cleaned_file_id]},
+            {
+                'schema': 'scratch',
+                'table': 'api_client_test_fixture',
+                'remote_host_id': 42,
+                'credential_id': 713,
+                'primary_keys': None,
+                'last_modified_keys': None
+            },
+            True,
+            **expected_kwargs
+        )
+
+    @pytest.mark.civis_file_to_table
+    @mock.patch('civis.io._tables._process_cleaning_results')
+    @mock.patch('civis.io._tables._run_cleaning')
     def test_civis_file_to_table_table_doesnt_exist_provide_table_columns(
             self,
             m_run_cleaning,

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -401,6 +401,107 @@ class ImportTests(CivisVCRTestCase):
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')
+    def test_civis_file_to_table_table_doesnt_exist_valid_table_columns_provided(
+            self,
+            m_run_cleaning,
+            m_process_cleaning_results,
+            _m_get_api_spec
+    ):
+        table = "scratch.api_client_test_fixture"
+        database = 'redshift-general'
+        mock_file_id = 1234
+        mock_cleaned_file_id = 1235
+        mock_import_id = 8675309
+
+        self.mock_client.imports.post_files_csv.return_value\
+            .id = mock_import_id
+        self.mock_client.get_database_id.return_value = 42
+        self.mock_client.default_credential = 713
+
+        self.mock_client.get_table_id.side_effect = ValueError('no table')
+        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
+                         {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
+        m_process_cleaning_results.return_value = (
+            [mock_cleaned_file_id],
+            True,  # headers
+            'gzip',  # compression
+            'comma',  # delimiter
+            table_columns  # table_columns
+        )
+        m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
+
+        with mock.patch.object(
+                civis.io._tables, 'run_job',
+                spec_set=True) as m_run_job:
+
+            run_job_future = mock.MagicMock(
+                spec=civis.futures.CivisFuture,
+                job_id=123,
+                run_id=234
+            )
+
+            m_run_job.return_value = run_job_future
+
+            result = civis.io.civis_file_to_table(
+                mock_file_id, database, table,
+                existing_table_rows='truncate',
+                delimiter=',',
+                headers=True,
+                client=self.mock_client,
+                table_columns=table_columns
+            )
+
+            assert result is run_job_future
+            m_run_job.assert_called_once_with(mock_import_id,
+                                              client=self.mock_client,
+                                              polling_interval=None)
+
+        m_run_cleaning.assert_called_once_with(
+            [mock_file_id], self.mock_client, False, True, 'comma', True
+        )
+        m_process_cleaning_results.assert_called_once_with(
+            [mock.sentinel.cleaning_future],
+            self.mock_client,
+            True,
+            False,
+            'comma'
+        )
+
+        expected_name = 'CSV import to scratch.api_client_test_fixture'
+        expected_kwargs = {
+            'name': expected_name,
+            'max_errors': None,
+            'existing_table_rows': 'truncate',
+            'hidden': True,
+            'column_delimiter': 'comma',
+            'compression': 'gzip',
+            'escaped': False,
+            'execution': 'immediate',
+            'loosen_types': False,
+            'table_columns': table_columns,
+            'redshift_destination_options': {
+                'diststyle': None, 'distkey': None,
+                'sortkeys': [None, None]
+            }
+
+        }
+        self.mock_client.imports.post_files_csv.assert_called_once_with(
+            {'file_ids': [mock_cleaned_file_id]},
+            {
+                'schema': 'scratch',
+                'table': 'api_client_test_fixture',
+                'remote_host_id': 42,
+                'credential_id': 713,
+                'primary_keys': None,
+                'last_modified_keys': None
+            },
+            True,
+            **expected_kwargs
+        )
+
+    @pytest.mark.civis_file_to_table
+    @mock.patch('civis.io._tables._process_cleaning_results')
+    @mock.patch('civis.io._tables._run_cleaning')
     def test_civis_file_to_table_table_does_not_exist_all_sql_types_missing(
             self,
             m_run_cleaning,

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -401,7 +401,7 @@ class ImportTests(CivisVCRTestCase):
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')
-    def test_civis_file_to_table_table_doesnt_exist_valid_table_columns_provided(
+    def test_civis_file_to_table_table_doesnt_exist_all_sql_types_provided(
             self,
             m_run_cleaning,
             m_process_cleaning_results,
@@ -613,7 +613,6 @@ class ImportTests(CivisVCRTestCase):
         table = "scratch.api_client_test_fixture"
         database = 'redshift-general'
         mock_file_id = 1234
-        mock_cleaned_file_id = 1235
         mock_import_id = 8675309
 
         self.mock_client.imports.post_files_csv.return_value\

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -377,7 +377,7 @@ class ImportTests(CivisVCRTestCase):
             'escaped': False,
             'execution': 'immediate',
             'loosen_types': False,
-            #'table_columns': mock_columns,
+            'table_columns': mock_columns,
             'redshift_destination_options': {
                 'diststyle': None, 'distkey': None,
                 'sortkeys': [None, None]

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -320,8 +320,7 @@ class ImportTests(CivisVCRTestCase):
         self.mock_client.default_credential = 713
 
         self.mock_client.get_table_id.side_effect = ValueError('no table')
-        mock_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
-                        {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
+        mock_columns = [{'name': 'foo', 'sql_type': 'INTEGER'}]
         m_process_cleaning_results.return_value = (
             [mock_cleaned_file_id],
             True,  # headers
@@ -378,7 +377,7 @@ class ImportTests(CivisVCRTestCase):
             'escaped': False,
             'execution': 'immediate',
             'loosen_types': False,
-            'table_columns': mock_columns,
+            #'table_columns': mock_columns,
             'redshift_destination_options': {
                 'diststyle': None, 'distkey': None,
                 'sortkeys': [None, None]

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -401,108 +401,7 @@ class ImportTests(CivisVCRTestCase):
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')
-    def test_civis_file_to_table_table_doesnt_exist_all_sql_types_provided(
-            self,
-            m_run_cleaning,
-            m_process_cleaning_results,
-            _m_get_api_spec
-    ):
-        table = "scratch.api_client_test_fixture"
-        database = 'redshift-general'
-        mock_file_id = 1234
-        mock_cleaned_file_id = 1235
-        mock_import_id = 8675309
-
-        self.mock_client.imports.post_files_csv.return_value\
-            .id = mock_import_id
-        self.mock_client.get_database_id.return_value = 42
-        self.mock_client.default_credential = 713
-
-        self.mock_client.get_table_id.side_effect = ValueError('no table')
-        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
-                         {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
-        m_process_cleaning_results.return_value = (
-            [mock_cleaned_file_id],
-            True,  # headers
-            'gzip',  # compression
-            'comma',  # delimiter
-            table_columns  # table_columns
-        )
-        m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
-
-        with mock.patch.object(
-                civis.io._tables, 'run_job',
-                spec_set=True) as m_run_job:
-
-            run_job_future = mock.MagicMock(
-                spec=civis.futures.CivisFuture,
-                job_id=123,
-                run_id=234
-            )
-
-            m_run_job.return_value = run_job_future
-
-            result = civis.io.civis_file_to_table(
-                mock_file_id, database, table,
-                existing_table_rows='truncate',
-                delimiter=',',
-                headers=True,
-                client=self.mock_client,
-                table_columns=table_columns
-            )
-
-            assert result is run_job_future
-            m_run_job.assert_called_once_with(mock_import_id,
-                                              client=self.mock_client,
-                                              polling_interval=None)
-
-        m_run_cleaning.assert_called_once_with(
-            [mock_file_id], self.mock_client, False, True, 'comma', True
-        )
-        m_process_cleaning_results.assert_called_once_with(
-            [mock.sentinel.cleaning_future],
-            self.mock_client,
-            True,
-            False,
-            'comma'
-        )
-
-        expected_name = 'CSV import to scratch.api_client_test_fixture'
-        expected_kwargs = {
-            'name': expected_name,
-            'max_errors': None,
-            'existing_table_rows': 'truncate',
-            'hidden': True,
-            'column_delimiter': 'comma',
-            'compression': 'gzip',
-            'escaped': False,
-            'execution': 'immediate',
-            'loosen_types': False,
-            'table_columns': table_columns,
-            'redshift_destination_options': {
-                'diststyle': None, 'distkey': None,
-                'sortkeys': [None, None]
-            }
-
-        }
-        self.mock_client.imports.post_files_csv.assert_called_once_with(
-            {'file_ids': [mock_cleaned_file_id]},
-            {
-                'schema': 'scratch',
-                'table': 'api_client_test_fixture',
-                'remote_host_id': 42,
-                'credential_id': 713,
-                'primary_keys': None,
-                'last_modified_keys': None
-            },
-            True,
-            **expected_kwargs
-        )
-
-    @pytest.mark.civis_file_to_table
-    @mock.patch('civis.io._tables._process_cleaning_results')
-    @mock.patch('civis.io._tables._run_cleaning')
-    def test_civis_file_to_table_table_does_not_exist_all_sql_types_missing(
+    def test_civis_file_to_table_table_doesnt_exist_all_sql_types_missing(
             self,
             m_run_cleaning,
             m_process_cleaning_results,
@@ -654,7 +553,8 @@ class ImportTests(CivisVCRTestCase):
         self.mock_client.default_credential = 713
 
         self.mock_client.get_table_id.side_effect = ValueError('no table')
-        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'}]
+        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
+                         {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
         m_process_cleaning_results.return_value = (
             [mock_cleaned_file_id],
             True,  # headers

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -43,11 +43,11 @@ NOTE: These commands could miss some log entries from a currently-running
 job. It does not re-fetch logs that might have been saved out of order, to
 preserve the chronological order of the logs and without duplication.
 
-- ``civis jobs follow-logs $JOB_ID``
+- ``civis jobs follow-log $JOB_ID``
 
   Output live log from the most recent job run for the given job ID.
 
-- ``civis jobs follow-run-logs $JOB_ID $RUN_ID``
+- ``civis jobs follow-run-log $JOB_ID $RUN_ID``
 
   Output live log from the given job and run ID.
 


### PR DESCRIPTION
[APIC-305](https://civisanalytics.atlassian.net/browse/APIC-305)

Ensure data types are detected when the destination table does not exist or it is being dropped and table_columns are provided but do not contain a sql_type for every column.