### PR TITLE
[CIVIS-1509] DOC improve documentation of input to `civis.io.civis_file_to_table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated the docstrings for `file_to_civis` (for `buf` and `expires_at`),
   `dataframe_to_file` (for `expires_at`), and `json_to_file` (for `expires_at`). (#427)
 - Ability to use joblib 1.1.x (#429)
+- Explicitly stated CSV-like civis file format requirement in 
+  `civis.io.civis_file_to_table`'s docstring (#422)
 
 ### Fixed
 - Fixed the Sphinx docs to show details of multi-word API endpoints (#442)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -918,10 +918,12 @@ def civis_file_to_table(file_id, database, table, client=None,
                         credential_id=None, polling_interval=None,
                         hidden=True):
     """Upload the contents of one or more Civis files to a Civis table.
-       All provided files will be loaded as an atomic unit in parallel, and
-       should share the same columns in the same order, and be in the same
-       format. Civis files cannot be in JSON like format and must be separated by 
-       a delimiter.
+    All provided files will be loaded as an atomic unit in parallel, and
+    should share the same columns in the same order, and be in the same
+    format. 
+    
+    .. note::
+        Civis files must be in a CSV-like delimiter separated format.
 
     Parameters
     ----------

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -920,7 +920,8 @@ def civis_file_to_table(file_id, database, table, client=None,
     """Upload the contents of one or more Civis files to a Civis table.
        All provided files will be loaded as an atomic unit in parallel, and
        should share the same columns in the same order, and be in the same
-       format.
+       format. Civis files cannot be in JSON like format and must be separated by 
+       a delimiter.
 
     Parameters
     ----------

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -920,8 +920,8 @@ def civis_file_to_table(file_id, database, table, client=None,
     """Upload the contents of one or more Civis files to a Civis table.
     All provided files will be loaded as an atomic unit in parallel, and
     should share the same columns in the same order, and be in the same
-    format. 
-    
+    format.
+
     .. note::
         Civis files must be in a CSV-like delimiter separated format.
 


### PR DESCRIPTION
This PR makes explicit the implicit requirement that Civis files in civis.io.civis_file_to_table must be in CSV-like format.

Closes #422 

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed

Screenshot of changes:

<img width="763" alt="Screen Shot 2021-12-08 at 4 04 54 PM" src="https://user-images.githubusercontent.com/41135406/145285497-26726a29-68db-47a9-86f2-45da25b149e3.png">

