### PR TITLE
[CIVIS-5100] SEC add `pip-audit` check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,20 @@ workflows:
             pip install --upgrade bandit && \
             bandit --version && \
             bandit -r civis -x civis/tests,civis/ml/tests
+      - pre-build:
+          name: pip-audit
+          command-run: |
+            pip install --upgrade pip setuptools wheel pip-audit && \
+            pip install --progress-bar off -e ".[dev-core,dev-civisml,docs]" && \
+            pip-audit --version && \
+            pip-audit
       - build-python:
           requires:
             - flake8
             - sphinx-build
             - twine
             - bandit
+            - pip-audit
           matrix:
             parameters:
               python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   snake-case keys at a `Response` object are now always available (and preferred). (#463)
 - Parameters for various classes/functions that have long been deprecated are removed:
   `api_key`, `resources`, `retry_total`, `archive`, `headers`.
-  Also dropped the deprecated methods in `ServiceClient`. (#471)
+  Also dropped the deprecated methods in `ServiceClient`. (#472)
 - The `return_type` parameter of a `civis.response.Response` object
-  no longer has the `"pandas"` option. (#472)
+  no longer has the `"pandas"` option. (#473)
 - When `civis.find` uses kwargs as filters, boolean values are now treated in the same
   way as other data types for value equality comparison, rather than the presence or
-  absence of the key in question. (#473)
+  absence of the key in question. (#474)
 
 ### Added
 - Added error handling of file_id with type string passed to `civis.io.civis_file_to_table`. (#454)
-- Added support for Python 3.10, 3.11, and 3.12 (#462, #474)
+- Added support for Python 3.10, 3.11, and 3.12 (#462, #475)
 
 ### Changed
 - Updated references from 'master' to 'main' (#460)
@@ -45,14 +45,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   with the current civis-python codebase. (#469)
 - Changed `civis.io.civis_file_to_table` to not rely on table ids for determining a table's existence (#470)
 - Broke out the "API Resources" documentation page into individual endpoint pages (#471)
-- Switched to `pyproject.toml` for packaging. (#474)
+- Switched to `pyproject.toml` for packaging. (#475)
 
 ### Deprecated
 ### Removed
-- Dropped support for Python 3.7 and 3.8 (#462, #474)
+- Dropped support for Python 3.7 and 3.8 (#462, #475)
 
 ### Fixed
 ### Security
+- Added the `pip-audit` check to CI
+  for potential security vulnerabilities of Python dependencies. (#476)
 
 ## 1.16.0 - 2021-12-14
 ### Added


### PR DESCRIPTION
This pull request adds the `pip-audit` check to CI for potential security vulnerabilities of the Python dependencies that this codebase uses.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
