### PR TITLE
[CIVIS-1609] FIX no `assert` statements in non-test code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to use joblib 1.1.x (#423)
 
 ### Fixed
+- Converted `assert` statements in non-test code into proper error handling (#430)
 - Handled the index-out-of-bounds error when CSV preprocessing fails in `civis_file_to_table`
   by raising a more informative exception (#428)
 - Removed no-longer-used PubNub code (#425)
-- Converted `assert` statements in non-test code into proper error handling (#430)
 - Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
 - Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   from `ContainerFuture` to `CivisFuture` (#426)
 - Updated the docstrings for `file_to_civis` (for `buf` and `expires_at`),
   `dataframe_to_file` (for `expires_at`), and `json_to_file` (for `expires_at`). (#427)
-- Added default values from swagger in client method's signature (#416)
 - Ability to use joblib 1.1.x (#423)
 
 ### Fixed
 - Corrected camel to snake case for "sql_type" in `io` docstrings, and added an input check to catch misspellings in the `table_columns` input (#419).
 - Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
 - Removed no-longer-used PubNub code (#425)
+- Converted `assert` statements in non-test code into proper error handling (#430)
 
 ## 1.15.1 - 2020-10-28
 ### Fixed

--- a/civis/base.py
+++ b/civis/base.py
@@ -1,4 +1,3 @@
-from builtins import super
 import os
 from posixpath import join
 import threading

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -6,6 +6,7 @@ import civis
 from civis.resources import generate_classes_maybe_cached
 from civis._utils import get_api_key
 from civis._deprecation import deprecate_param
+from civis.response import _RETURN_TYPES
 
 
 log = logging.getLogger(__name__)
@@ -383,9 +384,11 @@ class APIClient(MetaMixin):
     def __init__(self, api_key=None, return_type='snake',
                  retry_total=6, api_version="1.0", resources="all",
                  local_api_spec=None):
-        if return_type not in ['snake', 'raw', 'pandas']:
-            raise ValueError("Return type must be one of 'snake', 'raw', "
-                             "'pandas'")
+        if return_type not in _RETURN_TYPES:
+            raise ValueError(
+                f"Return type must be one of {set(_RETURN_TYPES)}: "
+                f"{return_type}"
+            )
         self._feature_flags = ()
         session_auth_key = get_api_key(api_key)
         self._session_kwargs = {'api_key': session_auth_key}

--- a/civis/cli/__main__.py
+++ b/civis/cli/__main__.py
@@ -7,8 +7,6 @@ This is based on https://github.com/zalando/openapi-cli-client,
 which has an Apache 2.0 License:
 https://github.com/zalando/openapi-cli-client/blob/master/LICENSE
 """
-from __future__ import print_function
-
 
 import calendar
 from collections import OrderedDict
@@ -141,7 +139,11 @@ def invoke(method, path, op, *args, **kwargs):
     body = {}
     body_params = [p for p in op['parameters'] if p['in'] == 'body']
     if body_params:
-        assert len(body_params) == 1  # There can be only one body parameter.
+        if len(body_params) != 1:
+            raise ValueError(
+                "There can be only one body parameter, "
+                f"but {len(body_params)} are found: {body_params}"
+            )
         props = body_params[0]['schema']['properties']
         param_map = param_case_map(props.keys())
         body = {param_map[k]: v for k, v in kwargs.items()

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -3,7 +3,6 @@
 """
 Additional commands to add to the CLI beyond the OpenAPI spec.
 """
-from __future__ import print_function
 import functools
 import operator
 import os

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -4,10 +4,7 @@ import json
 import os
 import re
 import textwrap
-try:
-    from inspect import Signature, Parameter
-except ImportError:
-    from funcsigs import Signature, Parameter
+from inspect import Signature, Parameter
 
 from jsonref import JsonRef
 import requests
@@ -20,7 +17,8 @@ from civis._utils import (camel_to_snake, to_camelcase,
                           retry_request, MAX_RETRIES)
 
 
-API_VERSIONS = ["1.0"]
+_RESOURCES = frozenset({"base", "all"})
+API_VERSIONS = frozenset({"1.0", })
 BASE_RESOURCES_V1 = [
     'aliases',
     'announcements',
@@ -551,10 +549,15 @@ def generate_classes(api_key, api_version="1.0", resources="all"):
         a given user, including those that may be in development and subject
         to breaking changes at a later date.
     """
-    assert api_version in API_VERSIONS, (
-        "APIClient api_version must be one of {}".format(API_VERSIONS))
-    assert resources in ["base", "all"], (
-        "resources must be one of {}".format(["base", "all"]))
+    if api_version not in API_VERSIONS:
+        raise ValueError(
+            f"APIClient api_version must be one of {set(API_VERSIONS)}: "
+            f"{api_version}"
+        )
+    if resources not in _RESOURCES:
+        raise ValueError(
+            f"resources must be one of {set(_RESOURCES)}: {resources}"
+        )
     raw_spec = get_api_spec(api_key, api_version)
     spec = JsonRef.replace_refs(raw_spec)
     return parse_api_spec(spec, api_version, resources)

--- a/civis/response.py
+++ b/civis/response.py
@@ -3,6 +3,9 @@ import requests
 from civis._utils import camel_to_snake
 
 
+_RETURN_TYPES = frozenset({'snake', 'raw', 'pandas'})
+
+
 class CivisClientError(Exception):
     def __init__(self, message, response):
         self.status_code = response.status_code
@@ -62,7 +65,10 @@ def convert_response_data_type(response, headers=None, return_type='snake'):
     `pandas.DataFrame`, or `pandas.Series`
         Depending on the value of `return_type`.
     """
-    assert return_type in ['snake', 'raw', 'pandas'], 'Invalid return type'
+    if return_type not in _RETURN_TYPES:
+        raise ValueError(
+            f"Return type not one of {set(_RETURN_TYPES)}: {return_type}"
+        )
 
     if return_type == 'raw':
         return response


### PR DESCRIPTION
`assert` statements shouldn't be used in the actual, non-test code, since they can be disabled by the `-O` flag: https://docs.python.org/3/using/cmdline.html#cmdoption-O It's not clear how likely folks would run Civis-related code with this flag on, but it's better to convert these `assert` statements into conditional statements with exception raising.