### PR TITLE
[CIVIS-6486] DEP limit `joblib` to `< 1.3.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,14 +78,6 @@ workflows:
             twine check dist/`ls dist/ | grep .tar.gz` && \
             twine check dist/`ls dist/ | grep .whl`
       - pre-build:
-          name: safety
-          command-run: |
-            pip install -e . && \
-            pip install --upgrade setuptools \
-            pip install --upgrade safety && \
-            safety --version && \
-            safety check
-      - pre-build:
           name: bandit
           command-run: |
             pip install --upgrade bandit && \
@@ -96,7 +88,6 @@ workflows:
             - flake8
             - sphinx-build
             - twine
-            - safety
             - bandit
           matrix:
             parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - civis.io.file_id_from_run_output now works for all job types (#461)
 - A nested `civis.response.Response` object now supports both snake-case and camel-case
   for key access. Previously, only the non-Pythonic camel-case keys were available. (#463)
+- Pinned the dependency `joblib` at `< 1.3.0`, since `joblib >= 1.3.0` is incompatible
+  with the current civis-python codebase. (#469)
 
 ### Deprecated
 ### Removed

--- a/civis/cli/_cli_commands.py
+++ b/civis/cli/_cli_commands.py
@@ -240,7 +240,7 @@ def notebooks_download_cmd(notebook_id, path):
     """Download a notebook to a specified local path."""
     client = civis.APIClient()
     info = client.notebooks.get(notebook_id)
-    response = requests.get(info['notebook_url'], stream=True)
+    response = requests.get(info['notebook_url'], stream=True, timeout=60)
     response.raise_for_status()
     chunk_size = 32 * 1024
     chunked = response.iter_content(chunk_size)

--- a/civis/io/_files.py
+++ b/civis/io/_files.py
@@ -110,7 +110,7 @@ def _single_upload(buf, name, client, **kwargs):
         # requests will not stream multipart/form-data, but _single_upload
         # is only used for small file objects or non-seekable file objects
         # which can't be streamed with using requests-toolbelt anyway
-        response = requests.post(url, files=form_key)
+        response = requests.post(url, files=form_key, timeout=60)
 
         if not response.ok:
             msg = _get_aws_error_message(response)
@@ -151,7 +151,8 @@ def _multipart_upload(buf, name, file_size, client, **kwargs):
         with open(file_path, 'rb') as fin:
             fin.seek(offset)
             partial_buf = BufferedPartialReader(fin, num_bytes)
-            part_response = requests.put(part_url, data=partial_buf)
+            part_response = requests.put(part_url, data=partial_buf,
+                                         timeout=60)
 
         if not part_response.ok:
             msg = _get_aws_error_message(part_response)
@@ -370,7 +371,7 @@ def _civis_to_file(file_id, buf, api_key=None, client=None):
         # Reset the buffer in case we had to retry.
         buf.seek(buf_orig_position)
 
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=60)
         response.raise_for_status()
         chunked = response.iter_content(CHUNK_SIZE)
         for lines in chunked:

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -347,7 +347,7 @@ def read_civis_sql(sql, database, use_pandas=False,
 
         data = pd.read_csv(url, **kwargs)
     else:
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=60)
         response.raise_for_status()
 
         with io.StringIO() as buf:
@@ -1196,7 +1196,7 @@ def _decompress_stream(response, buf, write_bytes=True, encoding="utf-8"):
 
 
 def _download_file(url, local_path, headers, compression):
-    response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True, timeout=60)
     response.raise_for_status()
 
     # gzipped buffers can be concatenated so write headers as gzip

--- a/civis/tests/test_io.py
+++ b/civis/tests/test_io.py
@@ -1272,7 +1272,7 @@ def test_civis_to_file_local(mock_requests):
             assert _fin.read() == 'abcdef'
     mock_civis.files.get.assert_called_once_with(137)
     mock_requests.get.assert_called_once_with(
-        mock_civis.files.get.return_value.file_url, stream=True)
+        mock_civis.files.get.return_value.file_url, stream=True, timeout=60)
 
 
 @mock.patch.object(_files, 'requests', autospec=True)
@@ -1312,7 +1312,7 @@ def test_civis_to_file_retries(mock_requests):
     mock_civis.files.get.assert_called_once_with(137)
     assert mock_requests.get.call_count == 2
     mock_requests.get.assert_called_with(
-         mock_civis.files.get.return_value.file_url, stream=True)
+         mock_civis.files.get.return_value.file_url, stream=True, timeout=60)
 
 
 @pytest.mark.parametrize('input_filename', ['newname', None])
@@ -1332,7 +1332,8 @@ def test_file_to_civis(mock_requests, input_filename):
     assert fid == expected_id
     mock_civis.files.post.assert_called_once_with(civis_name, expires_at=None)
     mock_requests.post.assert_called_once_with(
-        mock_civis.files.post.return_value.upload_url, files=mock.ANY)
+        mock_civis.files.post.return_value.upload_url, files=mock.ANY,
+        timeout=60)
 
 
 @pytest.mark.parametrize("table,expected", [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ click>=6.0
 jsonref>=0.1
 requests>=2.12.0
 jsonschema>=2.5.1
-joblib>=0.11
+joblib>=0.11,<1.3.0
 cloudpickle>=0.2
 tenacity>=6.2


### PR DESCRIPTION
Before this pull request, the `main` branch was broken because joblib >= 1.3.0 is incompatible with the current civis-python codebase, thereby making the test suite unable to run at all on CI. This pull request caps joblib to `< 1.3.0` so that the `main` branch is back to a healthy state for CI builds so as to not block other dev work on `main`.

Note that this pull request does not fully address the linked, internal ticket CIVIS-6486 (which has the goal of making civis-python compatible with joblib >= 1.3.0, something we aren't prioritizing at the moment), but is related to it.

Resolves #468.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
