### PR TITLE
[CIVIS-1972] BUG catch empty API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   circleci config so dev-requirements is only used when needed. (#452)
 - Removed unneeded time.sleep calls and pytest.mark calls and mocked time.sleep calls to optimize tests. (#453)
 - Fixed typo in "Testing Your Code" example of the User Guide (#458)
+- Adding try-except to catch JSONDecodeErrors in CivisAPIError (#459)
 
 ### Deprecated
 ### Removed

--- a/civis/base.py
+++ b/civis/base.py
@@ -61,7 +61,7 @@ class CivisAPIError(Exception):
                 json = response.json()
             except JSONDecodeError as e:
                 if "Expecting value: line 1 column 1 (char 0)" in str(e):
-                    self.error_message = "No Response from Civis API"
+                    self.error_message = "No Response Content from Civis API"
                 else:
                     self.error_message = f"Response Content: " \
                                     f"{(response.content or b'').decode()}"

--- a/civis/base.py
+++ b/civis/base.py
@@ -63,9 +63,11 @@ class CivisAPIError(Exception):
                 if "Expecting value: line 1 column 1 (char 0)" in str(e):
                     self.error_message = "No Response from Civis API"
                 else:
-                    self.error_message = f"Response Content: {(response.content or b'').decode()}"
+                    self.error_message = f"Response Content: " \
+                                    f"{(response.content or b'').decode()}"
             else:
-                self.error_message = json.get("errorDescription") or "No Error Message Available"
+                self.error_message = json.get("errorDescription") or \
+                                     "No Error Message Available"
         else:  # this was something like a 502
             self.error_message = response.reason
 

--- a/civis/base.py
+++ b/civis/base.py
@@ -60,7 +60,7 @@ class CivisAPIError(Exception):
             try:
                 json = response.json()
             except JSONDecodeError as e:
-                if "Expecting value: line 1 column 1 (char 0)" in e:
+                if "Expecting value: line 1 column 1 (char 0)" in str(e):
                     self.error_message = "No Response from Civis API"
                 else:
                     self.error_message = f"Response Content: {(response.content or b'').decode()}"

--- a/civis/base.py
+++ b/civis/base.py
@@ -59,13 +59,13 @@ class CivisAPIError(Exception):
         if response.content:  # the API itself gave an error response
             try:
                 json = response.json()
-                self.error_message = json["errorDescription"]
             except JSONDecodeError as e:
                 if "Expecting value: line 1 column 1 (char 0)" in e:
                     self.error_message = "No Response from Civis API"
                 else:
-                    json = response.json()
-                    self.error_message = json["errorDescription"]
+                    self.error_message = f"Response Content: {(response.content or b'').decode()}"
+            else:
+                self.error_message = json.get("errorDescription") or "No Error Message Available"
         else:  # this was something like a 502
             self.error_message = response.reason
 

--- a/civis/tests/test_base.py
+++ b/civis/tests/test_base.py
@@ -41,7 +41,9 @@ def test_civis_api_error_empty_response():
     # Fake response object, try to trigger error
     # Make sure response.json() gets the JSON decode error
     response = requests.Response()
+    response._content = b'foobar'
     with pytest.raises(JSONDecodeError):
         response.json()
 
     error = CivisAPIError(response)
+    assert error.error_message == "No Response from Civis API"

--- a/civis/tests/test_base.py
+++ b/civis/tests/test_base.py
@@ -46,4 +46,4 @@ def test_civis_api_error_empty_response():
         response.json()
 
     error = CivisAPIError(response)
-    assert error.error_message == "No Response from Civis API"
+    assert error.error_message == "No Response Content from Civis API"

--- a/civis/tests/test_base.py
+++ b/civis/tests/test_base.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import requests
 
-from civis.base import Endpoint, get_base_url
+from civis.base import Endpoint, get_base_url, CivisAPIError
 
 
 def test_base_url_default():
@@ -33,3 +33,7 @@ def test_store_last_response():
     resp = endpoint._call_api('GET')
     assert resp == returned_resp
     assert mock_client.last_response is resp
+
+
+def test_civis_api_error_empty_response():
+    returned_resp = {'errorDescription': 'Expecting value: line 1 column 1 (char 0)', 'content': ' '}

--- a/civis/tests/test_base.py
+++ b/civis/tests/test_base.py
@@ -1,5 +1,7 @@
 from unittest import mock
+from json.decoder import JSONDecodeError
 
+import pytest
 import requests
 
 from civis.base import Endpoint, get_base_url, CivisAPIError
@@ -36,4 +38,10 @@ def test_store_last_response():
 
 
 def test_civis_api_error_empty_response():
-    returned_resp = {'errorDescription': 'Expecting value: line 1 column 1 (char 0)', 'content': ' '}
+    # Fake response object, try to trigger error
+    # Make sure response.json() gets the JSON decode error
+    response = requests.Response()
+    with pytest.raises(JSONDecodeError):
+        response.json()
+
+    error = CivisAPIError(response)

--- a/tools/smoke_tests.py
+++ b/tools/smoke_tests.py
@@ -85,7 +85,8 @@ def main():
     for civisml_version in (None, 'v2.2'):  # None = latest production version
         logger.info('CivisML version: %r', civisml_version)
         mp = civis.ml.ModelPipeline(
-            model_name="[civis-python smoke test; do not count this as CivisML usage]",
+            model_name="[civis-python smoke test; do not count this as "
+                       "CivisML usage]",
             model="sparse_logistic",
             dependent_variable="type",
             primary_key="index",

--- a/tools/smoke_tests.py
+++ b/tools/smoke_tests.py
@@ -85,8 +85,7 @@ def main():
     for civisml_version in (None, 'v2.2'):  # None = latest production version
         logger.info('CivisML version: %r', civisml_version)
         mp = civis.ml.ModelPipeline(
-            model_name="[civis-python smoke test; do not count this as "
-                       "CivisML usage]",
+            model_name="[civis-python smoke test; do not count this as CivisML usage]",
             model="sparse_logistic",
             dependent_variable="type",
             primary_key="index",


### PR DESCRIPTION
Wrapped response.json() in a try-except to catch JSONDecodeErrors in CivisAPIError.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
