### PR TITLE
1.16.1, pin joblib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Security
 
+## 1.16.1 - 2023-06-29
+### Changed
+- Require joblib <1.3
+
 ## 1.16.0 - 2021-12-14
 ### Added
 - Added documentation around testing code using mocking (#447)
@@ -29,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added default values from swagger in client method's signature (#417)
 
 ### Changed
-- Explicitly stated CSV-like civis file format requirement in 
+- Explicitly stated CSV-like civis file format requirement in
   `civis.io.civis_file_to_table`'s docstring (#445)
 - Called out the fact that `joblib.Parallel`'s `pre_dispatch` defaults to `"2*n_jobs"`
   in the Sphinx docs (#443)
@@ -49,7 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   has `VARCHAR` (#439)
 - Updated info about MacOS shell configuration file to be `~/.zshrc` (#444)
 - Fixed the Sphinx docs to show details of multi-word API endpoints (#442)
-- Dropped the buggy/unnecessary `_get_headers` in `civis.io.read_civis_sql` (#415) 
+- Dropped the buggy/unnecessary `_get_headers` in `civis.io.read_civis_sql` (#415)
 - Clarified the `table_columns` parameter in `civis.io.*` functions (#434)
 - Warned about the `retry_total` parameter of `civis.APIClient` being inactive and deprecated (#431)
 - Converted `assert` statements in non-test code into proper error handling (#430, #435)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ click>=6.0,<9
 jsonref>=0.1,<=0.2.99
 requests>=2.12.0,<3
 jsonschema>=2.5.1,<5
-joblib>=0.11,<2
+joblib>=0.11,<1.3.0
 cloudpickle>=0.2,<3
 tenacity>=6.2,<9


### PR DESCRIPTION
- [] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed

This is a patch release to set a maximum version on joblib, which introduced a breaking change in v1.3
