### PR TITLE
[CIVIS-8512] ENH `job_url` property at `CivisFuture`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `civis_logger` for logging in Civis Platform scripts. (#478)
 - Added the stub file `client.pyi` to surface the API endpoints and their type annotations
   at a `civis.APIClient` instance to IDEs. (#479)
+- Added the `job_url` property to `CivisFuture` objects. (#482)
 
 ### Changed
 - Updated references from 'master' to 'main' (#460)

--- a/src/civis/futures.py
+++ b/src/civis/futures.py
@@ -39,14 +39,6 @@ class CivisFuture(PollableResult):
         first time. If ``False``, it will wait the number of seconds specified
         in `polling_interval` from object creation before polling.
 
-    Attributes
-    ----------
-    job_id : int
-        First element of the tuple given to `poller_args`
-    run_id : int or None
-        Second element of the tuple given to `poller_args`
-        (`None` if the poller function does not require a run ID)
-
     Examples
     --------
     This example is provided as a function at :func:`~civis.io.query_civis`.
@@ -151,15 +143,37 @@ class CivisFuture(PollableResult):
 
     @property
     def job_id(self):
+        """The job ID for the Civis Platform job that this future is tracking.
+
+        Returns
+        -------
+        int
+        """
         return self.poller_args[0]
 
     @property
     def run_id(self):
+        """The run ID for the Civis Platform job that this future is tracking.
+
+        Returns
+        -------
+        int | None
+        """
         try:
             return self.poller_args[1]
         except IndexError:
             # when poller function has job_id only but not run_id
             return None
+
+    @property
+    def job_url(self):
+        """The URL for the Civis Platform job that this future is tracking.
+
+        Returns
+        -------
+        str
+        """
+        return f"https://platform.civisanalytics.com/spa/#/jobs/{self.job_id}"
 
     def _check_message(self, message):
         try:

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -151,6 +151,9 @@ def test_future_job_id_run_id(poller_args, expected_job_id, expected_run_id):
     )
     assert result.job_id == expected_job_id
     assert result.run_id == expected_run_id
+    assert result.job_url == (
+        f"https://platform.civisanalytics.com/spa/#/jobs/{expected_job_id}"
+    )
 
 
 def test_container_future_job_id_run_id():
@@ -162,6 +165,7 @@ def test_container_future_job_id_run_id():
     )
     assert result.job_id == job_id
     assert result.run_id == run_id
+    assert result.job_url == f"https://platform.civisanalytics.com/spa/#/jobs/{job_id}"
 
 
 def test_container_scripts():


### PR DESCRIPTION
Let's do another new feature. Since we often craft the job URL from a `CivisFuture` object for logging etc., this pull request adds the `job_url` property to `CivisFuture`.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
