### PR TITLE
[APIC-66] ENH add job and run IDs as custom headers in API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Added job ID and run ID as custom headers in API calls (#437)
 - Added support for Python 3.9 (#436)
 - Added job ID and run ID to the exception message of `CivisJobFailure`
   coming from a `CivisFuture` object (#426)

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -60,8 +60,8 @@ def open_session(api_key, user_agent="civis-python"):
     user_agent = "{}/Python v{} Civis v{} {}".format(
         user_agent, ver_string, civis_version, session_agent)
     session.headers.update({"User-Agent": user_agent.strip(),
-                            "X-Job-ID": str(os.getenv("CIVIS_JOB_ID")),
-                            "X-Run-ID": str(os.getenv("CIVIS_RUN_ID"))})
+                            "X-Civis-Job-ID": str(os.getenv("CIVIS_JOB_ID")),
+                            "X-Civis-Run-ID": str(os.getenv("CIVIS_RUN_ID"))})
 
     return session
 

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -62,8 +62,7 @@ def open_session(api_key, user_agent="civis-python"):
     headers = {"User-Agent": user_agent.strip()}
     job_id, run_id = os.getenv("CIVIS_JOB_ID"), os.getenv("CIVIS_RUN_ID")
     if job_id:
-        headers.update({"X-Civis-Job-ID": str(job_id),
-                        "X-Civis-Run-ID": str(run_id)})
+        headers.update({"X-Civis-Job-ID": job_id, "X-Civis-Run-ID": run_id})
     session.headers.update(headers)
 
     return session

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -59,9 +59,12 @@ def open_session(api_key, user_agent="civis-python"):
                                    sys.version_info.micro)
     user_agent = "{}/Python v{} Civis v{} {}".format(
         user_agent, ver_string, civis_version, session_agent)
-    session.headers.update({"User-Agent": user_agent.strip(),
-                            "X-Civis-Job-ID": str(os.getenv("CIVIS_JOB_ID")),
-                            "X-Civis-Run-ID": str(os.getenv("CIVIS_RUN_ID"))})
+    headers = {"User-Agent": user_agent.strip()}
+    job_id, run_id = os.getenv("CIVIS_JOB_ID"), os.getenv("CIVIS_RUN_ID")
+    if job_id:
+        headers.update({"X-Civis-Job-ID": str(job_id),
+                        "X-Civis-Run-ID": str(run_id)})
+    session.headers.update(headers)
 
     return session
 

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -59,7 +59,9 @@ def open_session(api_key, user_agent="civis-python"):
                                    sys.version_info.micro)
     user_agent = "{}/Python v{} Civis v{} {}".format(
         user_agent, ver_string, civis_version, session_agent)
-    session.headers.update({"User-Agent": user_agent.strip()})
+    session.headers.update({"User-Agent": user_agent.strip(),
+                            "X-Job-ID": str(os.getenv("CIVIS_JOB_ID")),
+                            "X-Run-ID": str(os.getenv("CIVIS_RUN_ID"))})
 
     return session
 


### PR DESCRIPTION
This PR adds job and run IDs as custom headers in API calls, so that jobs and runs are more easily identifiable by their IDs through Civis Platform's logging.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
