### PR TITLE
[CIVIS-3365] TST mark CivisML smoke test as non-usage related

### DIFF
--- a/tools/smoke_tests.py
+++ b/tools/smoke_tests.py
@@ -85,6 +85,7 @@ def main():
     for civisml_version in (None, 'v2.2'):  # None = latest production version
         logger.info('CivisML version: %r', civisml_version)
         mp = civis.ml.ModelPipeline(
+            model_name="[civis-python smoke test; do not count this as CivisML usage]",
             model="sparse_logistic",
             dependent_variable="type",
             primary_key="index",


### PR DESCRIPTION
The civis-python smoke tests on Civis Platform run two CivisML training jobs. It's come to my attention that these CivisML jobs have confused our internal product team, since these jobs are incorrectly counted as genuine CivisML usage. This PR explicitly marks these CivisML jobs launched by civis-python smoke tests as unrelated. I've just tested this change and everything worked as expected and desired:

![Screen Shot 2022-09-01 at 9 25 48 AM](https://user-images.githubusercontent.com/86482098/187926144-f531ceb6-aa36-4a07-bdaf-89d7b8ccf364.png)

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
