### PR TITLE
[CIVP-19775] ENH add job and run ID to CivisJobFailure from CivisFuture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Added job ID and run ID to the exception message of `CivisJobFailure`
-  coming from a `ContainerFuture` object (#426)
+  coming from a `CivisFuture` object (#426)
 - Added the `encoding` parameter to both `civis.io.read_civis` and `civis.io.read_civis_sql`,
   so that these two functions can retrieve non-UTF-8 data when `use_pandas` is `False`. (#424)
 - `ContainerFuture` propagates error messages from logs (#416)
 - Added EmptyResultError to `civis.io.read_civis` docs (#412)
 - Added default values from swagger in client method's signature (#417)
+
+### Changed
+- Moved the changes from #416 for propagating error messages
+  from `ContainerFuture` to `CivisFuture` (#426)
 
 ### Fixed
 - Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Added job ID and run ID to the exception message of `CivisJobFailure`
+  coming from a `ContainerFuture` object (#426)
 - Added the `encoding` parameter to both `civis.io.read_civis` and `civis.io.read_civis_sql`,
   so that these two functions can retrieve non-UTF-8 data when `use_pandas` is `False`. (#424)
 - `ContainerFuture` propagates error messages from logs (#416)

--- a/civis/base.py
+++ b/civis/base.py
@@ -37,21 +37,23 @@ class CivisJobFailure(Exception):
         self.job_id = job_id
         self.run_id = run_id
         self._original_err_msg = err_msg
-        self.error_message = err_msg
-        self._update_error_message(err_msg)
+        self.error_message = _err_msg_with_job_run_ids(
+            self.__class__, err_msg, job_id, run_id)
         self.response = response
 
     def __str__(self):
         return self.error_message
 
-    def _update_error_message(self, err_msg):
-        if self.job_id is None and self.run_id is None:
-            self.error_message = err_msg
-        elif self.run_id is None:
-            self.error_message = f"(Job ID {self.job_id}) {err_msg}"
-        else:
-            self.error_message = (
-                f"(Job ID {self.job_id} / run ID {self.run_id}) {err_msg}")
+
+def _err_msg_with_job_run_ids(exc_cls, err_msg, job_id, run_id) -> str:
+    cls_name = exc_cls.__name__
+    if job_id is None and run_id is None:
+        return err_msg
+    elif run_id is None:
+        return f"({cls_name} from job ID {job_id}) {err_msg}"
+    else:
+        return (
+            f"({cls_name} from job ID {job_id} / run ID {run_id}) {err_msg}")
 
 
 class CivisAPIError(Exception):

--- a/civis/base.py
+++ b/civis/base.py
@@ -38,22 +38,20 @@ class CivisJobFailure(Exception):
         self.run_id = run_id
         self._original_err_msg = err_msg
         self.error_message = _err_msg_with_job_run_ids(
-            self.__class__, err_msg, job_id, run_id)
+            err_msg, job_id, run_id)
         self.response = response
 
     def __str__(self):
         return self.error_message
 
 
-def _err_msg_with_job_run_ids(exc_cls, err_msg, job_id, run_id) -> str:
-    cls_name = exc_cls.__name__
+def _err_msg_with_job_run_ids(err_msg, job_id, run_id) -> str:
     if job_id is None and run_id is None:
         return err_msg
     elif run_id is None:
-        return f"({cls_name} from job ID {job_id}) {err_msg}"
+        return f"(From job {job_id}) {err_msg}"
     else:
-        return (
-            f"({cls_name} from job ID {job_id} / run ID {run_id}) {err_msg}")
+        return f"(From job {job_id} / run {run_id}) {err_msg}"
 
 
 class CivisAPIError(Exception):

--- a/civis/base.py
+++ b/civis/base.py
@@ -33,12 +33,25 @@ def tostr_urljoin(*x):
 
 
 class CivisJobFailure(Exception):
-    def __init__(self, err_msg, response=None):
+    def __init__(self, err_msg, response=None, job_id=None, run_id=None):
+        self.job_id = job_id
+        self.run_id = run_id
+        self._original_err_msg = err_msg
         self.error_message = err_msg
+        self._update_error_message(err_msg)
         self.response = response
 
     def __str__(self):
         return self.error_message
+
+    def _update_error_message(self, err_msg):
+        if self.job_id is None and self.run_id is None:
+            self.error_message = err_msg
+        elif self.run_id is None:
+            self.error_message = f"(Job ID {self.job_id}) {err_msg}"
+        else:
+            self.error_message = (
+                f"(Job ID {self.job_id} / run ID {self.run_id}) {err_msg}")
 
 
 class CivisAPIError(Exception):

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -118,9 +118,8 @@ class CivisFuture(PollableResult):
 
         - MemoryError
         """
-        logs = self.client.scripts.list_containers_runs_logs(self.job_id,
-                                                             self.run_id,
-                                                             limit=nlog)
+        logs = self.client.jobs.list_runs_logs(
+            self.job_id, self.run_id, limit=nlog)
 
         # Check for memory errors
         msgs = [x['message'] for x in logs if x['level'] == 'error']

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -234,12 +234,14 @@ class ContainerFuture(CivisFuture):
                  poll_on_creation=True):
         if client is None:
             client = APIClient()
+
+        self._max_n_retries = max_n_retries
+
         super().__init__(client.scripts.get_containers_runs,
                          [int(job_id), int(run_id)],
                          polling_interval=polling_interval,
                          client=client,
                          poll_on_creation=poll_on_creation)
-        self._max_n_retries = max_n_retries
 
     def _set_api_exception(self, exc, result=None):
         # Catch attempts to set an exception. If there's retries

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -131,19 +131,19 @@ class CivisFuture(PollableResult):
         mem_err = [m for m in msgs if m.startswith('Process ran out of its')]
         if mem_err:
             err_msg = _err_msg_with_job_run_ids(
-                MemoryError, mem_err[0], self.job_id, self.run_id)
+                mem_err[0], self.job_id, self.run_id)
             exc = MemoryError(err_msg)
         else:
             # Unknown error; return logs to the user as a sort of traceback
             all_logs = '\n'.join([x['message'] for x in logs])
             if isinstance(exc, CivisJobFailure):
                 err_msg = _err_msg_with_job_run_ids(
-                    CivisJobFailure, all_logs + '\n' + exc.error_message,
+                    all_logs + '\n' + exc.error_message,
                     self.job_id, self.run_id)
                 exc.error_message = err_msg
             else:
                 err_msg = _err_msg_with_job_run_ids(
-                    exc.__class__, all_logs, self.job_id, self.run_id)
+                    all_logs, self.job_id, self.run_id)
                 exc = CivisJobFailure(
                     "", job_id=self.job_id, run_id=self.run_id)
                 exc.error_message = err_msg

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -101,7 +101,7 @@ class CivisFuture(PollableResult):
             fut._exception_handled = True
 
         if fut.failed():
-            # Container scripts do not return the error message,
+            # Some platform script types do not return the error message,
             # so we override with an exception we can pull from the
             # logs
             if isinstance(fut._exception, CivisJobFailure) and \

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -84,6 +84,63 @@ class CivisFuture(PollableResult):
                          client=client,
                          poll_on_creation=poll_on_creation)
 
+        self._exception_handled = False
+        self.add_done_callback(self._set_job_exception)
+
+    @staticmethod
+    def _set_job_exception(fut):
+        """Callback: On job completion, check the status.
+        If the job has failed, and has no pre-existing error message,
+        populate the error message with recent logs.
+        """
+        # Prevent infinite recursion: this function calls `set_exception`,
+        # which triggers callbacks (i.e. re-calls this function).
+        if fut._exception_handled:
+            return
+        else:
+            fut._exception_handled = True
+
+        if fut.failed():
+            # Container scripts do not return the error message,
+            # so we override with an exception we can pull from the
+            # logs
+            if isinstance(fut._exception, CivisJobFailure) and \
+               fut._exception.error_message == 'None':
+                fut._exception.error_message = ''
+                exc = fut._exception_from_logs(fut._exception)
+                fut.set_exception(exc)
+
+    def _exception_from_logs(self, exc, nlog=15):
+        """Create an exception if the log has a recognizable error
+
+        Search "error" emits in the last ``n_log`` lines.
+        This function presently recognizes the following errors:
+
+        - MemoryError
+        """
+        logs = self.client.scripts.list_containers_runs_logs(self.job_id,
+                                                             self.run_id,
+                                                             limit=nlog)
+
+        # Check for memory errors
+        msgs = [x['message'] for x in logs if x['level'] == 'error']
+        mem_err = [m for m in msgs if m.startswith('Process ran out of its')]
+        if mem_err:
+            exc = MemoryError(mem_err[0])
+        else:
+            # Unknown error; return logs to the user as a sort of traceback
+            job_run_ids_in_exc = _format_job_run_ids_in_exception(
+                self.job_id, self.run_id)
+            all_logs = (
+                f"{job_run_ids_in_exc} "
+                + '\n'.join([x['message'] for x in logs])
+            )
+            if isinstance(exc, CivisJobFailure):
+                exc.error_message = all_logs + '\n' + exc.error_message
+            else:
+                exc = CivisJobFailure(all_logs)
+        return exc
+
     @property
     def job_id(self):
         return self.poller_args[0]
@@ -183,62 +240,6 @@ class ContainerFuture(CivisFuture):
                          client=client,
                          poll_on_creation=poll_on_creation)
         self._max_n_retries = max_n_retries
-        self._exception_handled = False
-        self.add_done_callback(self._set_job_exception)
-
-    @staticmethod
-    def _set_job_exception(fut):
-        """Callback: On job completion, check the status.
-        If the job has failed, and has no pre-existing error message,
-        populate the error message with recent logs.
-        """
-        # Prevent infinite recursion: this function calls `set_exception`,
-        # which triggers callbacks (i.e. re-calls this function).
-        if fut._exception_handled:
-            return
-        else:
-            fut._exception_handled = True
-
-        if fut.failed():
-            # Container scripts do not return the error message,
-            # so we override with an exception we can pull from the
-            # logs
-            if isinstance(fut._exception, CivisJobFailure) and \
-               fut._exception.error_message == 'None':
-                fut._exception.error_message = ''
-                exc = fut._exception_from_logs(fut._exception)
-                fut.set_exception(exc)
-
-    def _exception_from_logs(self, exc, nlog=15):
-        """Create an exception if the log has a recognizable error
-
-        Search "error" emits in the last ``n_log`` lines.
-        This function presently recognizes the following errors:
-
-        - MemoryError
-        """
-        logs = self.client.scripts.list_containers_runs_logs(self.job_id,
-                                                             self.run_id,
-                                                             limit=nlog)
-
-        # Check for memory errors
-        msgs = [x['message'] for x in logs if x['level'] == 'error']
-        mem_err = [m for m in msgs if m.startswith('Process ran out of its')]
-        if mem_err:
-            exc = MemoryError(mem_err[0])
-        else:
-            # Unknown error; return logs to the user as a sort of traceback
-            job_run_ids_in_exc = _format_job_run_ids_in_exception(
-                self.job_id, self.run_id)
-            all_logs = (
-                f"{job_run_ids_in_exc} "
-                + '\n'.join([x['message'] for x in logs])
-            )
-            if isinstance(exc, CivisJobFailure):
-                exc.error_message = all_logs + '\n' + exc.error_message
-            else:
-                exc = CivisJobFailure(all_logs)
-        return exc
 
     def _set_api_exception(self, exc, result=None):
         # Catch attempts to set an exception. If there's retries

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -166,14 +166,6 @@ class CivisFuture(PollableResult):
             return False
         return match
 
-    def _poll_and_set_api_result(self):
-        with self._condition:
-            try:
-                result = self.poller(*self.poller_args)
-                self._set_api_result(result)
-            except Exception as e:
-                self._set_api_exception(exc=e)
-
     def outputs(self):
         """Block on job completion and return a list of run outputs.
 

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -228,7 +228,12 @@ class ContainerFuture(CivisFuture):
             exc = MemoryError(mem_err[0])
         else:
             # Unknown error; return logs to the user as a sort of traceback
-            all_logs = '\n'.join([x['message'] for x in logs])
+            job_run_ids_in_exc = _format_job_run_ids_in_exception(
+                self.job_id, self.run_id)
+            all_logs = (
+                f"{job_run_ids_in_exc} "
+                + '\n'.join([x['message'] for x in logs])
+            )
             if isinstance(exc, CivisJobFailure):
                 exc.error_message = all_logs + '\n' + exc.error_message
             else:
@@ -297,6 +302,10 @@ class ContainerFuture(CivisFuture):
                 self._invoke_callbacks()
                 return self.cancelled()
             return False
+
+
+def _format_job_run_ids_in_exception(job_id: int, run_id: int) -> str:
+    return f"(Job ID {job_id} / Run ID {run_id})"
 
 
 def _create_docker_command(*args, **kwargs):

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -120,6 +120,8 @@ class CivisFuture(PollableResult):
         """
         logs = self.client.jobs.list_runs_logs(
             self.job_id, self.run_id, limit=nlog)
+        # Reverse order as logs come back in reverse chronological order.
+        logs = logs[::-1]
 
         # Check for memory errors
         msgs = [x['message'] for x in logs if x['level'] == 'error']

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -118,6 +118,8 @@ class CivisFuture(PollableResult):
 
         - MemoryError
         """
+        # Traceback in platform logs may be delayed for a few seconds.
+        time.sleep(15)
         logs = self.client.jobs.list_runs_logs(
             self.job_id, self.run_id, limit=nlog)
         # Reverse order as logs come back in reverse chronological order.

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -306,6 +306,20 @@ def test_set_job_exception_metadata_exception():
     """
     # State "running" prevents termination when the object is created.
     mock_client = setup_client_mock(1, 2, state='running')
+    logs = [{'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10005,
+             'level': 'error',
+             'message': 'Failed'},
+            {'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10003,
+             'level': 'error',
+             'message': 'Error on job: Process ended with an '
+                        'error, exiting: 137.'},
+            {'created_at': '2017-05-10T12:00:00.000Z',
+             'id': 10000,
+             'level': 'error',
+             'message': 'something went wrong'}]
+    mock_client.jobs.list_runs_logs.return_value = logs
 
     class ModelFutureRaiseExc(_model.ModelFuture):
         def __init__(self, exc, *args, **kwargs):
@@ -348,7 +362,7 @@ def test_set_job_exception_memory_error():
              'id': 10000,
              'level': 'error',
              'message': err_msg}]
-    mock_client.scripts.list_containers_runs_logs.return_value = logs
+    mock_client.jobs.list_runs_logs.return_value = logs
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(MemoryError) as err:
         fut.result()
@@ -375,7 +389,7 @@ def test_set_job_exception_unknown_error():
     err_msg = (_format_job_run_ids_in_exception(1, 2)
                + " "
                + '\n'.join([x['message'] for x in logs]))
-    mock_client.scripts.list_containers_runs_logs.return_value = logs
+    mock_client.jobs.list_runs_logs.return_value = logs
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:
         fut.result()

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -32,7 +32,6 @@ except ImportError:
 
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
-from civis.futures import _format_job_run_ids_in_exception
 from civis.response import Response
 from civis.tests import (
     create_client_mock, create_client_mock_for_container_tests)
@@ -328,9 +327,8 @@ def test_set_job_exception_unknown_error():
              'message': 'Oops'}]
     mock_client = create_client_mock_for_container_tests(
         1, 2, state='failed', log_outputs=logs)
-    err_msg = (_format_job_run_ids_in_exception(1, 2)
-               + " "
-               + '\n'.join([x['message'] for x in logs]))
+    err_msg = (
+        "(Job ID 1 / run ID 2) " + '\n'.join([x['message'] for x in logs]))
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:
         fut.result()

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -255,7 +255,8 @@ def test_modelfuture_pickle_smoke(mock_client):
     pickle.loads(mf_pickle)
 
 
-def test_set_job_exception_metadata_exception():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_set_job_exception_metadata_exception(m_sleep):
     """Tests cases where accessing metadata throws exceptions
     """
     # State "running" prevents termination when the object is created.
@@ -285,7 +286,8 @@ def test_set_job_exception_metadata_exception():
         _model.ModelFuture._set_job_exception(fut)
 
 
-def test_set_job_exception_memory_error():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_set_job_exception_memory_error(m_sleep):
     err_msg = ('Process ran out of its allowed 3000 MiB of '
                'memory and was killed.')
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
@@ -309,7 +311,8 @@ def test_set_job_exception_memory_error():
     assert str(err.value) == err_msg
 
 
-def test_set_job_exception_unknown_error():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_set_job_exception_unknown_error(m_sleep):
     # If we really don't recognize the error, at least give the
     # user a few lines of logs so they can maybe figure it out themselves.
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
@@ -483,7 +486,8 @@ def test_metadata(mock_spec, mock_f2j):
     mock_f2j.assert_called_once_with(11, client=c)
 
 
-def test_train_data_fname():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_train_data_fname(m_sleep):
     # swap out the poller with a simple function that accepts *args, **kwargs
     # and returns a simple successful Response object
     def poller(*args, **kwargs):
@@ -517,8 +521,9 @@ def test_train_data_(mock_cio):
         'model_info.json', 11, 13, client=mock_client)
 
 
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
 @mock.patch.object(_model, "_load_table_from_outputs", autospec=True)
-def test_train_data_exc_handling(mock_load_table):
+def test_train_data_exc_handling(mock_load_table, m_sleep):
     def poller(*args, **kwargs):
         return Response({'state': 'succeeded'})
     mock_client = mock.MagicMock()
@@ -835,7 +840,8 @@ def test_modelpipeline_classmethod_constructor_defaults(mock_future):
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
 @mock.patch.object(_model, '_get_template_ids_all_versions',
                    mock.Mock(return_value=TEST_TEMPLATE_IDS))
-def test_modelpipeline_classmethod_constructor_nonint_id():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_modelpipeline_classmethod_constructor_nonint_id(m_sleep):
     # Verify that we can still JSON-serialize job and run IDs even
     # if they're entered in a non-JSON-able format.
     # We need to turn them into JSON to set them as script arguments.

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -313,22 +313,23 @@ def test_set_job_exception_unknown_error():
     # If we really don't recognize the error, at least give the
     # user a few lines of logs so they can maybe figure it out themselves.
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10005,
+             'id': 10000,
              'level': 'error',
-             'message': 'Failed'},
+             'message': 'Oops'},
             {'created_at': '2017-05-10T12:00:00.000Z',
              'id': 10003,
              'level': 'error',
              'message': 'Error on job: Process ended with an '
                         'error, exiting: 137.'},
             {'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10000,
+             'id': 10005,
              'level': 'error',
-             'message': 'Oops'}]
+             'message': 'Failed'}]
     mock_client = create_client_mock_for_container_tests(
         1, 2, state='failed', log_outputs=logs)
     err_msg = (
-        "(Job ID 1 / run ID 2) " + '\n'.join([x['message'] for x in logs]))
+        "(Job ID 1 / run ID 2) "
+        + '\n'.join([x['message'] for x in logs][::-1]))
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:
         fut.result()

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -316,18 +316,18 @@ def test_set_job_exception_unknown_error(m_sleep):
     # If we really don't recognize the error, at least give the
     # user a few lines of logs so they can maybe figure it out themselves.
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10000,
+             'id': 10005,
              'level': 'error',
-             'message': 'Oops'},
+             'message': 'Failed'},
             {'created_at': '2017-05-10T12:00:00.000Z',
              'id': 10003,
              'level': 'error',
              'message': 'Error on job: Process ended with an '
                         'error, exiting: 137.'},
             {'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10005,
+             'id': 10000,
              'level': 'error',
-             'message': 'Failed'}]
+             'message': 'Oops'}]
     mock_client = create_client_mock_for_container_tests(
         1, 2, state='failed', log_outputs=logs)
     err_msg = (

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -308,8 +308,7 @@ def test_set_job_exception_memory_error(m_sleep):
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(MemoryError) as err:
         fut.result()
-    expected = f"(MemoryError from job ID 1 / run ID 2) {err_msg}"
-    assert str(err.value) == expected
+    assert str(err.value) == f"(From job 1 / run 2) {err_msg}"
 
 
 @mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
@@ -332,7 +331,7 @@ def test_set_job_exception_unknown_error(m_sleep):
     mock_client = create_client_mock_for_container_tests(
         1, 2, state='failed', log_outputs=logs)
     err_msg = (
-        "(CivisJobFailure from job ID 1 / run ID 2) "
+        "(From job 1 / run 2) "
         + '\n'.join([x['message'] for x in logs][::-1]))
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -104,7 +104,7 @@ def setup_client_mock(script_id=-10, run_id=100, state='succeeded',
     c.scripts.post_containers_runs.return_value = mock_container_run_start
     c.scripts.get_containers_runs.return_value = mock_container_run
     c.scripts.list_containers_runs_outputs.return_value = (run_outputs or [])
-    c.scripts.list_containers_runs_logs.return_value = []
+    c.jobs.list_runs_logs.return_value = []
 
     def change_state_to_cancelled(script_id):
         mock_container_run.state = "cancelled"

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -30,12 +30,12 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-from civis import APIClient
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.futures import _format_job_run_ids_in_exception
 from civis.response import Response
-from civis.tests import create_client_mock
+from civis.tests import (
+    create_client_mock, create_client_mock_for_container_tests)
 import pytest
 
 from civis.ml import _model
@@ -66,53 +66,6 @@ TEST_TEMPLATE_IDS = {  # Must match TEST_TEMPLATE_ID_ALIAS_OBJECTS
     'v1.4': {'training': TRAIN_ID_OLD, 'prediction': PREDICT_ID_OLD, 'registration': None},  # noqa
     'dev': {'training': 345, 'prediction': 678, 'registration': 901},
 }
-
-
-def setup_client_mock(script_id=-10, run_id=100, state='succeeded',
-                      run_outputs=None):
-    """Return a Mock set up for use in testing container scripts
-
-    Parameters
-    ----------
-    script_id: int
-        Mock-create containers with this ID when calling `post_containers`
-        or `post_containers_runs`.
-    run_id: int
-        Mock-create runs with this ID when calling `post_containers_runs`.
-    state: str, optional
-        The reported state of the container run
-    run_outputs: list, optional
-        List of Response objects returned as run outputs
-
-    Returns
-    -------
-    `unittest.mock.Mock`
-        With scripts endpoints `post_containers`, `post_containers_runs`,
-        `post_cancel`, and `get_containers_runs` set up.
-    """
-    c = mock.Mock()
-    c.__class__ = APIClient
-
-    mock_container = Response({'id': script_id})
-    c.scripts.post_containers.return_value = mock_container
-    mock_container_run_start = Response({'id': run_id,
-                                         'container_id': script_id,
-                                         'state': 'queued'})
-    mock_container_run = Response({'id': run_id,
-                                   'container_id': script_id,
-                                   'state': state})
-    c.scripts.post_containers_runs.return_value = mock_container_run_start
-    c.scripts.get_containers_runs.return_value = mock_container_run
-    c.scripts.list_containers_runs_outputs.return_value = (run_outputs or [])
-    c.jobs.list_runs_logs.return_value = []
-
-    def change_state_to_cancelled(script_id):
-        mock_container_run.state = "cancelled"
-        return mock_container_run
-
-    c.scripts.post_cancel.side_effect = change_state_to_cancelled
-
-    return c
 
 
 def test_check_is_fit_exception():
@@ -245,7 +198,7 @@ def test_load_estimator(mock_retrieve):
 def test_load_table_from_outputs(mock_fid, mock_f2df):
     # Test that _load_table_from_outputs is calling functions
     # correctly. Let `autospec` catch errors in arguments being passed.
-    mock_client = setup_client_mock()
+    mock_client = create_client_mock_for_container_tests()
     _model._load_table_from_outputs(1, 2, 'fname', client=mock_client)
 
 
@@ -275,7 +228,7 @@ def test_show_civisml_warnings_error():
 @mock.patch.object(_model.ModelFuture, "_set_job_exception", autospec=True)
 @mock.patch.object(_model.ModelFuture, "add_done_callback", autospec=True)
 def test_modelfuture_constructor(mock_adc, mock_spe):
-    c = setup_client_mock(7, 17)
+    c = create_client_mock_for_container_tests(7, 17)
 
     mf = _model.ModelFuture(job_id=7, run_id=17, client=c)
     assert mf.is_training is True
@@ -293,9 +246,11 @@ def test_modelfuture_constructor(mock_adc, mock_spe):
                    mock.Mock(return_value=11, spec_set=True))
 @mock.patch.object(_model.cio, "file_to_json",
                    mock.Mock(return_value={'run': {'status': 'succeeded'}}))
-@mock.patch.object(_model, 'APIClient', return_value=setup_client_mock())
+@mock.patch.object(_model, 'APIClient',
+                   return_value=create_client_mock_for_container_tests())
 def test_modelfuture_pickle_smoke(mock_client):
-    mf = _model.ModelFuture(job_id=7, run_id=13, client=setup_client_mock())
+    mf = _model.ModelFuture(job_id=7, run_id=13,
+                            client=create_client_mock_for_container_tests())
     mf.result()
     mf_pickle = pickle.dumps(mf)
     pickle.loads(mf_pickle)
@@ -305,21 +260,7 @@ def test_set_job_exception_metadata_exception():
     """Tests cases where accessing metadata throws exceptions
     """
     # State "running" prevents termination when the object is created.
-    mock_client = setup_client_mock(1, 2, state='running')
-    logs = [{'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10005,
-             'level': 'error',
-             'message': 'Failed'},
-            {'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10003,
-             'level': 'error',
-             'message': 'Error on job: Process ended with an '
-                        'error, exiting: 137.'},
-            {'created_at': '2017-05-10T12:00:00.000Z',
-             'id': 10000,
-             'level': 'error',
-             'message': 'something went wrong'}]
-    mock_client.jobs.list_runs_logs.return_value = logs
+    mock_client = create_client_mock_for_container_tests(1, 2, state='running')
 
     class ModelFutureRaiseExc(_model.ModelFuture):
         def __init__(self, exc, *args, **kwargs):
@@ -346,7 +287,6 @@ def test_set_job_exception_metadata_exception():
 
 
 def test_set_job_exception_memory_error():
-    mock_client = setup_client_mock(1, 2, state='failed')
     err_msg = ('Process ran out of its allowed 3000 MiB of '
                'memory and was killed.')
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
@@ -362,7 +302,8 @@ def test_set_job_exception_memory_error():
              'id': 10000,
              'level': 'error',
              'message': err_msg}]
-    mock_client.jobs.list_runs_logs.return_value = logs
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed', log_outputs=logs)
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(MemoryError) as err:
         fut.result()
@@ -372,7 +313,6 @@ def test_set_job_exception_memory_error():
 def test_set_job_exception_unknown_error():
     # If we really don't recognize the error, at least give the
     # user a few lines of logs so they can maybe figure it out themselves.
-    mock_client = setup_client_mock(1, 2, state='failed')
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',
              'id': 10005,
              'level': 'error',
@@ -386,10 +326,11 @@ def test_set_job_exception_unknown_error():
              'id': 10000,
              'level': 'error',
              'message': 'Oops'}]
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='failed', log_outputs=logs)
     err_msg = (_format_job_run_ids_in_exception(1, 2)
                + " "
                + '\n'.join([x['message'] for x in logs]))
-    mock_client.jobs.list_runs_logs.return_value = logs
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
@@ -404,7 +345,8 @@ def test_set_job_exception_no_exception(mock_f2j):
     ro = [{'name': 'model_info.json', 'object_id': 137, 'object_type': 'File'},
           {'name': 'metrics.json', 'object_id': 139, 'object_type': 'File'}]
     ro = [Response(o) for o in ro]
-    mock_client = setup_client_mock(1, 2, state='succeeded', run_outputs=ro)
+    mock_client = create_client_mock_for_container_tests(
+        1, 2, state='succeeded', run_outputs=ro)
     fut = _model.ModelFuture(1, 2, client=mock_client)
     assert fut.exception() is None
 
@@ -458,7 +400,7 @@ def test_set_job_exception_validation_metadata():
 @mock.patch.object(_model.ModelFuture, "_set_job_exception",
                    lambda *args: None)
 def test_getstate():
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
 
     mf = _model.ModelFuture(3, 7, client=c)
     ret = mf.__getstate__()
@@ -475,7 +417,7 @@ def test_getstate():
                    mock.Mock(spec_set=True,
                              return_value={'run': {'status': 'foo'}}))
 def test_state():
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
 
     mf = _model.ModelFuture(3, 7, client=c)
     ret = mf.state
@@ -495,7 +437,7 @@ def test_state():
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_job_exception", mock.Mock())
 def test_table(mock_res, mock_lt, mock_meta):
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     assert mf.table == 'bar'
     mock_lt.assert_called_once_with(3, 7, 'predictions.csv',
@@ -509,7 +451,7 @@ def test_table(mock_res, mock_lt, mock_meta):
 @mock.patch.object(_model.ModelFuture, "result")
 @mock.patch.object(_model.ModelFuture, "_set_job_exception", mock.Mock())
 def test_table_no_pkey(mock_res, mock_lt, mock_meta):
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     assert mf.table == 'bar'
     mock_lt.assert_called_once_with(3, 7, 'predictions.csv',
@@ -524,7 +466,7 @@ def test_table_no_pkey(mock_res, mock_lt, mock_meta):
 @mock.patch.object(_model.ModelFuture, "_set_job_exception", mock.Mock())
 def test_table_None(mock_res, mock_lt, mock_meta):
     mock_lt.side_effect = FileNotFoundError()
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     assert mf.table is None
     mock_lt.assert_called_once_with(3, 7, 'predictions.csv',
@@ -536,7 +478,7 @@ def test_table_None(mock_res, mock_lt, mock_meta):
 @mock.patch.object(_model.cio, "file_to_json", return_value={'foo': 'bar'})
 @mock.patch.object(_model.ModelFuture, "_set_job_exception")
 def test_metadata(mock_spec, mock_f2j):
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     assert mf.metadata == {'foo': 'bar'}
     mock_f2j.assert_called_once_with(11, client=c)
@@ -595,7 +537,7 @@ def test_train_data_exc_handling(mock_load_table):
 @mock.patch.object(_model, "_load_estimator", return_value='spam')
 @mock.patch.object(_model.ModelFuture, "_set_job_exception", mock.Mock())
 def test_estimator(mock_le):
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
 
     mf = _model.ModelFuture(3, 7, client=c)
     assert mock_le.call_count == 0, "Estimator retrieval is lazy."
@@ -614,7 +556,7 @@ def test_estimator(mock_le):
 def test_validation_metadata_training(mock_spe, mock_f2f,
                                       mock_file_id_from_run_output):
     mock_file_id_from_run_output.return_value = 11
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
 
     assert mf.validation_metadata == 'foo'
@@ -630,7 +572,7 @@ def test_validation_metadata_missing(mock_spe, mock_f2f,
                                      mock_file_id_from_run_output):
     # Make sure that missing validation metadata doesn't cause an error
     mock_file_id_from_run_output.side_effect = FileNotFoundError
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
 
     assert mf.validation_metadata is None
@@ -646,7 +588,7 @@ def test_validation_metadata_missing(mock_spe, mock_f2f,
 def test_validation_metadata_prediction(mock_spe, mock_f2f,
                                         mock_file_id_from_run_output):
     mock_file_id_from_run_output.return_value = 11
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(1, 2, 3, 7, client=c)
 
     assert mf.validation_metadata == 'foo'
@@ -662,7 +604,7 @@ def test_validation_metadata_prediction(mock_spe, mock_f2f,
                                      'run': {'status': 'succeeded'}}))
 def test_metrics_training(mock_file_id_from_run_output):
     mock_file_id_from_run_output.return_value = 11
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
 
     assert mf.metrics == 'foo'
@@ -678,7 +620,7 @@ def test_metrics_training_None(mock_file_to_json,
         return_value={'metrics': 'foo',
                       'run': {'status': 'succeeded'}})
     mock_file_id_from_run_output.return_value = 11
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(3, 7, client=c)
     # override validation metadata to be None, as though we ran
     # a train job without validation
@@ -697,7 +639,7 @@ def test_metrics_training_None(mock_file_to_json,
                                      'run': {'status': 'succeeded'}}))
 def test_metrics_prediction(mock_file_id_from_run_output):
     mock_file_id_from_run_output.return_value = 11
-    c = setup_client_mock(3, 7)
+    c = create_client_mock_for_container_tests(3, 7)
     mf = _model.ModelFuture(1, 2, 3, 7, client=c)
 
     assert mf.metrics == 'foo'
@@ -769,7 +711,7 @@ def test__get_template_ids_invalid_version():
 #####################################
 @pytest.fixture
 def mp_setup():
-    mock_api = setup_client_mock()
+    mock_api = create_client_mock_for_container_tests()
     mock_api.aliases.list.return_value = TEST_TEMPLATE_ID_ALIAS_OBJECTS
     mp = _model.ModelPipeline('wf', 'dv', client=mock_api)
     return mp
@@ -898,7 +840,7 @@ def test_modelpipeline_classmethod_constructor_nonint_id():
     # Verify that we can still JSON-serialize job and run IDs even
     # if they're entered in a non-JSON-able format.
     # We need to turn them into JSON to set them as script arguments.
-    mock_client = setup_client_mock(1, 2)
+    mock_client = create_client_mock_for_container_tests(1, 2)
     container_response_stub = _container_response_stub(TRAIN_ID_PROD)
     mock_client.scripts.get_containers.return_value = container_response_stub
 
@@ -921,7 +863,7 @@ def test_modelpipeline_classmethod_constructor_old_version(
         mock_future, train_id, predict_id):
     # Test that we select the correct prediction template for different
     # versions of a training job.
-    mock_client = setup_client_mock()
+    mock_client = create_client_mock_for_container_tests()
     mock_client.scripts.get_containers.return_value = \
         _container_response_stub(from_template_id=train_id)
     mp = _model.ModelPipeline.from_existing(1, 1, client=mock_client)
@@ -964,7 +906,7 @@ def test_modelpipeline_train_from_estimator(mock_ccr, mock_f2c):
 @mock.patch.object(_model.ModelPipeline, "_create_custom_run")
 def test_modelpipeline_train_custom_etl(mock_ccr, mock_f2c, mock_template_ids):
     # Provide a custom ETL estimator and make sure we can train.
-    mock_api = setup_client_mock()
+    mock_api = create_client_mock_for_container_tests()
     # training template ID 11111 >= 9968 for the etl arg to work
     mock_template_ids.return_value = 11111, 22222, 33333
     etl = LogisticRegression()

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -33,6 +33,7 @@ except ImportError:
 from civis import APIClient
 from civis._utils import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
+from civis.futures import _format_job_run_ids_in_exception
 from civis.response import Response
 from civis.tests import create_client_mock
 import pytest
@@ -371,7 +372,9 @@ def test_set_job_exception_unknown_error():
              'id': 10000,
              'level': 'error',
              'message': 'Oops'}]
-    err_msg = '\n'.join([x['message'] for x in logs])
+    err_msg = (_format_job_run_ids_in_exception(1, 2)
+               + " "
+               + '\n'.join([x['message'] for x in logs]))
     mock_client.scripts.list_containers_runs_logs.return_value = logs
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:

--- a/civis/ml/tests/test_model.py
+++ b/civis/ml/tests/test_model.py
@@ -308,7 +308,8 @@ def test_set_job_exception_memory_error(m_sleep):
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(MemoryError) as err:
         fut.result()
-    assert str(err.value) == err_msg
+    expected = f"(MemoryError from job ID 1 / run ID 2) {err_msg}"
+    assert str(err.value) == expected
 
 
 @mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
@@ -331,7 +332,7 @@ def test_set_job_exception_unknown_error(m_sleep):
     mock_client = create_client_mock_for_container_tests(
         1, 2, state='failed', log_outputs=logs)
     err_msg = (
-        "(Job ID 1 / run ID 2) "
+        "(CivisJobFailure from job ID 1 / run ID 2) "
         + '\n'.join([x['message'] for x in logs][::-1]))
     fut = _model.ModelFuture(1, 2, client=mock_client)
     with pytest.raises(CivisJobFailure) as err:

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -173,8 +173,12 @@ class PollableResult(CivisAsyncResultBase):
                     err_msg = str(result['error'])
                 except:  # NOQA
                     err_msg = str(result)
-                self._set_api_exception(exc=CivisJobFailure(err_msg, result),
-                                        result=result)
+                job_id = getattr(self, "job_id", None)
+                run_id = getattr(self, "run_id", None)
+                self._set_api_exception(
+                    exc=CivisJobFailure(err_msg, result, job_id, run_id),
+                    result=result,
+                )
             elif result.state in DONE:
                 self.set_result(result)
                 self.cleanup()

--- a/civis/tests/mocks.py
+++ b/civis/tests/mocks.py
@@ -56,6 +56,8 @@ def create_client_mock_for_container_tests(
         The reported state of the container run
     run_outputs: list, optional
         List of Response objects returned as run outputs
+    log_outputs : list, optional
+        List of Response objects returned as log outputs
 
     Returns
     -------
@@ -78,7 +80,7 @@ def create_client_mock_for_container_tests(
     c.scripts.post_containers_runs.return_value = mock_container_run_start
     c.scripts.get_containers_runs.return_value = mock_container_run
     c.scripts.list_containers_runs_outputs.return_value = (run_outputs or [])
-    c.scripts.list_containers_runs_logs.return_value = (log_outputs or [])
+    c.jobs.list_runs_logs.return_value = (log_outputs or [])
 
     def change_state_to_cancelled(script_id):
         mock_container_run.state = "cancelled"

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -444,7 +444,7 @@ def test_container_exception_no_result_logs():
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
     expected_msg = (
-        "(Job ID 1 / run ID 2) " + '\n'.join([mem_msg, failed_msg, '']))
+        "(Job ID 1 / run ID 2) " + '\n'.join([failed_msg, mem_msg, '']))
     assert expected_msg == str(fut._exception.error_message)
     assert str(err.value) == expected_msg
 

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -445,8 +445,7 @@ def test_container_exception_no_result_logs(m_sleep):
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
     expected_msg = (
-        "(CivisJobFailure from job ID 1 / run ID 2) "
-        + '\n'.join([failed_msg, mem_msg, '']))
+        "(From job 1 / run 2) " + '\n'.join([failed_msg, mem_msg, '']))
     assert expected_msg == str(fut._exception.error_message)
     assert str(err.value) == expected_msg
 
@@ -476,5 +475,4 @@ def test_container_exception_memory_error(m_sleep):
 
     with pytest.raises(MemoryError) as err:
         fut.result()
-    expected = f"(MemoryError from job ID 1 / run ID 2) {err_msg}"
-    assert str(err.value) == expected
+    assert str(err.value) == f"(From job 1 / run 2) {err_msg}"

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -12,7 +12,8 @@ from civis.resources._resources import get_api_spec, generate_classes
 from civis.futures import (ContainerFuture,
                            _ContainerShellExecutor,
                            CustomScriptExecutor,
-                           _create_docker_command)
+                           _create_docker_command,
+                           _format_job_run_ids_in_exception)
 
 from civis.futures import CivisFuture
 from civis.tests import TEST_SPEC, create_client_mock, \
@@ -436,7 +437,10 @@ def test_container_exception_no_result_logs():
 
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
-    expected_msg = ('\n'.join([mem_msg, failed_msg, '']))
+    expected_msg = (
+        _format_job_run_ids_in_exception(1, 2)
+        + " "
+        + '\n'.join([mem_msg, failed_msg, '']))
     assert expected_msg == str(fut._exception.error_message)
     assert str(err.value) == expected_msg
 

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -12,8 +12,7 @@ from civis.resources._resources import get_api_spec, generate_classes
 from civis.futures import (ContainerFuture,
                            _ContainerShellExecutor,
                            CustomScriptExecutor,
-                           _create_docker_command,
-                           _format_job_run_ids_in_exception)
+                           _create_docker_command)
 
 from civis.futures import CivisFuture
 from civis.tests import TEST_SPEC, create_client_mock, \
@@ -437,9 +436,7 @@ def test_container_exception_no_result_logs():
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
     expected_msg = (
-        _format_job_run_ids_in_exception(1, 2)
-        + " "
-        + '\n'.join([mem_msg, failed_msg, '']))
+        "(Job ID 1 / run ID 2) " + '\n'.join([mem_msg, failed_msg, '']))
     assert expected_msg == str(fut._exception.error_message)
     assert str(err.value) == expected_msg
 

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -422,7 +422,8 @@ def test_future_retry_error():
     assert fut.result().state == 'succeeded'
 
 
-def test_container_exception_no_result_logs():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_container_exception_no_result_logs(m_sleep):
     # If the job errored with no output but with logs,
     # we should return error logs with the future exception.
     mem_msg = ('Run used approximately 2 millicores '
@@ -449,7 +450,8 @@ def test_container_exception_no_result_logs():
     assert str(err.value) == expected_msg
 
 
-def test_container_exception_memory_error():
+@mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
+def test_container_exception_memory_error(m_sleep):
     err_msg = ('Process ran out of its allowed 3000 MiB of '
                'memory and was killed.')
     logs = [{'created_at': '2017-05-10T12:00:00.000Z',

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -445,7 +445,8 @@ def test_container_exception_no_result_logs(m_sleep):
     with pytest.raises(CivisJobFailure) as err:
         fut.result()
     expected_msg = (
-        "(Job ID 1 / run ID 2) " + '\n'.join([failed_msg, mem_msg, '']))
+        "(CivisJobFailure from job ID 1 / run ID 2) "
+        + '\n'.join([failed_msg, mem_msg, '']))
     assert expected_msg == str(fut._exception.error_message)
     assert str(err.value) == expected_msg
 
@@ -475,4 +476,5 @@ def test_container_exception_memory_error(m_sleep):
 
     with pytest.raises(MemoryError) as err:
         fut.result()
-    assert str(err.value) == err_msg
+    expected = f"(MemoryError from job ID 1 / run ID 2) {err_msg}"
+    assert str(err.value) == expected

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -92,11 +92,21 @@ class CivisFutureTests(CivisVCRTestCase):
         self.assertFalse(result._check_message(message))
 
     @mock.patch(api_import_str, return_value=civis_api_spec_base)
+    def test_poller_call_count_poll_on_creation_true(self, mock_api):
+        poller = _create_poller_mock("succeeded")
+        CivisFuture(poller, (1, 2), poll_on_creation=True)
+        assert poller.call_count == 1
+
+    @mock.patch(api_import_str, return_value=civis_api_spec_base)
+    def test_poller_call_count_poll_on_creation_false(self, mock_api):
+        poller = _create_poller_mock("succeeded")
+        CivisFuture(poller, (1, 2), poll_on_creation=False)
+        assert poller.call_count == 0
+
+    @mock.patch(api_import_str, return_value=civis_api_spec_base)
     def test_set_api_result_succeeded(self, mock_api):
         poller = _create_poller_mock("succeeded")
-
         result = CivisFuture(poller, (1, 2))
-        assert poller.call_count == 1
         assert result._state == 'FINISHED'
 
     @mock.patch(api_import_str, return_value=civis_api_spec_base)

--- a/civis/tests/test_futures.py
+++ b/civis/tests/test_futures.py
@@ -34,10 +34,8 @@ def clear_lru_cache():
 
 
 def _create_poller_mock(state: str) -> mock.Mock:
-    poller = mock.Mock()
-    api_result = mock.Mock()
-    api_result.state = state
-    poller.return_value = api_result
+    api_result = mock.Mock(state=state)
+    poller = mock.Mock(return_value=api_result)
     return poller
 
 


### PR DESCRIPTION
This PR adds the job ID and run ID to the exception message of `CivisJobFailure` coming from a `CivisFuture` object.