### PR TITLE
[CIVIS-5100] SEC bump `requests` version to 2.32.1 in `docs/requirements.txt`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ workflows:
             pip install --progress-bar off -r docs/requirements.txt && \
             pip install --progress-bar off -e ".[dev-core,dev-civisml]" && \
             pip-audit --version && \
-            pip-audit
+            pip-audit --skip-editable
       - pre-build:
           name: sphinx-build
           command-run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Security
 - Added the `pip-audit` check to CI
-  for potential security vulnerabilities of Python dependencies. (#476)
+  for potential security vulnerabilities of Python dependencies. (#476, #485)
 
 ## 1.16.1 - 2023-07-10
 ### Changed

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -52,7 +52,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
+requests==2.32.1
     # via
     #   civis (pyproject.toml)
     #   sphinx


### PR DESCRIPTION
The latest CircleCI build at `main` [failed](https://github.com/civisanalytics/civis-python/runs/25198313180) because `requests` had just been updated for a security vulnerability ([ref](https://github.com/civisanalytics/civis-python/security/dependabot/3)). I ran the `pip-compile` command with `--upgrade` to refresh `docs/requirements.txt`.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
