### PR TITLE
[CIVIS-2562] RM drop API response return type "pandas"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Parameters for various classes/functions that have long been deprecated are removed:
   `api_key`, `resources`, `retry_total`, `archive`, `headers`.
   Also dropped the deprecated methods in `ServiceClient`. (#471)
+- The `return_type` parameter of a `civis.response.Response` object
+  no longer has the `"pandas"` option. (#472)
 
 ### Added
 - Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)

--- a/civis/base.py
+++ b/civis/base.py
@@ -100,7 +100,7 @@ def get_base_url():
     return base_url
 
 
-class Endpoint(object):
+class Endpoint:
 
     _lock = threading.Lock()
 

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -101,7 +101,7 @@ def find_one(object_list, filter_func=None, **kwargs):
     return results[0] if results else None
 
 
-class MetaMixin():
+class MetaMixin:
 
     @lru_cache(maxsize=128)
     def get_database_id(self, database):
@@ -357,9 +357,6 @@ class APIClient(MetaMixin):
         - ``'snake'`` Returns a :class:`civis.response.Response` object for the
           json-encoded content of a response. This maps the top-level json
           keys to snake_case.
-        - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
-          list-like responses and a :class:`pandas:pandas.Series` for single a
-          json response.
     retry_total : DEPRECATED int, optional
         A number indicating the maximum number of retries for 429, 502, 503, or
         504 errors. This parameter no longer has any effect since v1.15.0,

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -143,9 +143,6 @@ class ServiceClient():
             - ``'snake'`` Returns a :class:`civis.response.Response` object
             for the json-encoded content of a response. This maps the
             top-level json keys to snake_case.
-            - ``'pandas'`` Returns a :class:`pandas:pandas.DataFrame` for
-            list-like responses and a :class:`pandas:pandas.Series` for
-            single a json response.
         local_api_spec : collections.OrderedDict or string, optional
             The methods on this class are dynamically built from the Service
             API specification, which can be retrieved from the /endpoints
@@ -155,9 +152,8 @@ class ServiceClient():
             may be passed as either an OrderedDict or a filename which
             points to a json file.
         """
-        if return_type not in ['snake', 'raw', 'pandas']:
-            raise ValueError("Return type must be one of 'snake', 'raw', "
-                             "'pandas'")
+        if return_type not in ['snake', 'raw']:
+            raise ValueError("Return type must be one of 'snake', 'raw'")
         self._api_key = api_key
         self._service_id = service_id
         self._base_url = self.get_base_url()

--- a/civis/tests/test_response.py
+++ b/civis/tests/test_response.py
@@ -3,14 +3,7 @@ import pickle
 from unittest import mock
 
 import pytest
-
 import requests
-
-try:
-    import pandas as pd
-    has_pandas = True
-except ImportError:
-    has_pandas = False
 
 from civis.response import (
     CivisClientError, PaginatedResponse, _response_to_json,
@@ -138,24 +131,6 @@ def test_convert_data_type_raw_parsed():
 
     assert isinstance(data, dict)
     assert data == {'foo': 'bar'}
-
-
-@pytest.mark.skipif(not has_pandas, reason='pandas not installed')
-def test_convert_data_type_pandas_series():
-    response = _create_mock_response({'foo': 'bar'}, None)
-    data = convert_response_data_type(response, return_type='pandas')
-
-    assert isinstance(data, pd.Series)
-    assert data.equals(pd.Series({'foo': 'bar'}))
-
-
-@pytest.mark.skipif(not has_pandas, reason='pandas not installed')
-def test_convert_data_type_pandas_df():
-    response = _create_mock_response([{'foo': 'bar'}], None)
-    data = convert_response_data_type(response, return_type='pandas')
-
-    assert isinstance(data, pd.DataFrame)
-    assert data.equals(pd.DataFrame.from_records([{'foo': 'bar'}]))
 
 
 def test_convert_data_type_civis():


### PR DESCRIPTION
It's unclear why one would want to deal with an API response as a pandas object. Since `"pandas"` became an option of the response return type in both this codebase and its internal, private precursor 8+ years ago, it has seen zero internal usage. From users external to Civis, the one time we heard about this usage was when an error was raised (see the linked internal ticket) 4 years ago. All this is to say, it's time to simply drop this  `"pandas"` option to avoid further confusion.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
