### PR TITLE
[CIVIS-8660] ENH response objects: add repr and pprint, fix lists for `.json()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Security
 
+## 2.2.0 - 2024-05-28
+
+## Added
+- `civis.response.Response` has its own "repr" and pretty-print format,
+  instead of the previous dict-like representation that would incorrectly suggest immutability. (#487)
+- Added the `--version` flag to the command line interface. (#487)
+
+## Fixed
+- Fixed API response objects' `.json()` for lists. (#487)
+- Fixed `civis_logger` for always having the attribute `propagate` attribute set to `False`
+  so that it can also be used for notebooks and services/apps on Civis Platform. (#487)
+
 ## 2.1.0 - 2024-05-23
 
 ### Added

--- a/docs/source/responses.rst
+++ b/docs/source/responses.rst
@@ -1,6 +1,63 @@
 API Responses
 =============
 
+A Civis API call from ``client.<endpoint>.<method>`` returns a :class:`civis.response.Response` object
+(or a :class:`civis.response.PaginatedResponse` object, if ``<method>`` is a "list" call):
+
+.. code-block:: python
+
+   >>> import civis
+   >>> client = civis.APIClient()
+   >>> response = client.scripts.get(12345)
+   >>> response
+   Response(id=12345,
+            name='some script name',
+            created_at='2018-06-11T20:43:07.000Z',
+            updated_at='2018-06-11T20:43:19.000Z',
+            author=(id=67890,
+                    name='Platform User Name',
+                    username='platformusername',
+                    initials='PUN',
+                    online=False),
+            ...
+
+To retrieve information from a :class:`civis.response.Response` object,
+either the "getattr" or "getitem" syntax can be used:
+
+.. code-block:: python
+
+   >>> response.id
+   12345
+   >>> response['id']
+   12345
+   >>> response['name']
+   'some script name'
+   >>> response.name
+   'some script name'
+
+Nested response objects can be accessed using the same syntax:
+
+.. code-block:: python
+
+   >>> response.author['name']
+   'Platform User Name'
+   >>> response.author.name
+   'Platform User Name'
+
+Note that :class:`civis.response.Response` objects are read-only.
+If you need to modify information from a response object,
+call :func:`civis.response.Response.json` to get a dictionary representation of the response object.
+You can then modify this dictionary as needed:
+
+.. code-block:: python
+
+   >>> response.arguments = ...  # !!! Raises CivisImmutableResponseError
+   >>> response['arguments'] = ...  # !!! Raises CivisImmutableResponseError
+   >>>
+   >>> response_json = response.json()
+   >>> response_json['arguments'] = {'new_arg_for_a_similar_script': 'some_value'}
+   >>> # use response_json downstream, e.g., to create a new Civis Platform script
+
 Response Types
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.1.0"
+version = "2.2.0"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.9"

--- a/src/civis/cli/__main__.py
+++ b/src/civis/cli/__main__.py
@@ -23,6 +23,8 @@ import click
 from jsonref import JsonRef
 import yaml
 from requests import Request
+
+import civis
 from civis.cli._cli_commands import (
     civis_ascii_art,
     files_download_cmd,
@@ -260,6 +262,7 @@ def generate_cli():
     spec = JsonRef.replace_refs(spec)
 
     cli = click.Group()
+    cli = click.version_option(version=civis.__version__, package_name="civis")(cli)
 
     # Iterate through top-level resources (e.g., Scripts, Files, Models).
     groups = {}

--- a/src/civis/io/_files.py
+++ b/src/civis/io/_files.py
@@ -106,7 +106,7 @@ def _single_upload(buf, name, client, **kwargs):
     # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
     # Note that the payload must have "key" first and "file" last.
     url = file_response.upload_url
-    form = file_response.upload_fields._data_snake
+    form = file_response.upload_fields.json()
     form_key = OrderedDict(key=form.pop("key"))
     form_key.update(form)
 

--- a/src/civis/loggers.py
+++ b/src/civis/loggers.py
@@ -60,12 +60,7 @@ def civis_logger(name=None, level=None, fmt="%(message)s"):
     # When running on Civis Platform (as opposed to unit tests in CI),
     # we don't want to propagate log records to the root logger
     # in order to avoid duplicate logs.
-    # But in running unit tests we do want to leave `propagate` as `True`,
-    # or else all the logging/caplog tests would fail.
-    # The user can set the `propagate` attribute of the resulting logger
-    # back to True if they so choose.
-    if os.getenv("CIVIS_JOB_ID") and os.getenv("CIVIS_RUN_ID"):
-        logger.propagate = False
+    logger.propagate = False
 
     if isinstance(fmt, logging.Formatter):
         platform_fmt = fmt

--- a/src/civis/response.py
+++ b/src/civis/response.py
@@ -104,7 +104,7 @@ class Response:
     ----------
     json_data : dict | None
         This is `json_data` as it is originally returned to the user without
-        the key names being changed. See Notes. None is used if the original
+        the key names being changed. None is used if the original
         response returned a 204 No Content response.
     headers : dict
         This is the header for the API call without changing the key names.
@@ -144,7 +144,8 @@ class Response:
                 elif isinstance(v, list):
                     val = [Response(o) if isinstance(o, dict) else o for o in v]
                     for r in val:
-                        r._inner_response = True
+                        if isinstance(r, Response):
+                            r._inner_response = True
                 else:
                     val = v
 

--- a/src/civis/tests/mocks.py
+++ b/src/civis/tests/mocks.py
@@ -72,11 +72,10 @@ def create_client_mock_for_container_tests(
     mock_container_run_start = Response(
         {"id": run_id, "container_id": script_id, "state": "queued"}
     )
-    mock_container_run = Response(
-        {"id": run_id, "container_id": script_id, "state": state}
-    )
+    mock_container_run_json = {"id": run_id, "container_id": script_id, "state": state}
     if state == "failed":
-        mock_container_run._replace("error", "None")
+        mock_container_run_json["error"] = "None"
+    mock_container_run = Response(mock_container_run_json)
     c.scripts.post_containers_runs.return_value = mock_container_run_start
     c.scripts.get_containers_runs.return_value = mock_container_run
     c.scripts.list_containers_runs_outputs.return_value = run_outputs or []
@@ -84,8 +83,9 @@ def create_client_mock_for_container_tests(
     c.jobs.list_runs_logs.return_value = log_outputs or []
 
     def change_state_to_cancelled(script_id):
-        mock_container_run._replace("state", "cancelled")
-        return mock_container_run
+        mock_container_run_json = mock_container_run.json()
+        mock_container_run_json["state"] = "cancelled"
+        return Response(mock_container_run_json)
 
     c.scripts.post_cancel.side_effect = change_state_to_cancelled
 

--- a/src/civis/utils/_jobs.py
+++ b/src/civis/utils/_jobs.py
@@ -92,7 +92,7 @@ def run_template(id, arguments, JSONValue=False, client=None):
             )
         # Note that the cast to a dict is to convert
         # an expected Response object.
-        return json_output[0]._data_snake
+        return json_output[0].json()
     else:
         file_ids = {o.name: o.object_id for o in outputs}
         return file_ids

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -8,7 +8,11 @@ def _get_test_logger(*args, **kwargs):
     # Need to use a logger of a different name in each test function,
     # or else we'd hit this issue:
     # https://github.com/pytest-dev/pytest/issues/5577
-    return civis_logger(name=str(uuid4()), *args, **kwargs)
+    logger = civis_logger(name=str(uuid4()), *args, **kwargs)
+    # Set `propagate` back to `True`,
+    # or else all the logging/caplog tests would fail.
+    logger.propagate = True
+    return logger
 
 
 def test_civis_logger_base_case(caplog, capsys):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -234,7 +234,7 @@ def test_infer(mock_make_factory, mock_job):
     ):
         civis.parallel.infer_backend_factory(client=mock_client)
 
-    expected = mock_job._data_snake
+    expected = mock_job.json()
     del expected["from_template_id"]
     del expected["id"]
     mock_make_factory.assert_called_once_with(
@@ -460,7 +460,7 @@ def test_result_exception_no_result(m_sleep):
     with pytest.raises(TransportableException) as exc:
         res.get()
 
-    assert "{'state': 'failed'}" in str(exc.value)
+    assert "Response(state='failed')" in str(exc.value)
     assert callback.call_count == 0
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,7 @@
 import io
 import pickle
 import pprint
+import sys
 from string import ascii_lowercase
 from unittest import mock
 
@@ -273,6 +274,11 @@ def test_response_arguments_preserve_case():
             {"fooBar": 1, "arguments": {"FOO": 2, "FOO_BAR": 3}},
             {"foo_bar": 1, "arguments": {"FOO": 2, "FOO_BAR": 3}},
         ),
+        (
+            {"fooBar": [{"name": "a", "type": "b"}, {"name": "c", "type": "d"}]},
+            {"foo_bar": [{"name": "a", "type": "b"}, {"name": "c", "type": "d"}]},
+        ),
+        ({"fooBar": ["a", "b", "c"]}, {"foo_bar": ["a", "b", "c"]}),
     ],
 )
 def test_json(source, as_snake_case):
@@ -336,6 +342,13 @@ def test_repr(json_data, expected_repr):
     assert repr(response) == expected_repr
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason=(
+        "pprint for dataclasses is only available since 3.10+, "
+        "https://bugs.python.org/issue43080"
+    ),
+)
 @pytest.mark.parametrize(
     "json_data, expected",
     [

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,5 +1,7 @@
 import io
 import pickle
+import pprint
+from string import ascii_lowercase
 from unittest import mock
 
 import pytest
@@ -314,15 +316,77 @@ def test_len(json_data, expected_length):
 @pytest.mark.parametrize(
     "json_data, expected_repr",
     [
-        ({}, "{}"),
-        ({"foo": 123}, "{'foo': 123}"),
-        ({"foo": {"barBaz": 456}}, "{'foo': {'bar_baz': 456}}"),
+        (None, "Response()"),
+        ({}, "Response()"),
+        ({"foo": 123}, "Response(foo=123)"),
+        ({"foo": {"barBaz": 456}}, "Response(foo=(bar_baz=456))"),
+        # repr() call doesn't wrap long lines.
+        (
+            {
+                "foo": {ascii_lowercase[i]: i for i in range(3)},
+                "fooBar": {ascii_lowercase[i]: i for i in range(15)},
+            },
+            "Response(foo=(a=0, b=1, c=2), foo_bar=(a=0, b=1, c=2, d=3, e=4, f=5, g=6, h=7, i=8, j=9, k=10, l=11, m=12, n=13, o=14))",  # noqa: E501
+        ),
     ],
 )
 def test_repr(json_data, expected_repr):
     response = Response(json_data)
     assert response.json_data == json_data
     assert repr(response) == expected_repr
+
+
+@pytest.mark.parametrize(
+    "json_data, expected",
+    [
+        # A "short" response's pprint looks the same as its repr.
+        ({"foo": {"barBaz": 456}}, "Response(foo=(bar_baz=456))"),
+        # A "long" response's pprint triggers line wrapping in pretty-printing.
+        (
+            {ascii_lowercase[i]: i for i in range(15)},
+            "Response(a=0,\n"
+            "         b=1,\n"
+            "         c=2,\n"
+            "         d=3,\n"
+            "         e=4,\n"
+            "         f=5,\n"
+            "         g=6,\n"
+            "         h=7,\n"
+            "         i=8,\n"
+            "         j=9,\n"
+            "         k=10,\n"
+            "         l=11,\n"
+            "         m=12,\n"
+            "         n=13,\n"
+            "         o=14)",
+        ),
+        (
+            {
+                "foo": {ascii_lowercase[i]: i for i in range(3)},
+                "fooBar": {ascii_lowercase[i]: i for i in range(15)},
+            },
+            "Response(foo=(a=0, b=1, c=2),\n"
+            "         foo_bar=(a=0,\n"
+            "                  b=1,\n"
+            "                  c=2,\n"
+            "                  d=3,\n"
+            "                  e=4,\n"
+            "                  f=5,\n"
+            "                  g=6,\n"
+            "                  h=7,\n"
+            "                  i=8,\n"
+            "                  j=9,\n"
+            "                  k=10,\n"
+            "                  l=11,\n"
+            "                  m=12,\n"
+            "                  n=13,\n"
+            "                  o=14))",
+        ),
+    ],
+)
+def test_pprint(json_data, expected):
+    response = Response(json_data)
+    assert pprint.pformat(response) == expected
 
 
 def test_get():


### PR DESCRIPTION
This pull request updates `civis.response.Response`:

* Fix `.json()` where nested list objects weren't handled correctly.
* Add repr and pretty-printing protocols to improve user experience

Also added `civis --version` and fixed a small bug for `civis_logger` along the way.
 
---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
