### PR TITLE
[CIVIS-1678] MAINT turn on security checks with `safety` and `bandit`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,26 @@ workflows:
             python setup.py sdist bdist_wheel && \
             twine check dist/`ls dist/ | grep .tar.gz` && \
             twine check dist/`ls dist/ | grep .whl`
+      - pre-build:
+          name: safety
+          command-run: |
+            pip install -e . && \
+            pip install --upgrade safety && \
+            safety --version && \
+            safety check
+      - pre-build:
+          name: bandit
+          command-run: |
+            pip install --upgrade bandit && \
+            bandit --version && \
+            bandit -r civis -x civis/tests
       - build-python:
           requires:
             - flake8
             - sphinx-build
             - twine
+            - safety
+            - bandit
           matrix:
             parameters:
               python-version: ["3.7", "3.8", "3.9"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
           command-run: |
             pip install --upgrade bandit && \
             bandit --version && \
-            bandit -r civis -x civis/tests
+            bandit -r civis -x civis/tests,civis/ml/tests
       - build-python:
           requires:
             - flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added default values from swagger in client method's signature (#417)
 
 ### Changed
+- Explicitly stated CSV-like civis file format requirement in 
+  `civis.io.civis_file_to_table`'s docstring (#445)
 - Called out the fact that `joblib.Parallel`'s `pre_dispatch` defaults to `"2*n_jobs"`
   in the Sphinx docs (#443)
 - Updated `civis_api_spec.json`, moved it to under `civis/resources/`, and checked in
@@ -27,8 +29,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated the docstrings for `file_to_civis` (for `buf` and `expires_at`),
   `dataframe_to_file` (for `expires_at`), and `json_to_file` (for `expires_at`). (#427)
 - Ability to use joblib 1.1.x (#429)
-- Explicitly stated CSV-like civis file format requirement in 
-  `civis.io.civis_file_to_table`'s docstring (#422)
 
 ### Fixed
 - Updated info about MacOS shell configuration file to be `~/.zshrc` (#444)
@@ -45,6 +45,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Dropped support for Python 3.6 (#436)
 - Removed no-longer-used PubNub code (#425)
 - Removed no-longer-supported Python 2 option for notebook creation in the CLI (#421)
+
+### Security
+- Turned on `safety` and `bandit` checks at CircleCI builds (#446)
 
 ## 1.15.1 - 2020-10-28
 ### Fixed

--- a/civis/_utils.py
+++ b/civis/_utils.py
@@ -147,7 +147,7 @@ def retry(exceptions, retries=5, delay=0.5, backoff=2):
                         time.sleep(new_delay)
                         new_delay = min(
                             (pow(2, n_failed) / 4) *
-                            (random() + backoff), 50 + 10 * random()
+                            (random() + backoff), 50 + 10 * random()  # nosec
                         )
                     else:
                         raise exc

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -135,8 +135,10 @@ def _multipart_upload(buf, name, file_size, client, **kwargs):
 
     # Platform will give us a URL for each file part
     urls = file_response.upload_urls
-    assert num_parts == len(urls), \
-        "There are {} file parts but only {} urls".format(num_parts, len(urls))
+    if num_parts != len(urls):
+        raise ValueError(
+            f"There are {num_parts} file parts but only {len(urls)} urls"
+        )
 
     # upload function wrapped with a retry decorator
     @retry(RETRY_EXCEPTIONS)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1151,7 +1151,7 @@ def _get_sql_select(table, columns=None):
     if columns and not isinstance(columns, (list, tuple)):
         raise TypeError("columns must be a list, tuple or None")
     select = ", ".join(columns) if columns is not None else "*"
-    sql = "select {} from {}".format(select, table)
+    sql = "select {} from {}".format(select, table)  # nosec
     return sql
 
 

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from io import BytesIO
 import logging
 import os
-import pickle
+import pickle  # nosec
 from tempfile import TemporaryDirectory
 import time
 import warnings

--- a/civis/run_joblib_func.py
+++ b/civis/run_joblib_func.py
@@ -11,7 +11,7 @@ will be set as an output on this run.
 from datetime import datetime, timedelta
 from io import BytesIO
 import os
-import pickle
+import pickle  # nosec
 import sys
 import warnings
 


### PR DESCRIPTION
This PR turns on security checks with `safety` and `bandit`. The checks are run on CircleCI builds.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
