### PR TITLE
[APIC-305] Require sql_type for every column when table_columns is provided (CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Bump minimum pubnub version to `4.1.12` (#397)
+- In `civis.io.civis_file_to_table`, ensure that data types are detected when table_columns are provided with no sql_types. Additionally, throw an error if some sql_types are provided and not others.
 - Retain specific sql types when there are multiple input files and `table_columns` specified in `civis.io.civis_file_to_table` ()
 
 ## 1.14.2 - 2020-06-03

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -662,10 +662,13 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     headers : bool, optional [DEPRECATED]
         Whether or not the first row of the file should be treated as
         headers. The default, ``None``, attempts to autodetect whether
@@ -805,10 +808,13 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     delimiter : string, optional
         The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
     headers : bool, optional
@@ -934,10 +940,13 @@ def civis_file_to_table(file_id, database, table, client=None,
     sortkey2 : str, optional
         The second column in a compound sortkey for the table.
     table_columns : list[Dict[str, str]], optional
-        A list of dictionaries corresponding to the columns in
-        the source file. Each dictionary should have keys
-        for column "name" and "sqlType". The import will only copy these
-        columns regardless if there are more columns in the table.
+        An array of hashes corresponding to the columns in the order
+        they appear in the source file. Each hash should have keys for
+        database column "name" and "sqlType". This parameter is
+        required if the table does not exist, the table is being dropped,
+        or the columns in the source file do not appear in the same order
+        as in the destination table. The “sqlType” key is not required
+        when appending to an existing table.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
         uniquely identify a record. These columns must not contain null values.


### PR DESCRIPTION
Update changelog to reflect change in https://github.com/civisanalytics/civis-python/pull/400.