### PR TITLE
[APIC-284] remove python 3.5 support since it is reaching EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
@@ -15,4 +14,4 @@ env:
 before_script: flake8 civis
 script:
     - py.test -rxs --cov civis
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.5* ]] ; then sphinx-build -b html -n docs/source/ docs/build/ ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.8* ]] ; then sphinx-build -b html -n docs/source/ docs/build/ ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bump minimum pubnub version to `4.1.12` (#397)
 - In `civis.io.civis_file_to_table`, ensure that data types are detected when table_columns are provided with no sql_types. Additionally, throw an error if some sql_types are provided and not others.
 - Retain specific sql types when there are multiple input files and `table_columns` specified in `civis.io.civis_file_to_table` ()
+- Removed Python 3.5 support (#404)
 
 ## 1.14.2 - 2020-06-03
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ dependencies with
 Python version support
 ----------------------
 
-Python 3.5, 3.6, 3.7, and 3.8
+Python 3.6, 3.7, and 3.8
 
 .. end-include-marker-python-version-support-section
 

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -92,7 +92,7 @@ class PollableResult(CivisAsyncResultBase):
     # Implementation notes: The `PollableResult` depends on some private
     # features of the `concurrent.futures.Future` class, so it's possible
     # that future versions of Python could break something here.
-    # (It works under at least 3.4, 3.5, and 3.6)
+    # (It works under at least 3.6)
     # We use the following `Future` implementation details
     # - The `Future` checks its state against predefined strings. We use
     #   `STATE_TRANS` to translate from the Civis platform states to `Future`

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ def main():
                 'civis = civis.cli.__main__:main',
                 'civis_joblib_worker = civis.run_joblib_func:main',
             ]
-        }
+        },
+        python_requires=">=3.6"
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools import find_packages, setup
 CLASSIFIERS = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
'Python 3.5 will reach its "end of life" at the end of September 2020.' (https://www.python.org/downloads/release/python-3510/)