### PR TITLE
[CIVIS-1510] DOC call out `joblib.Parallel`'s `pre_dispatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added default values from swagger in client method's signature (#417)
 
 ### Changed
+- Called out the fact that `joblib.Parallel`'s `pre_dispatch` defaults to `"2*n_jobs"`
+  in the Sphinx docs (#443)
 - Updated `civis_api_spec.json`, moved it to under `civis/resources/`, and checked in
   a script to facilitate updating it again (#440, #441)
 - Bumped version numbers for dependencies to allow their latest major releases (#436)

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -96,10 +96,13 @@ You can find more about custom joblib backends in the
 
 Note that :class:`joblib.Parallel` takes both a ``n_jobs`` and ``pre_dispatch``
 parameter. The Civis joblib backend doesn't queue submitted jobs itself,
-so it will run ``pre_dispatch`` jobs at once. The default value of
-``pre_dispatch`` is "2*n_jobs", which will run a maximum of ``2 * n_jobs`` jobs
-at once in the Civis Platform. Set ``pre_dispatch="n_jobs"`` in your
-:class:`~joblib.Parallel` call to run at most ``n_jobs`` jobs.
+so it will run ``pre_dispatch`` jobs at once.
+
+.. note::
+    The default value of
+    ``pre_dispatch`` is ``"2*n_jobs"``, which will run a maximum of ``2 * n_jobs`` jobs
+    at once on Civis Platform. Set ``pre_dispatch="n_jobs"`` in your
+    :class:`joblib.Parallel` call to run at most ``n_jobs`` jobs.
 
 The Civis joblib backend uses `cloudpickle <https://github.com/cloudpipe/cloudpickle>`_
 to transport code and data from the parent environment to the Civis Platform.


### PR DESCRIPTION
This PR calls out the default value of `joblib.Parallel`'s `pre_dispatch` to be `"2*n_jobs"` (not `"n_jobs"`) in the Sphinx docs.

Closes #361 

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
