### PR TITLE
[APIC-296] MAINT Python client's file_to_civis should not warn about file size of 0 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added default values from swagger in client method's signature (#417)
 
 ### Changed
+- Added a warning message when using `civis.io.file_to_civis` with file size of 0 bytes (#451)
 - Specified that `civis.io.civis_file_to_table` can handle compressed files (#450)
 - Explicitly stated CSV-like civis file format requirement in 
   `civis.io.civis_file_to_table`'s docstring (#445)

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -292,7 +292,9 @@ def _file_to_civis(buf, name, api_key=None, client=None, **kwargs):
         client = APIClient(api_key=api_key)
 
     file_size = _buf_len(buf)
-    if not file_size:
+    if file_size == 0:
+        log.warning('Warning: file size is zero bytes.')
+    elif not file_size:
         log.warning('Could not determine file size; defaulting to '
                     'single post. Files over 5GB will fail.')
 


### PR DESCRIPTION
- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [ ] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed

This change adds logic to the civis.io.file_to_civis function that warns the user if they are using the function on a file with a size of zero bytes.


