### PR TITLE
[APIC-313] retain specific sql types in civis_file_to_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Bump minimum pubnub version to `4.1.12` (#397)
+- Retain specific sql types when there are multiple input files and `table_columns` specified in `civis.io.civis_file_to_table` ()
 
 ## 1.14.2 - 2020-06-03
 ### Added

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1063,11 +1063,12 @@ def civis_file_to_table(file_id, database, table, client=None,
     redshift_options = dict(distkey=distkey, sortkeys=[sortkey1, sortkey2],
                             diststyle=diststyle)
 
-    # If multiple files are being imported, there might be differences in
+    # If multiple files are being imported and the user hasn't explicitly
+    # provided table column info, then there might be differences in
     # their precisions/lengths - setting this option will allow the Civis API
     # to increase these values for the data types provided, and decreases the
-    # risk of a length-related import failure
-    loosen_types = len(file_id) > 1
+    # risk of a length-related import failure when types are inferred.
+    loosen_types = need_table_columns and len(file_id) > 1
 
     import_name = 'CSV import to {}.{}'.format(schema, table)
     import_job = client.imports.post_files_csv(

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -536,102 +536,120 @@ class ImportTests(CivisVCRTestCase):
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')
     def test_civis_file_to_table_table_doesnt_exist_provide_table_columns(
-            self,
-            m_run_cleaning,
-            m_process_cleaning_results,
-            _m_get_api_spec
+        self,
+        m_run_cleaning,
+        m_process_cleaning_results,
+        _m_get_api_spec
     ):
-        table = "scratch.api_client_test_fixture"
-        database = 'redshift-general'
-        mock_file_id = 1234
-        mock_cleaned_file_id = 1235
-        mock_import_id = 8675309
 
-        self.mock_client.imports.post_files_csv.return_value\
-            .id = mock_import_id
-        self.mock_client.get_database_id.return_value = 42
-        self.mock_client.default_credential = 713
+        # pytest.parametrize apparently doesn't work with unittest.TestCase
+        # objects, which this ultimately inherits from, so we'll define a
+        # function here and run subtests below.
+        # See https://docs.pytest.org/en/stable/unittest.html.
+        def run_subtest(mock_file_ids):
+            table = "scratch.api_client_test_fixture"
+            database = 'redshift-general'
+            mock_cleaned_file_ids = mock.Mock()
+            mock_import_id = 8675309
 
-        self.mock_client.get_table_id.side_effect = ValueError('no table')
-        table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
-                         {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
-        m_process_cleaning_results.return_value = (
-            [mock_cleaned_file_id],
-            True,  # headers
-            'gzip',  # compression
-            'comma',  # delimiter
-            None  # table_columns
-        )
-        m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
+            self.mock_client.imports.post_files_csv.return_value.id = \
+                mock_import_id
+            self.mock_client.get_database_id.return_value = 42
+            self.mock_client.default_credential = 713
 
-        with mock.patch.object(
-                civis.io._tables, 'run_job',
-                spec_set=True) as m_run_job:
+            self.mock_client.get_table_id.side_effect = ValueError('no table')
+            table_columns = [{'name': 'foo', 'sql_type': 'INTEGER'},
+                             {'name': 'bar', 'sql_type': 'VARCHAR(42)'}]
+            m_process_cleaning_results.return_value = (
+                mock_cleaned_file_ids,
+                True,  # headers
+                'gzip',  # compression
+                'comma',  # delimiter
+                None  # table_columns
+            )
+            m_run_cleaning.return_value = [mock.sentinel.cleaning_future]
 
-            run_job_future = mock.MagicMock(
-                spec=civis.futures.CivisFuture,
-                job_id=123,
-                run_id=234
+            with mock.patch.object(
+                    civis.io._tables, 'run_job',
+                    spec_set=True) as m_run_job:
+
+                run_job_future = mock.MagicMock(
+                    spec=civis.futures.CivisFuture,
+                    job_id=123,
+                    run_id=234
+                )
+
+                m_run_job.return_value = run_job_future
+
+                result = civis.io.civis_file_to_table(
+                    mock_file_ids, database, table,
+                    existing_table_rows='truncate',
+                    table_columns=table_columns,
+                    delimiter=',',
+                    headers=True,
+                    client=self.mock_client
+                )
+
+                assert result is run_job_future
+                m_run_job.assert_called_once_with(mock_import_id,
+                                                  client=self.mock_client,
+                                                  polling_interval=None)
+
+            m_run_cleaning.assert_called_once_with(
+                [mock_file_ids] if isinstance(mock_file_ids, int)
+                else mock_file_ids,
+                self.mock_client, False, True, 'comma', True
+            )
+            m_process_cleaning_results.assert_called_once_with(
+                [mock.sentinel.cleaning_future],
+                self.mock_client,
+                True,
+                False,
+                'comma'
             )
 
-            m_run_job.return_value = run_job_future
+            expected_name = 'CSV import to scratch.api_client_test_fixture'
+            expected_kwargs = {
+                'name': expected_name,
+                'max_errors': None,
+                'existing_table_rows': 'truncate',
+                'hidden': True,
+                'column_delimiter': 'comma',
+                'compression': 'gzip',
+                'escaped': False,
+                'execution': 'immediate',
+                'loosen_types': False,
+                'table_columns': table_columns,
+                'redshift_destination_options': {
+                    'diststyle': None, 'distkey': None,
+                    'sortkeys': [None, None]
+                }
 
-            result = civis.io.civis_file_to_table(
-                mock_file_id, database, table,
-                existing_table_rows='truncate',
-                table_columns=table_columns,
-                delimiter=',',
-                headers=True,
-                client=self.mock_client
-            )
-
-            assert result is run_job_future
-            m_run_job.assert_called_once_with(mock_import_id,
-                                              client=self.mock_client,
-                                              polling_interval=None)
-
-        m_run_cleaning.assert_called_once_with(
-            [mock_file_id], self.mock_client, False, True, 'comma', True
-        )
-        m_process_cleaning_results.assert_called_once_with(
-            [mock.sentinel.cleaning_future],
-            self.mock_client,
-            True,
-            False,
-            'comma'
-        )
-
-        expected_name = 'CSV import to scratch.api_client_test_fixture'
-        expected_kwargs = {
-            'name': expected_name,
-            'max_errors': None,
-            'existing_table_rows': 'truncate',
-            'hidden': True,
-            'column_delimiter': 'comma',
-            'compression': 'gzip',
-            'escaped': False,
-            'execution': 'immediate',
-            'loosen_types': False,
-            'table_columns': table_columns,
-            'redshift_destination_options': {
-                'diststyle': None, 'distkey': None,
-                'sortkeys': [None, None]
             }
+            self.mock_client.imports.post_files_csv.assert_called_once_with(
+                {'file_ids': mock_cleaned_file_ids},
+                {
+                    'schema': 'scratch',
+                    'table': 'api_client_test_fixture',
+                    'remote_host_id': 42,
+                    'credential_id': 713,
+                    'primary_keys': None,
+                    'last_modified_keys': None
+                },
+                True,
+                **expected_kwargs
+            )
 
-        }
-        self.mock_client.imports.post_files_csv.assert_called_once_with(
-            {'file_ids': [mock_cleaned_file_id]},
-            {
-                'schema': 'scratch',
-                'table': 'api_client_test_fixture',
-                'remote_host_id': 42,
-                'credential_id': 713,
-                'primary_keys': None,
-                'last_modified_keys': None
-            },
-            True,
-            **expected_kwargs
-        )
+        # Check that things work with a single file ID or multiple IDs.
+        # In particular, we want to ensure that loosen_types is set to False
+        # in both situations.
+        for mock_file_ids in (1234, [1234], [1234, 1235]):
+            with self.subTest(mock_file_ids):
+                self.mock_client.reset_mock()
+                m_run_cleaning.reset_mock()
+                m_process_cleaning_results.reset_mock()
+                run_subtest(mock_file_ids)
+
 
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -650,7 +650,6 @@ class ImportTests(CivisVCRTestCase):
                 m_process_cleaning_results.reset_mock()
                 run_subtest(mock_file_ids)
 
-
     @pytest.mark.civis_file_to_table
     @mock.patch('civis.io._tables._process_cleaning_results')
     @mock.patch('civis.io._tables._run_cleaning')


### PR DESCRIPTION
In the `civis.io.civis_file_to_table` function, the Python API client appears to tell platform to change SQL types like `VARCHAR(1)` in the `table_columns` argument to more generic values like `VARCHAR(1024)` when there are multiple files.  The behavior seems reasonable when data types are automatically inferred (i.e., when `need_table_columns` is true), as noted in the code comment, but if the user has specified a dtype with specific length like `VARCHAR(1)`, the import should just use that.