### PR TITLE
BUG Correct sql_type doc casing and check input for typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
 - Added default values from swagger in client method's signature (#416)
 
+### Fixed
+- Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
+
 ## 1.15.1 - 2020-10-28
 ### Fixed
 - fixes bug whereby calls with iterate=True do not retry (#413)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -668,10 +668,10 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     table_columns : list[Dict[str, str]], optional
         An array of hashes corresponding to the columns in the order
         they appear in the source file. Each hash should have keys for
-        database column "name" and "sqlType". This parameter is
+        database column "name" and "sql_type". This parameter is
         required if the table does not exist, the table is being dropped,
         or the columns in the source file do not appear in the same order
-        as in the destination table. The "sqlType" key is not required
+        as in the destination table. The "sql_type" key is not required
         when appending to an existing table.
     headers : bool, optional [DEPRECATED]
         Whether or not the first row of the file should be treated as
@@ -814,10 +814,10 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     table_columns : list[Dict[str, str]], optional
         An array of hashes corresponding to the columns in the order
         they appear in the source file. Each hash should have keys for
-        database column "name" and "sqlType". This parameter is
+        database column "name" and "sql_type". This parameter is
         required if the table does not exist, the table is being dropped,
         or the columns in the source file do not appear in the same order
-        as in the destination table. The "sqlType" key is not required
+        as in the destination table. The "sql_type" key is not required
         when appending to an existing table.
     delimiter : string, optional
         The column delimiter. One of ``','``, ``'\\t'`` or ``'|'``.
@@ -946,10 +946,10 @@ def civis_file_to_table(file_id, database, table, client=None,
     table_columns : list[Dict[str, str]], optional
         An array of hashes corresponding to the columns in the order
         they appear in the source file. Each hash should have keys for
-        database column "name" and "sqlType". This parameter is
+        database column "name" and "sql_type". This parameter is
         required if the table does not exist, the table is being dropped,
         or the columns in the source file do not appear in the same order
-        as in the destination table. The "sqlType" key is not required
+        as in the destination table. The "sql_type" key is not required
         when appending to an existing table.
     primary_keys: list[str], optional
         A list of the primary key column(s) of the destination table that
@@ -1022,6 +1022,23 @@ def civis_file_to_table(file_id, database, table, client=None,
         assert delimiter, "delimiter must be one of {}".format(
             DELIMITERS.keys()
         )
+    if table_columns:
+        # If the data cleaning code doesn't find a "sql_type" for each
+        # entry, it will silently replace the input table_columns with
+        # an inferred table_columns. Make sure there's no typos in the input.
+        keys = set(key for hash in table_columns for key in hash)
+        valid_keys = {'name', 'sql_type'}
+        invalid_keys = keys - valid_keys
+        if invalid_keys:
+            # Sort the sets for display to allow for deterministic testing in
+            # Python versions < 3.7.
+            raise ValueError(
+                "Keys of the dictionaries contained in `table_columns` must "
+                "be one of {}. The input `table_columns` also has "
+                "{}.".format(
+                    tuple(sorted(valid_keys)), tuple(sorted(invalid_keys))
+                )
+            )
 
     try:
         client.get_table_id(table, database)


### PR DESCRIPTION
The client is looking for the `table_columns` parameter to be a list of dictionaries, each of which has a "name" key and which optionally also have a "sql_type" key. If Civis Platform needs to know types, and there is no "sql_type" key in any of the dictionaries, the client will silently replace a user-provided `table_columns` with an inferred `table_columns`. The docstring claims that the expected formatting is "sqlType", but "sqlType" keys will be ignored.

Fix the docstrings to use snake case instead of camel case, and add a check on the `table_columns` input to prevent mistakes or typos.