### PR TITLE
[CIVIS-2263] ENH Add a data type guardrail for `civis.io.civis_file_to_table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+- Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)
+
 ### Changed
 - Clarified the usage example for `civis.io.civis_to_multifile_csv`. Updated 
   circleci config so dev-requirements is only used when needed. (#452)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1033,6 +1033,9 @@ def civis_file_to_table(file_id, database, table, client=None,
     if client is None:
         client = APIClient()
 
+    if type(file_id) == 'str':
+        raise TypeError('Invalid type for file_id: str')
+
     schema, table_name = split_schema_tablename(table)
     if isinstance(file_id, int):
         file_id = [file_id]

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1033,7 +1033,7 @@ def civis_file_to_table(file_id, database, table, client=None,
     if client is None:
         client = APIClient()
 
-    if type(file_id) == 'str':
+    if type(file_id) == str:
         raise TypeError('Invalid type for file_id: str')
 
     schema, table_name = split_schema_tablename(table)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -1021,6 +1021,10 @@ def civis_file_to_table(file_id, database, table, client=None,
         import. This may be the case if their columns have different types,
         their delimiters are different, headers are present in some but not
         others, or compressions do not match.
+    TypeError
+        If the type of the file_id parameter is a string. This situation may
+        arise when the file ID comes from an environment variable and is not
+        cast from string to integer before being passed to civis_file_to_table.
 
     Examples
     --------
@@ -1034,7 +1038,8 @@ def civis_file_to_table(file_id, database, table, client=None,
         client = APIClient()
 
     if type(file_id) == str:
-        raise TypeError('Invalid type for file_id: str')
+        raise TypeError("Invalid type for file_id: str. "
+                        "Must be int or list[int]")
 
     schema, table_name = split_schema_tablename(table)
     if isinstance(file_id, int):


### PR DESCRIPTION
- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed

Added a data type guardrail in civis.io.civis_file_to_table that raises a type error if file_id is a string.