### PR TITLE
[APIC-76] include services and other missing resources in sphinx docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - In `civis.io.civis_file_to_table`, ensure that data types are detected when table_columns are provided with no sql_types. Additionally, throw an error if some sql_types are provided and not others.
 - Retain specific sql types when there are multiple input files and `table_columns` specified in `civis.io.civis_file_to_table` ()
 - Removed Python 3.5 support (#404)
+- Updated list of base API resources to include `aliases`, `git_repos`, `json_values`, `services`, and `storage_hosts` so that they show up in the sphinx docs (#406)
 
 ## 1.14.2 - 2020-06-03
 ### Added

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -20,6 +20,7 @@ from civis._utils import (camel_to_snake, to_camelcase,
 
 API_VERSIONS = ["1.0"]
 BASE_RESOURCES_V1 = [
+    'aliases',
     'announcements',
     'apps',
     'civis',
@@ -31,9 +32,11 @@ BASE_RESOURCES_V1 = [
     'enhancements',
     'exports',
     'files',
+    'git_repos',
     'groups',
     'imports',
     'jobs',
+    'json_values',
     'match_targets',
     'media',
     'models',
@@ -48,6 +51,8 @@ BASE_RESOURCES_V1 = [
     'results',
     'scripts',
     'search',
+    'services',
+    'storage_hosts',
     'tables',
     'templates',
     'users',


### PR DESCRIPTION
This adds some missing API resources to the list of resources that the sphinx doc generation code uses to create https://civis-python.readthedocs.io/en/stable/api_resources.html.  Using the list to filter the resources is a way to avoid including, e.g., "admin" endpoints that users aren't going to be interested in. Maybe we should eventually just include all the resources in the doc, but I didn't want to make that larger change at the moment.