### PR TITLE
[CIVP-22464] BUG Better error message when CSV preprocessing fails in `civis_file_to_table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `dataframe_to_file` (for `expires_at`), and `json_to_file` (for `expires_at`). (#427)
 
 ### Fixed
-- Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
-- Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
+- Handled the index-out-of-bounds error when CSV preprocessing fails in `civis_file_to_table`
+  by raising a more informative exception (#428)
 - Removed no-longer-used PubNub code (#425)
+- Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
+- Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
 
 ## 1.15.1 - 2020-10-28
 ### Fixed

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1323,8 +1323,8 @@ def _run_cleaning(file_ids, client, need_table_columns, headers, delimiter,
         )
         fut = run_job(cleaner_job.id, client=client,
                       polling_interval=polling_interval)
-        log.debug('Started CSV preprocess job %d run %d for "%s"',
-                  cleaner_job.id, fut.run_id, client.files.get(fid).name)
+        log.debug('Started CSV preprocess job %d run %d for file %d (%s)',
+                  cleaner_job.id, fut.run_id, fid, client.files.get(fid).name)
         cleaning_futures.append(fut)
     return cleaning_futures
 

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1323,8 +1323,8 @@ def _run_cleaning(file_ids, client, need_table_columns, headers, delimiter,
         )
         fut = run_job(cleaner_job.id, client=client,
                       polling_interval=polling_interval)
-        log.debug('Started run %d for pre process job %d',
-                  fut.run_id, cleaner_job.id)
+        log.debug('Started CSV preprocess job %d run %d for "%s"',
+                  cleaner_job.id, fut.run_id, client.files.get(fid).name)
         cleaning_futures.append(fut)
     return cleaning_futures
 
@@ -1423,7 +1423,7 @@ def _process_cleaning_results(cleaning_futures, client, headers,
             )[0]
         except IndexError:
             raise CivisImportError(
-                "Unable to retrieve output fro CSV preprocess "
+                "Unable to retrieve output from CSV preprocess "
                 f"job {result.job_id} run {result.run_id}"
             )
         detected_info = client.files.get(output_file.object_id).detected_info


### PR DESCRIPTION
`civis.io.civis_file_to_table` assumes the internal CSV preprocessing jobs always return run outputs, but this assumption breaks down if CSV preprocessing fails with no run outputs and therefore leads to an uninformative "list index out of bounds" error. This PR handles this error and provides a better error message to aid debugging.