### PR TITLE
[CIVIS-1767] MAINT support Python 3.10 and 3.11, drop 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         type: string
     docker:
       # Pick the highest Python 3.x version that civis-python is known to support
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run:
@@ -100,4 +100,4 @@ workflows:
             - bandit
           matrix:
             parameters:
-              python-version: ["3.7", "3.8", "3.9"]
+              python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)
+- Added support for Python 3.10 and 3.11 (#462)
 
 ### Changed
 - Updated references from 'master' to 'main' (#460)
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 ### Removed
+- Dropped support for Python 3.7 (#462)
+
 ### Fixed
 ### Security
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,7 @@ sphinx_rtd_theme==1.0.0
 numpydoc==1.1.0
 
 # CivisML
-numpy==1.22.0; python_version >= "3.8"
-numpy==1.21.6; python_version < "3.8"
+numpy==1.22.0
 scikit-learn==1.0.1
 scipy==1.7.2
 feather-format==0.4.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,9 +6,9 @@ twine==4.0.2
 pandas==1.5.3
 
 # Docs
-Sphinx==4.3.0
-sphinx_rtd_theme==1.0.0
-numpydoc==1.1.0
+Sphinx==6.1.3
+sphinx-rtd-theme==1.2.0
+numpydoc==1.5.0
 
 # CivisML
 numpy==1.24.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 # Testing and linting
-pytest==6.2.5
-flake8==4.0.1
-pytest-cov==3.0.0
-twine==3.6.0
-pandas==1.3.4
+pytest==7.2.1
+flake8==6.0.0
+pytest-cov==4.0.0
+twine==4.0.2
+pandas==1.5.3
 
 # Docs
 Sphinx==4.3.0
@@ -11,7 +11,7 @@ sphinx_rtd_theme==1.0.0
 numpydoc==1.1.0
 
 # CivisML
-numpy==1.22.0
-scikit-learn==1.0.1
-scipy==1.7.2
+numpy==1.24.2
+scikit-learn==1.2.1
+scipy==1.10.0
 feather-format==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pyyaml>=3.0,<7
-click>=6.0,<9
-jsonref>=0.1,<=0.2.99
-requests>=2.12.0,<3
-jsonschema>=2.5.1,<5
-joblib>=0.11,<2
-cloudpickle>=0.2,<3
-tenacity>=6.2,<9
+PyYAML>=3.0
+click>=6.0
+jsonref>=0.1
+requests>=2.12.0
+jsonschema>=2.5.1
+joblib>=0.11
+cloudpickle>=0.2
+tenacity>=6.2

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,14 @@ from setuptools import find_packages, setup
 
 _THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
-PYTHON_REQUIRES = ">=3.7"
+PYTHON_REQUIRES = ">=3.8"
 CLASSIFIERS = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3 :: Only',
 ]
 


### PR DESCRIPTION
This PR turns on CircleCI builds for Python 3.10 and 3.11. We're also dropping Python 3.7.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
