### PR TITLE
[CIVIS-1614] DOC specify response type in Returns documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-- Added the type of `civis.Response` in the API resources documentation (#438)
+- Added the type of `civis.Response` returned in the API resources documentation (#438)
 - Added support for Python 3.9 (#436)
 - Added job ID and run ID to the exception message of `CivisJobFailure`
   coming from a `CivisFuture` object (#426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Added the type of `civis.Response` in the API resources documentation (#438)
 - Added support for Python 3.9 (#436)
 - Added job ID and run ID to the exception message of `CivisJobFailure`
   coming from a `CivisFuture` object (#426)

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -155,11 +155,11 @@ def doc_from_responses(responses, is_iterable):
     properties = get_properties(schema)
     if properties:
         if is_iterable:
-            resp_type = "civis.response.PaginatedResponse\n"
+            resp_type = ":class:`civis.response.PaginatedResponse`\n"
         else:
-            resp_type = "civis.response.Response\n"
+            resp_type = ":class:`civis.response.Response`\n"
         result_doc = resp_type + (
-            "\n".join(docs_from_properties(properties)))
+            "\n".join(docs_from_properties(properties, level=1)))
     else:
         description = response_object['description']
         result_doc_fmt = "None\n    Response code {}: {}"

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -16,27 +16,27 @@ with open(TEST_SPEC) as f:
 RESPONSE_DOC = (
 """Returns
 -------
-civis.response.Response
-id : integer
-    The ID of the credential.
-name : string
-    The name identifying the credential
-type : string
-    The credential's type.
-username : string
-    The username for the credential.
-description : string
-    A long description of the credential.
-owner : string
-    The name of the user who this credential belongs to.
-remote_host_id : integer
-    The ID of the remote host associated with this credential.
-remote_host_name : string
-    The name of the remote host associated with this credential.
-created_at : string/time
-    The creation time for this credential.
-updated_at : string/time
-    The last modification time for this credential.""")  # noqa: E122
+:class:`civis.response.Response`
+    - id : integer
+        The ID of the credential.
+    - name : string
+        The name identifying the credential
+    - type : string
+        The credential's type.
+    - username : string
+        The username for the credential.
+    - description : string
+        A long description of the credential.
+    - owner : string
+        The name of the user who this credential belongs to.
+    - remote_host_id : integer
+        The ID of the remote host associated with this credential.
+    - remote_host_name : string
+        The name of the remote host associated with this credential.
+    - created_at : string/time
+        The creation time for this credential.
+    - updated_at : string/time
+        The last modification time for this credential.""")  # noqa: E122
 
 
 def test_create_method_iterator_kwarg():

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -16,6 +16,7 @@ with open(TEST_SPEC) as f:
 RESPONSE_DOC = (
 """Returns
 -------
+civis.response.Response
 id : integer
     The ID of the credential.
 name : string
@@ -137,7 +138,7 @@ def test_deprecated_notice_handles_none():
 
 def test_doc_from_responses():
     responses = OrderedDict([('200', OrderedDict([('description', 'success'), ('schema', OrderedDict([('type', 'array'), ('items', OrderedDict([('type', 'object'), ('properties', OrderedDict([('id', OrderedDict([('description', 'The ID of the credential.'), ('type', 'integer')])), ('name', OrderedDict([('description', 'The name identifying the credential'), ('type', 'string')])), ('type', OrderedDict([('description', "The credential's type."), ('type', 'string')])), ('username', OrderedDict([('description', 'The username for the credential.'), ('type', 'string')])), ('description', OrderedDict([('description', 'A long description of the credential.'), ('type', 'string')])), ('owner', OrderedDict([('description', 'The name of the user who this credential belongs to.'), ('type', 'string')])), ('remoteHostId', OrderedDict([('description', 'The ID of the remote host associated with this credential.'), ('type', 'integer')])), ('remoteHostName', OrderedDict([('description', 'The name of the remote host associated with this credential.'), ('type', 'string')])), ('createdAt', OrderedDict([('description', 'The creation time for this credential.'), ('type', 'string'), ('format', 'time')])), ('updatedAt', OrderedDict([('description', 'The last modification time for this credential.'), ('type', 'string'), ('format', 'time')]))]))]))]))]))])  # noqa: E501
-    x = _resources.doc_from_responses(responses)
+    x = _resources.doc_from_responses(responses, False)
     assert x == RESPONSE_DOC
 
 


### PR DESCRIPTION
Ticket: https://civisanalytics.atlassian.net/browse/CIVIS-1614

These changes are to specify the civis response type (regular vs paginated) in https://civis-python.readthedocs.io/en/v1.15.1/api_resources.html

TODO: update CHANGELOG, if this implementation is good. 
