### PR TITLE
[CIVIS-2571] DOC split "API Resources" page into individual endpoint pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ swagger.json
 
 # Sphinx docs
 docs/source/generated/
-docs/source/api_resources.rst
+docs/source/api_*.rst
 
 # IDEs
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Pinned the dependency `joblib` at `< 1.3.0`, since `joblib >= 1.3.0` is incompatible
   with the current civis-python codebase. (#469)
 - Changed `civis.io.civis_file_to_table` to not rely on table ids for determining a table's existence (#470)
+- Broke out the "API Resources" documentation page into individual endpoint pages (#471)
 
 ### Deprecated
 ### Removed

--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ To install dependencies for building the documentation::
 To build the API documentation locally::
 
     cd docs
-    make html
+    make html  # or run `FETCH_REMOTE_RESOURCES=true make html` for the API resources available to the given CIVIS_API_KEY
 
 Then open ``docs/build/html/index.html``.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -348,8 +348,8 @@ _autodoc_fmt = ('.. autoclass:: {}\n'
 
 
 def _write_resources_rst(class_names, filename, civis_module):
-    with open(filename, 'w') as _out:
-        _out.write(
+    with open(filename, 'w') as resources_rst_file:
+        resources_rst_file.write(
             ".. _api_resources:\n\n"
             "API Resources\n"
             "=============\n\n"
@@ -357,18 +357,18 @@ def _write_resources_rst(class_names, filename, civis_module):
             "   :titlesonly:\n\n"
         )
         for class_name in class_names:
-            endpoint_rst = f"api_{class_name.lower()}_endpoint.rst"
-            _out.write(f"   {endpoint_rst.replace('.rst', '')}\n")
-            with open(endpoint_rst, "w") as endpoint_rst_file:
+            endpoint_rst_filename_no_ext = f"api_{class_name.lower()}_endpoint"
+            endpoint_rst_filename = f"{endpoint_rst_filename_no_ext}.rst"
+            resources_rst_file.write(f"   {endpoint_rst_filename_no_ext}\n")
+            with open(endpoint_rst_filename, "w") as endpoint_rst_file:
                 endpoint_rst_file.write(
-                    f".. _{endpoint_rst.replace('.rst', '')}:\n\n"
+                    f".. _{endpoint_rst_filename_no_ext}:\n\n"
                 )
-                name = class_name.title()
-                full_path = '.'.join((civis_module, name))
+                endpoint_name = class_name.title()
+                full_path = '.'.join((civis_module, endpoint_name))
                 endpoint_rst_file.write(
-                    f"{name}\n"
-                    f"{'=' * len(name)}\n\n"
-                    f"The ``{name}`` endpoint.\n\n"
+                    f"{endpoint_name}\n"
+                    f"{'=' * len(endpoint_name)}\n\n"
                 )
                 endpoint_rst_file.write(_autodoc_fmt.format(full_path, full_path))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -349,22 +349,41 @@ _autodoc_fmt = ('.. autoclass:: {}\n'
 
 def _write_resources_rst(class_names, filename, civis_module):
     with open(filename, 'w') as _out:
-        _out.write('.. _api_resources:\n\nAPI Resources\n=============\n\n')
+        _out.write(
+            ".. _api_resources:\n\n"
+            "API Resources\n"
+            "=============\n\n"
+            ".. toctree::\n"
+            "   :titlesonly:\n\n"
+        )
         for class_name in class_names:
-            name = class_name.title()
-            header = '`{}`\n{}\n'.format(name, '"' * (len(name) + 2))
-            full_path = '.'.join((civis_module, name))
-            _out.write(header)
-            _out.write(_autodoc_fmt.format(full_path, full_path))
+            endpoint_rst = f"api_{class_name.lower()}_endpoint.rst"
+            _out.write(f"   {endpoint_rst.replace('.rst', '')}\n")
+            with open(endpoint_rst, "w") as endpoint_rst_file:
+                endpoint_rst_file.write(
+                    f".. _{endpoint_rst.replace('.rst', '')}:\n\n"
+                )
+                name = class_name.title()
+                full_path = '.'.join((civis_module, name))
+                endpoint_rst_file.write(
+                    f"{name}\n"
+                    f"{'=' * len(name)}\n\n"
+                    f"The ``{name}`` endpoint.\n\n"
+                )
+                endpoint_rst_file.write(_autodoc_fmt.format(full_path, full_path))
 
 
 import civis
 _generated_attach_point = civis.resources._resources
 _generated_attach_path = 'civis.resources._resources'
 _rst_basename = 'api_resources.rst'
-_test_build = os.getenv('CIRCLECI') == 'true' or _on_rtd
 
-if _test_build:
+if os.getenv("FETCH_REMOTE_RESOURCES", "false").lower() == "true":
+    api_key = os.environ.get("CIVIS_API_KEY")
+    api_version = "1.0"
+    extra_classes = civis.resources._resources.generate_classes(
+        api_key=api_key, api_version=api_version)
+else:
     import json
     from collections import OrderedDict
     from jsonref import JsonRef
@@ -379,12 +398,7 @@ if _test_build:
             json.load(_raw, object_pairs_hook=OrderedDict))
     extra_classes = civis.resources._resources.parse_api_spec(
         api_spec, '1.0', 'base')
-else:
-    api_key = os.environ.get("CIVIS_API_KEY")
-    user_agent = "civis-python/SphinxDocs"
-    api_version = "1.0"
-    extra_classes = civis.resources._resources.generate_classes(
-        api_key=api_key, api_version=api_version)
+
 sorted_class_names = sorted(extra_classes.keys())
 
 civis.APIClient.__doc__ += _make_attr_docs(sorted_class_names,


### PR DESCRIPTION
Before this pull request, the "API Resources" documentation page (from the auto-generated `api_resources.html`, compiled from the auto-generated `api_resources.rst` created by the Sphinx `conf.py` script) had all the endpoints and their methods included on one single page and therefore was slow to load and navigate. This pull request changes the "API Resources" page so that now it only shows the list of the endpoint names, and that each endpoint has its own separate page for details.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] The CircleCI builds have all passed
