### PR TITLE
[CIVIS-5287] FIX `find` should handle boolean kwargs like other data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Also dropped the deprecated methods in `ServiceClient`. (#471)
 - The `return_type` parameter of a `civis.response.Response` object
   no longer has the `"pandas"` option. (#472)
+- When `civis.find` uses kwargs as filters, boolean values are now treated in the same
+  way as other data types for value equality comparison, rather than the presence or
+  absence of the key in question. (#473)
 
 ### Added
 - Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)

--- a/civis/civis.py
+++ b/civis/civis.py
@@ -29,15 +29,16 @@ def find(object_list, filter_func=None, **kwargs):
         if and only if ``bool(filter_func(object))`` is ``True``.
     **kwargs
         Key-value pairs for more fine-grained filtering; they cannot be used
-        in conjunction with `filter_func`. All keys must be strings.
-        For an `object` from the input iterable to be included in the
-        returned list, all the `key`s must be attributes of `object`, plus
-        any one of the following conditions for a given `key`:
+        in conjunction with ``filter_func``. All keys must be strings.
+        For an object ``obj`` from the input iterable to be included in the
+        returned list, all the keys must be attributes of ``obj``, plus
+        any one of the following conditions for a given key:
 
-        - `value` is a one-argument function and
-          ``bool(value(getattr(object, key)))`` is ``True``
-        - `value` is ``True``
-        - ``getattr(object, key)`` is equal to ``value``
+        - ``value`` is a one-argument function and
+          ``bool(value(getattr(obj, key)))`` is equal to ``True``
+        - ``value`` is either ``True`` or ``False``, and
+          ``getattr(obj, key) is value`` is ``True``
+        - ``getattr(obj, key) == value`` is ``True``
 
     Returns
     -------
@@ -67,7 +68,7 @@ def find(object_list, filter_func=None, **kwargs):
                     if not v(getattr(o, k, None)):
                         return False
                 elif isinstance(v, bool):
-                    if hasattr(o, k) != v:
+                    if getattr(o, k) is not v:
                         return False
                 elif v != getattr(o, k, None):
                     return False

--- a/civis/tests/test_civis.py
+++ b/civis/tests/test_civis.py
@@ -1,9 +1,35 @@
 from unittest import mock
 
 import civis
+from civis import find
 from civis.resources import API_SPEC
+from civis.response import Response
 
 import pytest
+
+
+def test_find_filter_with_kwargs():
+    r1 = Response({"foo": 0, "bar": "a", "baz": True})
+    r2 = Response({"foo": 1, "bar": "b", "baz": True})
+    r3 = Response({"foo": 2, "bar": "b", "baz": False})
+
+    assert find([r1, r2, r3], wrong_attr="whatever") == []
+
+    assert find([r1, r2, r3], foo=0) == [r1]
+    assert find([r1, r2, r3], foo=1) == [r2]
+    assert find([r1, r2, r3], foo=1, bar="b") == [r2]
+
+    assert find([r1, r2, r3], bar="b") == [r2, r3]
+    assert find([r1, r2, r3], bar="b", foo=1) == [r2]
+
+    assert find([r1, r2, r3], foo=True) == []
+    assert find([r1, r2, r3], foo=False) == []
+    assert find([r1, r2, r3], bar=True) == []
+    assert find([r1, r2, r3], bar=False) == []
+    assert find([r1, r2, r3], baz=True) == [r1, r2]
+    assert find([r1, r2, r3], baz=False) == [r3]
+
+    assert find([r1, r2, r3], foo=int) == [r2, r3]
 
 
 @pytest.mark.parametrize('schema_tablename', [


### PR DESCRIPTION
This pull request fixes `civis.find` for its unintuitive behavior with boolean kwarg filters. As suggested in #227, boolean kwargs are now treated the same way as kwargs of other data types, for value comparison instead of presence or absence of an attribute.

Resolves #227.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
