### PR TITLE
[CIVIS-5257] RM deprecated parameters and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Instantiating a `civis.response.Response` object no longer
   accepts the boolean `snake_case` keyword argument;
   snake-case keys at a `Response` object are now always available (and preferred). (#463)
+- Parameters for various classes/functions that have long been deprecated are removed:
+  `api_key`, `resources`, `retry_total`, `archive`, `headers`.
+  Also dropped the deprecated methods in `ServiceClient`. (#471)
 
 ### Added
 - Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)

--- a/civis/base.py
+++ b/civis/base.py
@@ -2,7 +2,6 @@ import os
 from posixpath import join
 import threading
 from concurrent import futures
-import warnings
 from requests import Request
 from json.decoder import JSONDecodeError
 
@@ -169,9 +168,6 @@ class CivisAsyncResultBase(futures.Future):
     polling_interval : int or float
         The number of seconds between API requests to check whether a result
         is ready.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -181,16 +177,12 @@ class CivisAsyncResultBase(futures.Future):
         in `polling_interval` from object creation before polling.
     """
     def __init__(self, poller, poller_args,
-                 polling_interval=None, api_key=None, client=None,
+                 polling_interval=None, client=None,
                  poll_on_creation=True):
         super().__init__()
         self.poller = poller
         self.poller_args = poller_args
         self.polling_interval = polling_interval
-        if api_key is not None:
-            warnings.warn('The "api_key" parameter is deprecated and will be '
-                          'removed in v2. Please use the `client` parameter '
-                          'instead.', FutureWarning)
         self.client = client
         self.poll_on_creation = poll_on_creation
 

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -368,12 +368,6 @@ class APIClient(MetaMixin):
     api_version : string, optional
         The version of endpoints to call. May instantiate multiple client
         objects with different versions. Currently only "1.0" is supported.
-    resources : string, optional
-        When set to "base", only the default endpoints will be exposed in the
-        client object. Set to "all" to include all endpoints available for
-        a given user, including those that may be in development and subject
-        to breaking changes at a later date. This will be removed in a future
-        version of the API client.
     local_api_spec : collections.OrderedDict or string, optional
         The methods on this class are dynamically built from the Civis API
         specification, which can be retrieved from the /endpoints endpoint.
@@ -382,9 +376,9 @@ class APIClient(MetaMixin):
         a local cache of the specification may be passed as either an
         OrderedDict or a filename which points to a json file.
     """
-    @deprecate_param('v2.0.0', 'retry_total', 'resources')
+    @deprecate_param('v2.0.0', 'retry_total')
     def __init__(self, api_key=None, return_type='snake',
-                 retry_total=6, api_version="1.0", resources="all",
+                 retry_total=6, api_version="1.0",
                  local_api_spec=None):
         if retry_total != 6:
             warnings.warn(
@@ -402,17 +396,9 @@ class APIClient(MetaMixin):
         self._session_kwargs = {'api_key': session_auth_key}
         self.last_response = None
 
-        # Catch deprecation warnings from generate_classes_maybe_cached and
-        # the functions it calls until the `resources` argument is removed.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=FutureWarning,
-                module='civis')
-            classes = generate_classes_maybe_cached(local_api_spec,
-                                                    session_auth_key,
-                                                    api_version,
-                                                    resources)
+        classes = generate_classes_maybe_cached(local_api_spec,
+                                                session_auth_key,
+                                                api_version)
         for class_name, cls in classes.items():
             setattr(self, class_name, cls(self._session_kwargs, client=self,
                                           return_type=return_type))

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -1,11 +1,9 @@
 from functools import lru_cache
 import logging
-import warnings
 
 import civis
 from civis.resources import generate_classes_maybe_cached
 from civis._utils import get_api_key
-from civis._deprecation import deprecate_param
 from civis.response import _RETURN_TYPES
 
 
@@ -360,11 +358,6 @@ class APIClient(MetaMixin):
         - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
           list-like responses and a :class:`pandas:pandas.Series` for single a
           json response.
-    retry_total : DEPRECATED int, optional
-        A number indicating the maximum number of retries for 429, 502, 503, or
-        504 errors. This parameter no longer has any effect since v1.15.0,
-        as retries are automatically handled. This parameter will be removed
-        at version 2.0.0.
     api_version : string, optional
         The version of endpoints to call. May instantiate multiple client
         objects with different versions. Currently only "1.0" is supported.
@@ -376,16 +369,8 @@ class APIClient(MetaMixin):
         a local cache of the specification may be passed as either an
         OrderedDict or a filename which points to a json file.
     """
-    @deprecate_param('v2.0.0', 'retry_total')
     def __init__(self, api_key=None, return_type='snake',
-                 retry_total=6, api_version="1.0",
-                 local_api_spec=None):
-        if retry_total != 6:
-            warnings.warn(
-                "Setting the retry_total parameter no longer has any effect, "
-                "as retries are now handled automatically.",
-                FutureWarning
-            )
+                 api_version="1.0", local_api_spec=None):
         if return_type not in _RETURN_TYPES:
             raise ValueError(
                 f"Return type must be one of {set(_RETURN_TYPES)}: "

--- a/civis/futures.py
+++ b/civis/futures.py
@@ -34,9 +34,6 @@ class CivisFuture(PollableResult):
     polling_interval : int or float, optional
         The number of seconds between API requests to check whether a result
         is ready.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
     poll_on_creation : bool, optional
         If ``True`` (the default), it will poll upon calling ``result()`` the
@@ -73,15 +70,14 @@ class CivisFuture(PollableResult):
     True
     """
     def __init__(self, poller, poller_args,
-                 polling_interval=None, api_key=None, client=None,
+                 polling_interval=None, client=None,
                  poll_on_creation=True):
         if client is None:
-            client = APIClient(api_key=api_key)
+            client = APIClient()
 
         super().__init__(poller=poller,
                          poller_args=poller_args,
                          polling_interval=polling_interval,
-                         api_key=api_key,
                          client=client,
                          poll_on_creation=poll_on_creation)
 

--- a/civis/io/_databases.py
+++ b/civis/io/_databases.py
@@ -3,13 +3,11 @@ import logging
 from civis import APIClient
 from civis._utils import maybe_get_random_name
 from civis.futures import CivisFuture
-from civis._deprecation import deprecate_param
 
 log = logging.getLogger(__name__)
 
 
-@deprecate_param('v2.0.0', 'api_key')
-def query_civis(sql, database, api_key=None, client=None, credential_id=None,
+def query_civis(sql, database, client=None, credential_id=None,
                 preview_rows=10, polling_interval=None, hidden=True):
     """Execute a SQL statement as a Civis query.
 
@@ -23,9 +21,6 @@ def query_civis(sql, database, api_key=None, client=None, credential_id=None,
         The SQL statement to execute.
     database : str or int
         The name or ID of the database.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -51,7 +46,7 @@ def query_civis(sql, database, api_key=None, client=None, credential_id=None,
     >>> run.result()  # Wait for query to complete
     """
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     database_id = client.get_database_id(database)
     cred_id = credential_id or client.default_credential
     resp = client.queries.post(database_id,
@@ -63,9 +58,8 @@ def query_civis(sql, database, api_key=None, client=None, credential_id=None,
                        client=client, poll_on_creation=False)
 
 
-@deprecate_param('v2.0.0', 'api_key')
 def transfer_table(source_db, dest_db, source_table, dest_table,
-                   job_name=None, api_key=None, client=None,
+                   job_name=None, client=None,
                    source_credential_id=None, dest_credential_id=None,
                    polling_interval=None, **advanced_options):
     """Transfer a table from one location to another.
@@ -86,9 +80,6 @@ def transfer_table(source_db, dest_db, source_table, dest_table,
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
         used.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -115,7 +106,7 @@ def transfer_table(source_db, dest_db, source_table, dest_table,
     ...                source_table='schma.tbl', dest_table='schma.tbl')
     """
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     source_cred_id = source_credential_id or client.default_credential
     dest_cred_id = dest_credential_id or client.default_credential
     job_name = maybe_get_random_name(job_name)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -48,9 +48,8 @@ DELIMITERS = {
 _File = collections.namedtuple("_File", "id name detected_info")
 
 
-@deprecate_param('v2.0.0', 'api_key')
 def read_civis(table, database, columns=None, use_pandas=False, encoding=None,
-               job_name=None, api_key=None, client=None, credential_id=None,
+               job_name=None, client=None, credential_id=None,
                polling_interval=None, archive=False, hidden=True, **kwargs):
     """Read data from a Civis table.
 
@@ -79,9 +78,6 @@ def read_civis(table, database, columns=None, use_pandas=False, encoding=None,
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
         used.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -140,8 +136,7 @@ def read_civis(table, database, columns=None, use_pandas=False, encoding=None,
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)
     if client is None:
-        # Instantiate client here in case users provide a (deprecated) api_key
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     sql = _get_sql_select(table, columns)
     data = read_civis_sql(sql=sql, database=database, use_pandas=use_pandas,
                           encoding=encoding, job_name=job_name, client=client,
@@ -215,10 +210,9 @@ def export_to_civis_file(sql, database, job_name=None, client=None,
     return fut
 
 
-@deprecate_param('v2.0.0', 'api_key')
 def read_civis_sql(sql, database, use_pandas=False,
                    encoding=None, job_name=None,
-                   api_key=None, client=None, credential_id=None,
+                   client=None, credential_id=None,
                    polling_interval=None, archive=False,
                    hidden=True, **kwargs):
     """Read data from Civis using a custom SQL string.
@@ -250,9 +244,6 @@ def read_civis_sql(sql, database, use_pandas=False,
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
         used.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -307,7 +298,7 @@ def read_civis_sql(sql, database, use_pandas=False,
     civis.io.civis_to_csv : Write directly to a CSV file.
     """
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     if use_pandas and NO_PANDAS:
         raise ImportError("use_pandas is True but pandas is not installed.")
     if archive:
@@ -359,8 +350,7 @@ def read_civis_sql(sql, database, use_pandas=False,
     return data
 
 
-@deprecate_param('v2.0.0', 'api_key')
-def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
+def civis_to_csv(filename, sql, database, job_name=None,
                  client=None, credential_id=None, include_header=True,
                  compression='none', delimiter=',', unquoted=False,
                  archive=False, hidden=True, polling_interval=None):
@@ -383,9 +373,6 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
         used.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -434,7 +421,7 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
 
     db_id = client.get_database_id(database)
     credential_id = credential_id or client.default_credential
@@ -481,8 +468,7 @@ def civis_to_csv(filename, sql, database, job_name=None, api_key=None,
     return fut
 
 
-@deprecate_param('v2.0.0', 'api_key')
-def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
+def civis_to_multifile_csv(sql, database, job_name=None,
                            client=None, credential_id=None,
                            include_header=True,
                            compression='none', delimiter='|',
@@ -506,9 +492,6 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     job_name : str, optional
         A name to give the job. If omitted, a random job name will be
         used.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -589,7 +572,7 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     civis.APIClient.scripts.post_sql
     """
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     delimiter = DELIMITERS.get(delimiter)
     if not delimiter:
         raise ValueError(
@@ -625,8 +608,8 @@ def civis_to_multifile_csv(sql, database, job_name=None, api_key=None,
     return unload_manifest
 
 
-@deprecate_param('v2.0.0', 'api_key', 'headers')
-def dataframe_to_civis(df, database, table, api_key=None, client=None,
+@deprecate_param('v2.0.0', 'headers')
+def dataframe_to_civis(df, database, table, client=None,
                        max_errors=None, existing_table_rows="fail",
                        diststyle=None, distkey=None,
                        sortkey1=None, sortkey2=None,
@@ -652,9 +635,6 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
         The schema and table you want to upload to. E.g.,
         ``'scratch.table'``. Schemas or tablenames with periods must
         be double quoted, e.g. ``'scratch."my.table"'``.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -746,7 +726,7 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     :func:`~pandas.DataFrame.to_csv`
     """  # noqa: E501
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     if archive:
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)
@@ -778,8 +758,7 @@ def dataframe_to_civis(df, database, table, api_key=None, client=None,
     return fut
 
 
-@deprecate_param('v2.0.0', 'api_key')
-def csv_to_civis(filename, database, table, api_key=None, client=None,
+def csv_to_civis(filename, database, table, client=None,
                  max_errors=None, existing_table_rows="fail",
                  diststyle=None, distkey=None,
                  sortkey1=None, sortkey2=None,
@@ -801,9 +780,6 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     table : str
         The schema and table you want to upload to. E.g.,
         ``'scratch.table'``.
-    api_key : DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -889,7 +865,7 @@ def csv_to_civis(filename, database, table, api_key=None, client=None,
     >>> fut.result()
     """  # noqa: E501
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     if archive:
         warnings.warn("`archive` is deprecated and will be removed in v2.0.0. "
                       "Use `hidden` instead.", FutureWarning)

--- a/civis/io/_tables.py
+++ b/civis/io/_tables.py
@@ -22,7 +22,6 @@ from civis.base import EmptyResultError, CivisImportError, CivisAPIError
 from civis.futures import CivisFuture
 from civis.io import civis_to_file, file_to_civis
 from civis.utils import run_job
-from civis._deprecation import deprecate_param
 
 import requests
 
@@ -581,16 +580,15 @@ def civis_to_multifile_csv(sql, database, job_name=None,
     return unload_manifest
 
 
-@deprecate_param('v2.0.0', 'headers')
 def dataframe_to_civis(df, database, table, client=None,
                        max_errors=None, existing_table_rows="fail",
                        diststyle=None, distkey=None,
                        sortkey1=None, sortkey2=None,
                        table_columns=None,
-                       headers=None, credential_id=None,
+                       credential_id=None,
                        primary_keys=None, last_modified_keys=None,
                        execution="immediate",
-                       delimiter=None, polling_interval=None,
+                       polling_interval=None,
                        hidden=True, **kwargs):
     """Upload a `pandas` `DataFrame` into a Civis table.
 
@@ -638,16 +636,6 @@ def dataframe_to_civis(df, database, table, client=None,
         dropped, or the columns in the source file do not appear in the same
         order as in the destination table. Example:
         ``[{"name": "foo", "sql_type": "INT"}, {"name": "bar", "sql_type": "VARCHAR"}]``
-    headers : bool, optional [DEPRECATED]
-        Whether or not the first row of the file should be treated as
-        headers. The default, ``None``, attempts to autodetect whether
-        or not the first row contains headers.
-
-        This parameter has no effect in versions >= 1.11 and will be
-        removed in v2.0. Tables will always be written with column
-        names read from the DataFrame. Use the `header` parameter
-        (which will be passed directly to :func:`~pandas.DataFrame.to_csv`)
-        to modify the column names in the Civis Table.
     credential_id : str or int, optional
         The ID of the database credential.  If ``None``, the default
         credential will be used.
@@ -660,9 +648,6 @@ def dataframe_to_civis(df, database, table, client=None,
     last_modified_keys: list[str], optional
         A list of the columns indicating a record has been updated. If
         existing_table_rows is "upsert", this field is required.
-    escaped: bool, optional
-        A boolean value indicating whether or not the source file has quotes
-        escaped with a backslash. Defaults to false.
     execution: string, optional, default "immediate"
         One of "delayed" or "immediate". If "immediate", refresh column
         statistics as part of the run. If "delayed", flag the table for a

--- a/civis/parallel.py
+++ b/civis/parallel.py
@@ -11,10 +11,13 @@ from tempfile import TemporaryDirectory
 import time
 import warnings
 
-
 import cloudpickle
 from joblib._parallel_backends import ParallelBackendBase
-from joblib.my_exceptions import TransportableException
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from joblib.my_exceptions import TransportableException
+
 from joblib import register_parallel_backend as _joblib_reg_para_backend
 import requests
 

--- a/civis/polling.py
+++ b/civis/polling.py
@@ -59,9 +59,6 @@ class PollableResult(CivisAsyncResultBase):
     polling_interval : int or float
         The number of seconds between API requests to check whether a result
         is ready.
-    api_key : DEPRECATED str, optional
-        This is not used by PollableResult, but is required to match the
-        interface from CivisAsyncResultBase.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -101,14 +98,13 @@ class PollableResult(CivisAsyncResultBase):
     # - We use the `Future` thread lock called `_condition`
     # - We assume that results of the Future are stored in `_result`.
     def __init__(self, poller, poller_args,
-                 polling_interval=None, api_key=None, client=None,
+                 polling_interval=None, client=None,
                  poll_on_creation=True):
         if polling_interval is None:
             polling_interval = _DEFAULT_POLLING_INTERVAL
         super().__init__(poller=poller,
                          poller_args=poller_args,
                          polling_interval=polling_interval,
-                         api_key=api_key,
                          client=client,
                          poll_on_creation=poll_on_creation)
         if self.polling_interval <= 0:

--- a/civis/run_joblib_func.py
+++ b/civis/run_joblib_func.py
@@ -17,7 +17,11 @@ import warnings
 
 import civis
 import cloudpickle
-from joblib.my_exceptions import TransportableException
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from joblib.my_exceptions import TransportableException
+
 from joblib.format_stack import format_exc
 from joblib import parallel_backend as _joblib_para_backend
 

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -4,7 +4,6 @@ import json
 from jsonref import JsonRef
 import re
 import requests
-import warnings
 
 from civis import APIClient
 from civis.base import CivisAPIError, Endpoint, tostr_urljoin
@@ -167,22 +166,6 @@ class ServiceClient:
         for class_name, klass in classes.items():
             setattr(self, class_name, klass(client=self,
                                             return_type=return_type))
-
-    def parse_path(self, path, operations):
-        """ Parse an endpoint into a class where each valid http request
-        on that endpoint is converted into a convenience function and
-        attached to the class as a method.
-        """
-        warnings.warn("This method is deprecated and will be removed in "
-                      "v2.0.0. Use the `_parse_service_path` function "
-                      "instead.")
-        return _parse_service_path(path, operations, root_path=self._root_path)
-
-    def parse_api_spec(self, api_spec):
-        warnings.warn("This method is deprecated and will be removed in "
-                      "v2.0.0. Use the `parse_service_api_spec` function "
-                      "instead.")
-        return parse_service_api_spec(api_spec, root_path=self._root_path)
 
     @lru_cache(maxsize=4)
     def get_api_spec(self):

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -110,7 +110,7 @@ class ServiceEndpoint(Endpoint):
         return response
 
 
-class ServiceClient():
+class ServiceClient:
 
     def __init__(self, service_id, root_path=None,
                  swagger_path="/endpoints", api_key=None,

--- a/civis/tests/test_cli.py
+++ b/civis/tests/test_cli.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import json
 import os
+import warnings
 from unittest import mock
 
 import pytest
@@ -37,9 +38,9 @@ def test_generate_cli_civis(mock_retrieve_spec_dict):
         civis_spec = json.load(f, object_pairs_hook=OrderedDict)
     mock_retrieve_spec_dict.return_value = civis_spec
 
-    with pytest.warns(None) as warn_rec:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         cli = generate_cli()
-    assert len(warn_rec) == 0
 
     # Check a regular command.
     list_runs_cmd = cli.commands['scripts'].commands['list-containers-runs']

--- a/civis/tests/test_deprecate.py
+++ b/civis/tests/test_deprecate.py
@@ -1,3 +1,5 @@
+import warnings
+
 from civis import _deprecation
 
 import pytest
@@ -90,8 +92,8 @@ def test_deprecate_no_warning():
     # deprecated parameter.
     decorated_func = _deprecation.deprecate_param('v2.0.0', 'param2')(adder)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         output = decorated_func(1, param3=5)
 
     assert output == 6, "The function should still give the expected output."
-    assert len(record) == 0, "No warnings should be raised."

--- a/civis/tests/test_parallel.py
+++ b/civis/tests/test_parallel.py
@@ -1,12 +1,17 @@
 from math import sqrt
 import io
 import pickle
+import warnings
 from unittest import mock
 
 import pytest
 from joblib import delayed, Parallel
 from joblib import parallel_backend, register_parallel_backend
-from joblib.my_exceptions import TransportableException
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from joblib.my_exceptions import TransportableException
+
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.response import Response
 import requests

--- a/civis/tests/test_resources.py
+++ b/civis/tests/test_resources.py
@@ -79,10 +79,9 @@ def test_create_method_no_iterator_kwarg():
 def test_exclude_resource():
     include = "tables/"
     exclude = "excluded_in_base/"
-    assert _resources.exclude_resource(exclude, "1.0", "base")
-    assert not _resources.exclude_resource(include, "1.0", "base")
-    assert not _resources.exclude_resource(exclude, "9.0", "base")
-    assert not _resources.exclude_resource(exclude, "1.0", "all")
+    assert _resources.exclude_resource(exclude, "1.0")
+    assert not _resources.exclude_resource(include, "1.0")
+    assert not _resources.exclude_resource(exclude, "9.0")
 
 
 def test_property_type():
@@ -217,7 +216,7 @@ def test_duplicate_names_generated_from_api_spec():
     paths = resolved_civis_api_spec['paths']
     classes = defaultdict(list)
     for path, ops in paths.items():
-        class_name, methods = _resources.parse_path(path, ops, "1.0", "all")
+        class_name, methods = _resources.parse_path(path, ops, "1.0")
         method_names = [x[0] for x in methods]
         classes[class_name].extend(method_names)
     for cls, names in classes.items():
@@ -304,33 +303,29 @@ def test_create_method_keyword_only():
 def test_generate_classes_maybe_cached(mock_parse, mock_gen, mock_open):
     api_key = "mock"
     api_version = "1.0"
-    resources = "all"
 
     # Calls generate_classes when no cache is passed
-    _resources.generate_classes_maybe_cached(None, api_key, api_version,
-                                             resources)
-    mock_gen.assert_called_once_with(api_key, api_version, resources)
+    _resources.generate_classes_maybe_cached(None, api_key, api_version)
+    mock_gen.assert_called_once_with(api_key, api_version)
     mock_gen.reset_mock()
 
     # Handles OrderedDict
     spec = OrderedDict({"test": True})
-    _resources.generate_classes_maybe_cached(spec, api_key, api_version,
-                                             resources)
-    mock_parse.assert_called_once_with(spec, api_version, resources)
+    _resources.generate_classes_maybe_cached(spec, api_key, api_version)
+    mock_parse.assert_called_once_with(spec, api_version)
     assert not mock_gen.called
 
     # Handles str
     mock_parse.reset_mock()
-    _resources.generate_classes_maybe_cached('mock', api_key, api_version,
-                                             resources)
-    mock_parse.assert_called_once_with(spec, api_version, resources)
+    _resources.generate_classes_maybe_cached('mock', api_key, api_version)
+    mock_parse.assert_called_once_with(spec, api_version)
     assert not mock_gen.called
 
     # Error when a regular dict is passed
     bad_spec = {"test": True}
     with pytest.raises(ValueError):
         _resources.generate_classes_maybe_cached(bad_spec, api_key,
-                                                 api_version, resources)
+                                                 api_version)
 
 
 @mock.patch('civis.resources._resources.parse_method', autospec=True)
@@ -342,7 +337,7 @@ def test_parse_api_spec_names(mock_method):
                   "/oneword/": mock_ops,
                   "/hyphen-words": mock_ops}
     mock_api_spec = {"paths": mock_paths}
-    classes = _resources.parse_api_spec(mock_api_spec, "1.0", "all")
+    classes = _resources.parse_api_spec(mock_api_spec, "test_api_version")
     assert sorted(classes.keys()) == ["hyphen_words", "oneword", "two_words"]
     assert classes["oneword"].__name__ == "Oneword"
     assert classes["two_words"].__name__ == "Two_Words"

--- a/civis/utils/_jobs.py
+++ b/civis/utils/_jobs.py
@@ -2,22 +2,17 @@ import logging
 
 from civis import APIClient
 from civis.futures import CivisFuture
-from civis._deprecation import deprecate_param
 
 log = logging.getLogger(__name__)
 
 
-@deprecate_param("v2.0.0", "api_key")
-def run_job(job_id, api_key=None, client=None, polling_interval=None):
+def run_job(job_id, client=None, polling_interval=None):
     """Run a job.
 
     Parameters
     ----------
     job_id: str or int
         The ID of the job.
-    api_key: DEPRECATED str, optional
-        Your Civis API key. If not given, the :envvar:`CIVIS_API_KEY`
-        environment variable will be used.
     client: :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -31,7 +26,7 @@ def run_job(job_id, api_key=None, client=None, polling_interval=None):
         A `CivisFuture` object.
     """
     if client is None:
-        client = APIClient(api_key=api_key)
+        client = APIClient()
     run = client.jobs.post_runs(job_id)
     return CivisFuture(
         client.jobs.get_runs,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -378,7 +378,7 @@ if _test_build:
         api_spec = JsonRef.replace_refs(
             json.load(_raw, object_pairs_hook=OrderedDict))
     extra_classes = civis.resources._resources.parse_api_spec(
-        api_spec, '1.0', 'base')
+        api_spec, '1.0')
 else:
     api_key = os.environ.get("CIVIS_API_KEY")
     user_agent = "civis-python/SphinxDocs"


### PR DESCRIPTION
Parameters for various classes/functions that have long been deprecated are removed:
  `api_key`, `resources`, `retry_total`, `archive`, `headers`, and the deprecated methods in `ServiceClient`.

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
