### PR TITLE
[APIC-306] Fixed a bug in parsing responses that included "update" as a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated list of base API resources to include `aliases`, `git_repos`, `json_values`, `services`, and `storage_hosts` so that they show up in the sphinx docs (#406)
 - Update the API spec at `civis/tests/civis_api_spec.json` so that new endpoints are included (e.g., `/exports/files/csv`) (#407)
 
+### Fixed
+
+- Fixed a bug in parsing responses that included "update" as a key (e.g., in column information from `client.tables.get(...)`). (#)
+
 ## 1.14.2 - 2020-06-03
 ### Added
 - Added support for Python 3.8 (#391)

--- a/civis/response.py
+++ b/civis/response.py
@@ -118,6 +118,9 @@ class Response(dict):
             self.calls_remaining = headers.get('X-RateLimit-Remaining')
             self.rate_limit = headers.get('X-RateLimit-Limit')
 
+        # Keys to update for this response object.
+        self_updates = {}
+
         if json_data is not None:
             for key, v in json_data.items():
                 if snake_case:
@@ -131,8 +134,11 @@ class Response(dict):
                 else:
                     val = v
 
-                self.update({key: val})
-                self.__dict__.update({key: val})
+                self_updates[key] = val
+
+        self.update(self_updates)
+        # Update self.__dict__ at the end to avoid replacing the update method.
+        self.__dict__.update(self_updates)
 
 
 class PaginatedResponse:

--- a/civis/tests/test_response.py
+++ b/civis/tests/test_response.py
@@ -174,3 +174,15 @@ def test_convert_data_type_civis_list():
     assert isinstance(data[0], Response)
     assert data[0]['foo'] == 'bar'
     assert data[0].headers == {'header': 'val'}
+
+
+def test_parse_column_names():
+    """Check that responses that include 'update' as a key are parsed right."""
+    resp_dict = {
+        'columns': [
+            {'valueDistributionPercent': {'update': 50.0, 'foo': 50.0},
+             'valueDistribution': {'update': 1, 'foo': 1}}
+        ]
+    }
+    resp = Response(resp_dict)
+    assert resp.columns[0].value_distribution_percent['update'] == 50.0


### PR DESCRIPTION
This fixes a bug where a column named "update" would cause response parsing to fail for `/tables` endpoints.

The `civis.response.Response` provides convenient access to response attributes (e.g., `response.attrib` as opposed to `response['attrib']`). In retrospect, perhaps it'd have been better not to have that functionality recur all the way down the response structure (or at least not into user-provided table info), but that ship has sailed, and in order to minimize breaking changes, this PR should preserve the existing functionality and avoid the bug.