### PR TITLE
[HACK-465] Use default arguments from swagger when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
+- Added default values from swagger in client method's signature (#416)
 
 ## 1.15.1 - 2020-10-28
 ### Fixed

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -211,8 +211,9 @@ def create_signature(args, optional_args):
     ----------
     args : list
         List of strings that name the required arguments of a function.
-    optional_args : list
-        List of strings that name the optional arguments of a function.
+    optional_args : dict
+        Dict of strings that name the optional arguments of a function,
+        and their default values.
 
     Returns
     -------
@@ -377,11 +378,11 @@ def parse_param_body(parameter):
     for name, prop in properties.items():
         snake_name = camel_to_snake(name)
         is_req = name in req
-        default = prop.get('default', DEFAULT_STR)
         doc_list = docs_from_property(name, prop, properties, 0, not is_req)
         doc = "\n".join(doc_list) + "\n"
-        a = {"name": snake_name, "in": "body", "required": is_req,
-             "doc": doc, "default": default}
+        a = {"name": snake_name, "in": "body", "required": is_req, "doc": doc}
+        if not is_req:
+            a['default'] = prop.get('default', DEFAULT_STR)
         arguments.append(a)
     return arguments
 

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -69,6 +69,7 @@ ITERATOR_PARAM_DESC = (
     "    True, limit and page_num are ignored. Defaults to False.\n")
 CACHED_SPEC_PATH = os.path.join(os.path.expanduser('~'),
                                 ".civis_api_spec.json")
+DEFAULT_STR = 'DEFAULT'
 
 
 @deprecate_param('v2.0.0', 'resources')
@@ -220,14 +221,14 @@ def create_signature(args, optional_args):
         a dynamically created function.
     """
     p = [Parameter(x, Parameter.POSITIONAL_OR_KEYWORD) for x in args]
-    p += [Parameter(x, Parameter.KEYWORD_ONLY, default='DEFAULT')
-          for x in optional_args]
+    p += [Parameter(x, Parameter.KEYWORD_ONLY, default=default_value)
+          for x, default_value in optional_args.items()]
     return Signature(p)
 
 
 def split_method_params(params):
     args = []
-    optional_args = []
+    optional_args = {}
     body_params = []
     query_params = []
     path_params = []
@@ -236,7 +237,7 @@ def split_method_params(params):
         if param["required"]:
             args.append(name)
         else:
-            optional_args.append(name)
+            optional_args[name] = param.get('default', DEFAULT_STR)
         if param["in"] == "body":
             body_params.append(name)
         elif param["in"] == "query":
@@ -333,6 +334,8 @@ def parse_param(param):
         req = param['required']
         doc = doc_from_param(param)
         a = {"name": snake_name, "in": param_in, "required": req, "doc": doc}
+        if not req:
+            a['default'] = param.get('default', DEFAULT_STR)
         args.append(a)
     return args
 
@@ -374,9 +377,11 @@ def parse_param_body(parameter):
     for name, prop in properties.items():
         snake_name = camel_to_snake(name)
         is_req = name in req
+        default = prop.get('default', DEFAULT_STR)
         doc_list = docs_from_property(name, prop, properties, 0, not is_req)
         doc = "\n".join(doc_list) + "\n"
-        a = {"name": snake_name, "in": "body", "required": is_req, "doc": doc}
+        a = {"name": snake_name, "in": "body", "required": is_req,
+             "doc": doc, "default": default}
         arguments.append(a)
     return arguments
 

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -155,7 +155,7 @@ def test_split_method_params():
     x = _resources.split_method_params(params)
     args, kwargs, body_params, query_params, path_params = x
     assert sorted(args) == sorted(["a", "b", "c"])
-    assert kwargs == ["d"]
+    assert kwargs == {"d": _resources.DEFAULT_STR}
     assert body_params == ["a"]
     assert sorted(query_params) == sorted(["c", "d"])
     assert path_params == ["b"]
@@ -176,17 +176,24 @@ def test_parse_params():
     param2 = {"name": "B", "in": "path", "required": True,
               "description": "nah!", "type": "integer"}
     x, y = _resources.parse_params([param, param2], "summary!", "get")
-    expect_x, expect_y = ([{'in': 'query', 'doc': 'a : string, optional\n    yeah!\n', 'required': False, 'name': 'a'}, {'in': 'path', 'doc': 'b : integer\n    nah!\n', 'required': True, 'name': 'b'}], 'summary!\n\nParameters\n----------\nb : integer\n    nah!\na : string, optional\n    yeah!\n')  # noqa: E501
+    expect_x, expect_y = ([{'in': 'query', 'doc': 'a : string, optional\n    yeah!\n', 'required': False, 'name': 'a', 'default': _resources.DEFAULT_STR}, {'in': 'path', 'doc': 'b : integer\n    nah!\n', 'required': True, 'name': 'b'}], 'summary!\n\nParameters\n----------\nb : integer\n    nah!\na : string, optional\n    yeah!\n')  # noqa: E501
     assert x == expect_x
     assert y == expect_y
 
 
 def test_parse_param_body():
     expected = [{'required': False, 'name': 'a', 'in': 'body',
-                 'doc': 'a : list, optional\n'}]
+                 'doc': 'a : list, optional\n',
+                 'default': _resources.DEFAULT_STR}]
     param_body = {"schema": {"properties": {"A": {"type": "array"}}}}
     x = _resources.parse_param_body(param_body)
     assert x == expected
+
+    expected_with_default = [{'required': False, 'name': 'a', 'in': 'body',
+                              'doc': 'a : list, optional\n', 'default': 50}]
+    param_body_with_default = {"schema": {"properties": {"A": {"type": "array", "default": 50}}}}  # noqa: E501
+    x_with_default = _resources.parse_param_body(param_body_with_default)
+    assert x_with_default == expected_with_default
 
 
 def test_parse_method_name():


### PR DESCRIPTION
Some of our users have found it misleading that default arguments are always set to 'DEFAULT'. Also some of our endpoints do use default arguments and it would be nice to be able to include that in the signature if specified in the swagger.

The 'default' property is included as swagger 2.0 format as optional (https://swagger.io/docs/specification/2-0/describing-parameters/), but it was not being read-in as part of the civis-python parsing process.

This PR uses that default value if present in the swagger, if not it uses the previous 'DEFAULT' string because not setting a default for kwargs will cause the signature to read it as required.

here is an example with our sdkclient.weights.list() method which takes some optional arguments to filter by.
Before (all set to 'DEFAULT'):
<img width="698" alt="Screen Shot 2021-02-11 at 1 55 14 PM" src="https://user-images.githubusercontent.com/56272711/107691224-cad49b00-6c70-11eb-9d5a-1b713562c6ae.png">

After (real default values where specified):
<img width="795" alt="Screen Shot 2021-02-11 at 1 40 03 PM" src="https://user-images.githubusercontent.com/56272711/107690998-83e6a580-6c70-11eb-9eed-7642a711f50f.png">
