### PR TITLE
[CIVIS-1642] FIX deprecate the inactive `retry_total` parameter of `civis.APIClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to use joblib 1.1.x (#423)
 
 ### Fixed
+- Warned about the `retry_total` parameter of `civis.APIClient` being inactive and deprecated (#431) 
 - Handled the index-out-of-bounds error when CSV preprocessing fails in `civis_file_to_table`
   by raising a more informative exception (#428)
 - Removed no-longer-used PubNub code (#425)

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -359,9 +359,11 @@ class APIClient(MetaMixin):
         - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
           list-like responses and a :class:`pandas:pandas.Series` for single a
           json response.
-    retry_total : int, optional
+    retry_total : DEPRECATED int, optional
         A number indicating the maximum number of retries for 429, 502, 503, or
-        504 errors.
+        504 errors. This parameter no longer has any effect since v1.15.0,
+        as retries are automatically handled. This parameter will be removed
+        at version 2.0.0.
     api_version : string, optional
         The version of endpoints to call. May instantiate multiple client
         objects with different versions. Currently only "1.0" is supported.
@@ -379,10 +381,16 @@ class APIClient(MetaMixin):
         a local cache of the specification may be passed as either an
         OrderedDict or a filename which points to a json file.
     """
-    @deprecate_param('v2.0.0', 'resources')
+    @deprecate_param('v2.0.0', 'retry_total', 'resources')
     def __init__(self, api_key=None, return_type='snake',
                  retry_total=6, api_version="1.0", resources="all",
                  local_api_spec=None):
+        if retry_total != 6:
+            warnings.warn(
+                "Setting the retry_total parameter no longer has any effect, "
+                "as retries are now handled automatically.",
+                FutureWarning
+            )
         if return_type not in ['snake', 'raw', 'pandas']:
             raise ValueError("Return type must be one of 'snake', 'raw', "
                              "'pandas'")


### PR DESCRIPTION
civis-python v1.15.0, released in Sept 2020, reworked the retry logic (https://github.com/civisanalytics/civis-python/pull/401), which made the `retry_total` parameter of `civis.APIClient` actually not used by anything. This present PR officially deprecates this parameter.