### PR TITLE
MAINT Remove unsupported Python 2 notebook option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
+- Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
 
 ## 1.15.1 - 2020-10-28
 ### Fixed

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -251,7 +251,7 @@ def notebooks_download_cmd(notebook_id, path):
 
 
 @click.command('new')
-@click.argument('language', type=click.Choice(['python3', 'python2', 'r']),
+@click.argument('language', type=click.Choice(['python3', 'r']),
                 default='python3')
 @click.option('--mem', type=int, default=None,
               help='Memory allocated for this notebook in MiB.')


### PR DESCRIPTION
Civis Platform no longer supports Python 2 notebooks (currently Python 3 and R), but the CLI was still presenting Python 2 as an option.