### PR TITLE
ContainerFuture propagates error from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-- `ContainerFuture` returns error logs as an error message when a job
-  fails but no message is returned (#416)
+- `ContainerFuture` propagates error messages from logs (#416)
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
 
 ## 1.15.1 - 2020-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- `ContainerFuture` returns error logs as an error message when a job
+  fails but no message is returned (#413)
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
 
 ## 1.15.1 - 2020-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - `ContainerFuture` returns error logs as an error message when a job
-  fails but no message is returned (#413)
+  fails but no message is returned (#416)
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
 
 ## 1.15.1 - 2020-10-28

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -299,8 +299,6 @@ class ContainerFuture(CivisFuture):
             fut._exception_handled = True
 
         if fut.failed():
-            import ipdb
-            ipdb.set_trace()
             # Container scripts do not return the error message,
             # so we override with an exception we can pull from the
             # logs
@@ -318,8 +316,6 @@ class ContainerFuture(CivisFuture):
         - MemoryError
         """
 
-        import ipdb
-        ipdb.set_trace()
         logs = self.client.scripts.list_containers_runs_logs(self.job_id,
                                                              self.run_id,
                                                              limit=nlog)

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -11,7 +11,7 @@ import threading
 import warnings
 
 from civis import APIClient
-from civis.base import CivisAPIError, DONE
+from civis.base import CivisAPIError, CivisJobFailure, DONE
 from civis.polling import PollableResult
 
 from pubnub.pubnub import PubNub
@@ -286,6 +286,57 @@ class ContainerFuture(CivisFuture):
                          client=client,
                          poll_on_creation=poll_on_creation)
         self._max_n_retries = max_n_retries
+        self._exception_handled = False
+        self.add_done_callback(self._set_job_exception)
+
+    @staticmethod
+    def _set_job_exception(fut):
+        # Prevent infinite recursion: this function calls `set_exception`,
+        # which triggers callbacks (i.e. re-calls this function).
+        if fut._exception_handled:
+            return
+        else:
+            fut._exception_handled = True
+
+        if fut.failed():
+            import ipdb
+            ipdb.set_trace()
+            # Container scripts do not return the error message,
+            # so we override with an exception we can pull from the
+            # logs
+            if isinstance(fut._exception, CivisJobFailure) and \
+               fut._exception.error_message == 'None':
+                exc = fut._exception_from_logs(fut._exception)
+                fut.set_exception(exc)
+
+    def _exception_from_logs(self, exc, nlog=15):
+        """Create an exception if the log has a recognizable error
+
+        Search "error" emits in the last ``n_log`` lines.
+        This function presently recognizes the following errors:
+
+        - MemoryError
+        """
+
+        import ipdb
+        ipdb.set_trace()
+        logs = self.client.scripts.list_containers_runs_logs(self.job_id,
+                                                             self.run_id,
+                                                             limit=nlog)
+
+        # Check for memory errors
+        msgs = [x['message'] for x in logs if x['level'] == 'error']
+        mem_err = [m for m in msgs if m.startswith('Process ran out of its')]
+        if mem_err:
+            exc = MemoryError(mem_err[0])
+        else:
+            # Unknown error; return logs to the user as a sort of traceback
+            all_logs = '\n'.join([x['message'] for x in logs])
+            if isinstance(exc, CivisJobFailure):
+                exc.error_message = all_logs + '\n' + exc.error_message
+            else:
+                exc = CivisJobFailure(all_logs)
+        return exc
 
     def _set_api_exception(self, exc, result=None):
         # Catch attempts to set an exception. If there's retries

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -291,6 +291,10 @@ class ContainerFuture(CivisFuture):
 
     @staticmethod
     def _set_job_exception(fut):
+        """Callback: On job completion, check the status.
+        If the job has failed, and has no pre-existing error message,
+        populate the error message with recent logs.
+        """
         # Prevent infinite recursion: this function calls `set_exception`,
         # which triggers callbacks (i.e. re-calls this function).
         if fut._exception_handled:
@@ -304,6 +308,7 @@ class ContainerFuture(CivisFuture):
             # logs
             if isinstance(fut._exception, CivisJobFailure) and \
                fut._exception.error_message == 'None':
+                fut._exception.error_message = ''
                 exc = fut._exception_from_logs(fut._exception)
                 fut.set_exception(exc)
 
@@ -315,7 +320,6 @@ class ContainerFuture(CivisFuture):
 
         - MemoryError
         """
-
         logs = self.client.scripts.list_containers_runs_logs(self.job_id,
                                                              self.run_id,
                                                              limit=nlog)

--- a/civis/ml/_model.py
+++ b/civis/ml/_model.py
@@ -451,27 +451,25 @@ class ModelFuture(ContainerFuture):
 
     def __init__(self, job_id, run_id, train_job_id=None, train_run_id=None,
                  polling_interval=None, client=None, poll_on_creation=True):
-        super().__init__(job_id, run_id,
-                         polling_interval=polling_interval,
-                         client=client,
-                         poll_on_creation=poll_on_creation)
         if train_job_id and train_run_id:
             self.is_training = False
             self.train_job_id = train_job_id
             self.train_run_id = train_run_id
         else:
             self.is_training = True
-            self.train_job_id = self.job_id
-            self.train_run_id = self.run_id
+            self.train_job_id = job_id
+            self.train_run_id = run_id
         self._metadata, self._val_metadata = None, None
         self._train_data, self._train_data_fname = None, None
         self._train_metadata = None
         self._table, self._estimator = None, None
-        self._exception_handled = False
-        self.add_done_callback(self._set_model_exception)
+        super().__init__(job_id, run_id,
+                         polling_interval=polling_interval,
+                         client=client,
+                         poll_on_creation=poll_on_creation)
 
     @staticmethod
-    def _set_model_exception(fut):
+    def _set_job_exception(fut):
         """Callback: On job completion, check the metadata.
         If it indicates an exception, replace the generic
         ``CivisJobFailure`` by a more informative ``ModelError``.
@@ -533,7 +531,7 @@ class ModelFuture(ContainerFuture):
         self.client = APIClient()
         self.poller = self.client.scripts.get_containers_runs
         self._begin_tracking()
-        self.add_done_callback(self._set_model_exception)
+        self.add_done_callback(self._set_job_exception)
 
     @property
     def state(self):

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -379,9 +379,6 @@ def test_set_job_exception_unknown_error():
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
-    print(str(err))
-    print(str(err.value))
-    print(err_msg)
     assert str(err.value).startswith(err_msg)
 
 

--- a/civis/tests/__init__.py
+++ b/civis/tests/__init__.py
@@ -1,1 +1,1 @@
-from civis.tests.mocks import create_client_mock, TEST_SPEC  # NOQA
+from civis.tests.mocks import create_client_mock, create_client_container_mock, TEST_SPEC  # NOQA

--- a/civis/tests/__init__.py
+++ b/civis/tests/__init__.py
@@ -1,1 +1,1 @@
-from civis.tests.mocks import create_client_mock, create_client_container_mock, TEST_SPEC  # NOQA
+from civis.tests.mocks import create_client_mock, create_client_mock_for_container_tests, TEST_SPEC  # NOQA

--- a/civis/tests/mocks.py
+++ b/civis/tests/mocks.py
@@ -38,9 +38,14 @@ def create_client_mock(cache=TEST_SPEC):
     return mock_client
 
 
-def create_client_container_mock(script_id=-10, run_id=100, state='succeeded',
-                                 run_outputs=None, log_outputs=None):
-    """Return a Mock set up for use in testing container scripts
+def create_client_mock_for_container_tests(
+        script_id=-10, run_id=100, state='succeeded',
+        run_outputs=None, log_outputs=None):
+    """Returns a CivisAPIClient Mock set up for testing methods that use
+    container scripts. Contains endpoint method mocks and return values
+    for posting container jobs, retrieving outputs, and reading logs.
+    Also contains the mocks to cancel the container when the state
+    is set to 'failed'.
 
     Parameters
     ----------
@@ -60,8 +65,7 @@ def create_client_container_mock(script_id=-10, run_id=100, state='succeeded',
         With scripts endpoints `post_containers`, `post_containers_runs`,
         `post_cancel`, and `get_containers_runs` set up.
     """
-    c = mock.Mock()
-    c.__class__ = APIClient
+    c = create_client_mock()
 
     mock_container = Response({'id': script_id})
     c.scripts.post_containers.return_value = mock_container

--- a/civis/tests/mocks.py
+++ b/civis/tests/mocks.py
@@ -5,6 +5,7 @@ import os
 from unittest import mock
 
 from civis import APIClient
+from civis.response import Response
 
 
 TEST_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -35,6 +36,58 @@ def create_client_mock(cache=TEST_SPEC):
         mock_client = mock.create_autospec(real_client, spec_set=True)
 
     return mock_client
+
+
+def create_client_container_mock(script_id=-10, run_id=100, state='succeeded',
+                                 run_outputs=None, log_outputs=None):
+    """Return a Mock set up for use in testing container scripts
+
+    Parameters
+    ----------
+    script_id: int
+        Mock-create containers with this ID when calling `post_containers`
+        or `post_containers_runs`.
+    run_id: int
+        Mock-create runs with this ID when calling `post_containers_runs`.
+    state: str, optional
+        The reported state of the container run
+    run_outputs: list, optional
+        List of Response objects returned as run outputs
+
+    Returns
+    -------
+    `unittest.mock.Mock`
+        With scripts endpoints `post_containers`, `post_containers_runs`,
+        `post_cancel`, and `get_containers_runs` set up.
+    """
+    c = mock.Mock()
+    c.__class__ = APIClient
+
+    mock_container = Response({'id': script_id})
+    c.scripts.post_containers.return_value = mock_container
+    mock_container_run_start = Response({'id': run_id,
+                                         'container_id': script_id,
+                                         'state': 'queued'})
+    mock_container_run = Response({'id': run_id,
+                                   'container_id': script_id,
+                                   'state': state})
+    if state == 'failed':
+        mock_container_run['error'] = 'None'
+    c.scripts.post_containers_runs.return_value = mock_container_run_start
+    c.scripts.get_containers_runs.return_value = mock_container_run
+    c.scripts.list_containers_runs_outputs.return_value = (run_outputs or [])
+    c.scripts.list_containers_runs_logs.return_value = (log_outputs or [])
+
+    def change_state_to_cancelled(script_id):
+        mock_container_run.state = "cancelled"
+        return mock_container_run
+
+    c.scripts.post_cancel.side_effect = change_state_to_cancelled
+
+    # Avoid channels endpoint while testing here
+    del c.channels
+
+    return c
 
 
 @lru_cache(maxsize=1)

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -18,7 +18,7 @@ from civis.futures import (CivisFuture,
                            JobCompleteListener,
                            _LONG_POLLING_INTERVAL)
 from civis.tests import TEST_SPEC, create_client_mock, \
-    create_client_container_mock
+    create_client_mock_for_container_tests
 from pubnub.enums import PNStatusCategory
 
 from civis.tests.testcase import CivisVCRTestCase
@@ -316,7 +316,7 @@ def test_container_future_job_id_run_id():
     result = ContainerFuture(
         job_id=job_id,
         run_id=run_id,
-        client=create_client_container_mock(),
+        client=create_client_mock_for_container_tests(),
     )
     assert result.job_id == job_id
     assert result.run_id == run_id
@@ -540,18 +540,51 @@ def test_future_retry_error():
 def test_container_exception_no_result_logs():
     # If the job errored with no output but with logs,
     # we should return error logs with the future exception.
-    msg = 'Failed: The job container failed. Exit code 1'
+    mem_msg = ('Run used approximately 2 millicores '
+               'of its 256 millicore CPU limit')
+    failed_msg = 'Failed: The job container failed. Exit code 1'
     logs = [{'id': 111, 'created_at': 'abc',
-             'message': 'Run used approximately 2 millicores '
-             'of its 256 millicore CPU limit',
+             'message': mem_msg,
              'level': 'info'},
             {'id': 222,
              'created_at': 'def',
-             'message': msg,
+             'message': failed_msg,
              'level': 'error'}]
-    mock_client = create_client_container_mock(1, 2, state='failed',
-                                               run_outputs=[],
-                                               log_outputs=logs)
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed',
+        run_outputs=[],
+        log_outputs=logs)
     fut = ContainerFuture(1, 2, client=mock_client)
 
-    assert msg in str(fut._exception.error_message)
+    with pytest.raises(CivisJobFailure) as err:
+        fut.result()
+    expected_msg = ('\n'.join([mem_msg, failed_msg, '']))
+    assert expected_msg == str(fut._exception.error_message)
+    assert str(err.value) == expected_msg
+
+
+def test_container_exception_memory_error():
+    err_msg = ('Process ran out of its allowed 3000 MiB of '
+               'memory and was killed.')
+    logs = [{'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10005,
+             'level': 'error',
+             'message': 'Failed'},
+            {'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10003,
+             'level': 'error',
+             'message': 'Error on job: Process ended with an '
+                        'error, exiting: 137.'},
+            {'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10000,
+             'level': 'error',
+             'message': err_msg}]
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed',
+        run_outputs=[],
+        log_outputs=logs)
+    fut = ContainerFuture(1, 2, client=mock_client)
+
+    with pytest.raises(MemoryError) as err:
+        fut.result()
+    assert str(err.value) == err_msg

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -316,7 +316,7 @@ def test_container_future_job_id_run_id():
     result = ContainerFuture(
         job_id=job_id,
         run_id=run_id,
-        client=create_client_mock(),
+        client=create_client_container_mock(),
     )
     assert result.job_id == job_id
     assert result.run_id == run_id

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -13,7 +13,8 @@ import requests
 
 import civis.parallel
 from civis.futures import ContainerFuture
-from civis.tests import create_client_mock, create_client_container_mock
+from civis.tests import (
+    create_client_mock, create_client_mock_for_container_tests)
 
 
 _MOCK_JOB_KWARGS = dict(
@@ -376,8 +377,9 @@ def test_result_success(mock_civis):
     # Test that we can get a result back from a succeeded job.
     callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    mock_client = create_client_container_mock(1, 2, state='success',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='success',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
@@ -390,8 +392,9 @@ def test_result_callback_no_get(mock_civis):
     # Test that the completed callback happens even if we don't call `get`
     callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    mock_client = create_client_container_mock(1, 2, state='success',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='success',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
     civis.parallel._CivisBackendResult(fut, callback)
     assert callback.call_count == 1
@@ -403,8 +406,9 @@ def test_result_exception(mock_civis):
     callback = mock.MagicMock()
     exc = ZeroDivisionError()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock(exc)
-    mock_client = create_client_container_mock(1, 2, state='failed',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
@@ -418,8 +422,9 @@ def test_result_exception_no_result():
     # a generic TransportableException back.
     callback = mock.MagicMock()
 
-    mock_client = create_client_container_mock(1, 2, state='failed',
-                                               run_outputs=[])
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed',
+        run_outputs=[])
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
     fut._set_api_exception(CivisJobFailure(
@@ -440,8 +445,9 @@ def test_result_callback_exception(mock_civis):
     mock_civis.io.civis_to_file.side_effect = exc
     # We're simulating a job which succeeded but generated an
     # exception when we try to download the outputs.
-    mock_client = create_client_container_mock(1, 2, state='succeeded',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='succeeded',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
 
     res = civis.parallel._CivisBackendResult(fut, callback)
@@ -459,8 +465,9 @@ def test_result_eventual_success(mock_civis):
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=2, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    mock_client = create_client_container_mock(1, 2, state='success',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='success',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
@@ -476,8 +483,9 @@ def test_result_eventual_failure(mock_civis):
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=10, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    mock_client = create_client_container_mock(1, 2, state='success',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='success',
+        run_outputs=mock.MagicMock())
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
@@ -492,8 +500,9 @@ def test_result_running_and_cancel_requested(mock_civis):
     # state. Make sure these are treated as cancelled runs.
     response = Response({'is_cancel_requested': True,
                          'state': 'running'})
-    mock_client = create_client_container_mock(1, 2, state='running',
-                                               run_outputs=mock.MagicMock())
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='running',
+        run_outputs=mock.MagicMock())
     mock_client.scripts.post_cancel.return_value = response
     fut = ContainerFuture(1, 2, client=mock_client)
     callback = mock.MagicMock()

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -7,13 +7,13 @@ import pytest
 from joblib import delayed, Parallel
 from joblib import parallel_backend, register_parallel_backend
 from joblib.my_exceptions import TransportableException
-from civis.base import CivisAPIError
+from civis.base import CivisAPIError, CivisJobFailure
 from civis.response import Response
 import requests
 
 import civis.parallel
 from civis.futures import ContainerFuture
-from civis.tests import create_client_mock
+from civis.tests import create_client_mock, create_client_container_mock
 
 
 _MOCK_JOB_KWARGS = dict(
@@ -376,8 +376,9 @@ def test_result_success(mock_civis):
     # Test that we can get a result back from a succeeded job.
     callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-    fut.set_result(Response({'state': 'success'}))
+    mock_client = create_client_container_mock(1, 2, state='success',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
     assert res.get() == 'spam'
@@ -389,9 +390,9 @@ def test_result_callback_no_get(mock_civis):
     # Test that the completed callback happens even if we don't call `get`
     callback = mock.MagicMock()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock('spam')
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-    fut.set_result(Response({'state': 'success'}))
-
+    mock_client = create_client_container_mock(1, 2, state='success',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
     civis.parallel._CivisBackendResult(fut, callback)
     assert callback.call_count == 1
 
@@ -402,8 +403,9 @@ def test_result_exception(mock_civis):
     callback = mock.MagicMock()
     exc = ZeroDivisionError()
     mock_civis.io.civis_to_file.side_effect = make_to_file_mock(exc)
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-    fut._set_api_exception(Response({'state': 'failed'}))
+    mock_client = create_client_container_mock(1, 2, state='failed',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(ZeroDivisionError):
@@ -416,17 +418,16 @@ def test_result_exception_no_result():
     # a generic TransportableException back.
     callback = mock.MagicMock()
 
-    # Passing the client mock as an argument instead of globally
-    # patching the client tests that the _CivisBackendResult
-    # uses the client object on the input CivisFuture.
-    mock_client = create_client_mock()
-    mock_client.scripts.list_containers_runs_outputs.return_value = []
+    mock_client = create_client_container_mock(1, 2, state='failed',
+                                               run_outputs=[])
     fut = ContainerFuture(1, 2, client=mock_client)
-    fut._set_api_exception(Response({'state': 'failed'}))
     res = civis.parallel._CivisBackendResult(fut, callback)
+    fut._set_api_exception(CivisJobFailure(
+                           Response({'state': 'failed'})))
 
     with pytest.raises(TransportableException) as exc:
         res.get()
+
     assert "{'state': 'failed'}" in str(exc.value)
     assert callback.call_count == 0
 
@@ -437,11 +438,12 @@ def test_result_callback_exception(mock_civis):
     callback = mock.MagicMock()
     exc = ZeroDivisionError()
     mock_civis.io.civis_to_file.side_effect = exc
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-
     # We're simulating a job which succeeded but generated an
     # exception when we try to download the outputs.
-    fut._set_api_exception(Response({'state': 'succeeded'}))
+    mock_client = create_client_container_mock(1, 2, state='succeeded',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
+
     res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(ZeroDivisionError):
@@ -457,8 +459,9 @@ def test_result_eventual_success(mock_civis):
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=2, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-    fut.set_result(Response({'state': 'success'}))
+    mock_client = create_client_container_mock(1, 2, state='success',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
     assert res.get() == 'spam'
@@ -473,8 +476,9 @@ def test_result_eventual_failure(mock_civis):
     exc = requests.ConnectionError()
     se = make_to_file_mock('spam', max_n_err=10, exc=exc)
     mock_civis.io.civis_to_file.side_effect = se
-    fut = ContainerFuture(1, 2, client=mock.MagicMock())
-    fut.set_result(Response({'state': 'success'}))
+    mock_client = create_client_container_mock(1, 2, state='success',
+                                               run_outputs=mock.MagicMock())
+    fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
 
     with pytest.raises(requests.ConnectionError):
@@ -488,10 +492,10 @@ def test_result_running_and_cancel_requested(mock_civis):
     # state. Make sure these are treated as cancelled runs.
     response = Response({'is_cancel_requested': True,
                          'state': 'running'})
-    client = mock.MagicMock()
-    client.scripts.post_cancel.return_value = response
-    fut = ContainerFuture(1, 2, client=client)
-    fut.set_result(response)
+    mock_client = create_client_container_mock(1, 2, state='running',
+                                               run_outputs=mock.MagicMock())
+    mock_client.scripts.post_cancel.return_value = response
+    fut = ContainerFuture(1, 2, client=mock_client)
     callback = mock.MagicMock()
     # When a _CivisBackendResult created by the Civis joblib backend completes
     # successfully, a callback is executed. When cancelled, this callback


### PR DESCRIPTION
The Civis API currently returns `'error': None` when a Python/R/container script fails, so API client users don't get any information about what caused the failure. CivisML works around this by returning error logs to the user in these cases. This PR moves this behavior from `ModelPipeline` to `ContainerFuture` so that users can get more informative errors when running jobs outside of CivisML as well.

This is something of a workaround, especially since R client users won't get the benefits. Longer-term, we'd like to get more informative errors directly from the API.