### PR TITLE
[CIVIS-1869] DOC Add confirmation of compressed file usage in civis_file_to_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added default values from swagger in client method's signature (#417)
 
 ### Changed
+- Specified that `civis.io.civis_file_to_table` can handle compressed files (#450)
 - Explicitly stated CSV-like civis file format requirement in 
   `civis.io.civis_file_to_table`'s docstring (#445)
 - Called out the fact that `joblib.Parallel`'s `pre_dispatch` defaults to `"2*n_jobs"`

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -928,7 +928,9 @@ def civis_file_to_table(file_id, database, table, client=None,
     format.
 
     .. note::
-        Civis files must be in a CSV-like delimiter separated format.
+        Civis files must be in a CSV-like delimiter separated format and
+        will be accepted in both uncompressed and compressed format
+        (.zip, .gz).
 
     Parameters
     ----------


### PR DESCRIPTION
Tested and confirmed that .gz files can be used in civis.io.civis_file_to_table and added a section to the docstring.
<img width="769" alt="CIVIS1869" src="https://user-images.githubusercontent.com/41135406/147985331-447d3eda-c4ce-4314-bcf6-10b2757283cd.png">

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
