### PR TITLE
[CIVIS-1851] DOC update info about MacOS shell config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to use joblib 1.1.x (#429)
 
 ### Fixed
+- Updated info about MacOS shell configuration file to be `~/.zshrc` (#444)
 - Fixed the Sphinx docs to show details of multi-word API endpoints (#442)
 - Dropped the buggy/unnecessary `_get_headers` in `civis.io.read_civis_sql` (#415) 
 - Clarified the `table_columns` parameter in `civis.io.*` functions (#434)

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ follow the steps below for your operating system to set up your environment.
 Linux / MacOS
 ~~~~~~~~~~~~~
 
-1. Add the following to your shell configuration file (``.zshrc`` for MacOS or ``.bashrc`` for Linux, by default)::
+1. Add the following to your shell configuration file (``~/.zshrc`` for MacOS or ``~/.bashrc`` for Linux, by default)::
 
     export CIVIS_API_KEY="alphaNumericApiK3y"
 

--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,11 @@ follow the steps below for your operating system to set up your environment.
 Linux / MacOS
 ~~~~~~~~~~~~~
 
-1. Add the following to ``.bash_profile`` (or ``.bashrc`` for Linux) for bash::
+1. Add the following to your shell configuration file (``.zshrc`` for MacOS or ``.bashrc`` for Linux, by default)::
 
     export CIVIS_API_KEY="alphaNumericApiK3y"
 
-2. Source your ``.bash_profile`` (or restart your terminal).
+2. Source your shell configuration file (or restart your terminal).
 
 Windows 10
 ~~~~~~~~~~

--- a/examples/PythonAPIClientDemo.ipynb
+++ b/examples/PythonAPIClientDemo.ipynb
@@ -1574,10 +1574,10 @@
     "\n",
     "Keep your API keys safe! Don’t check the key into GitHub or share in plaintext. If you do, immediately cancel the API key from the user profile page and contact support@civisanalytics.com .\n",
     "\n",
-    "You can add your API keys to your bash profile files (OSX or Linux) using a text editor of your choice. An example is included below in emacs:\n",
+    "You can add your API keys to your shell configuration file (`~/.zshrc` MacOS or `~/.bashrc` Linux by default) using a text editor of your choice. An example is included below in emacs:\n",
     "\n",
     "```\n",
-    "emacs .bash_profile\n",
+    "emacs <path-to-your-shell-config-file>\n",
     "```\n",
     "\n",
     "Make a new line and enter this:\n",
@@ -1591,7 +1591,7 @@
     "Then run:\n",
     "\n",
     "```\n",
-    "source .bash_profile\n",
+    "source <path-to-your-shell-config-file>\n",
     "```"
    ]
   },


### PR DESCRIPTION
MacOS has switched to ZSH as the default shell, but our docs still mention `.bash_profile` for the API key set-up. This PR updates the docs.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
