### PR TITLE
[CIVIS-6486] ENH `civis.parallel` compatible with joblib >= v1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ workflows:
       - pre-build:
           name: bandit
           command-run: |
+            pip install --progress-bar off -e ".[dev-core]" && \
             bandit --version && \
             bandit -r src -x tests
       - pre-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ workflows:
       - pre-build:
           name: bandit
           command-run: |
-            pip install --upgrade bandit && \
             bandit --version && \
             bandit -r src -x tests
       - pre-build:
@@ -91,7 +90,6 @@ workflows:
       - pre-build:
           name: pip-audit
           command-run: |
-            pip install --upgrade pip setuptools wheel pip-audit && \
             pip install --progress-bar off -r docs/requirements.txt && \
             pip install --progress-bar off -e ".[dev-core,dev-civisml]" && \
             pip-audit --version && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,12 @@ workflows:
           name: black
           command-run: |
             pip install --progress-bar off -e ".[dev-core]" && \
-            black --check src tools tests
+            black --check src tools tests docs/source/conf.py
       - pre-build:
           name: flake8
           command-run: |
             pip install --progress-bar off -e ".[dev-core]" && \
-            flake8 src tools tests
+            flake8 src tools tests docs/source/conf.py
       - pre-build:
           name: pip-audit
           command-run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 ### Changed
+- Refactored the `civis.parallel` module and related unit tests due to major changes
+  of joblib from v1.2.0 to v1.3.0 (API-breaking changes for dropping
+  `joblib.my_exceptions.TransportableException` and `joblib.format_stack.format_exc`,
+  as well as the substantial changes to the internals of `joblib.Parallel`). (#488)
+- Bumped the minimum required version of `joblib` to v1.3.0,
+  which is the version where `joblib.parallel_config` was introduced and
+  `joblib.parallel_backend` was deprecated. (#488)
+
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed `civis.parallel.make_backend_template_factory` so that
+  keyword arguments are now accepted and passed to `client.scripts.post_custom`. (#488)
+
 ### Security
+- Bumped the minimum required version of `joblib` to v1.3.0,
+  partly due to a security vulnerability for < v1.2.0
+  ([CVE-2022-21797](https://nvd.nist.gov/vuln/detail/CVE-2022-21797)). (#488)
+- Bumped the minimum required version of `requests` to the latest v2.32.3, 
+  due to a security vulnerability for < v2.32.0
+  ([CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195)). (#488)
 
 ## 2.2.0 - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   keyword arguments are now accepted and passed to `client.scripts.post_custom`. (#488)
 
 ### Security
-- Bumped the minimum required version of `joblib` to v1.3.0,
-  partly due to a security vulnerability for < v1.2.0
-  ([CVE-2022-21797](https://nvd.nist.gov/vuln/detail/CVE-2022-21797)). (#488)
 - Bumped the minimum required version of `requests` to the latest v2.32.3, 
   due to a security vulnerability for < v2.32.0
   ([CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195)). (#488)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -66,11 +66,8 @@ sphinx==7.3.7
     # via
     #   civis (pyproject.toml)
     #   numpydoc
-    #   sphinx-copybutton
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-copybutton==0.5.2
-    # via civis (pyproject.toml)
 sphinx-rtd-theme==2.0.0
     # via civis (pyproject.toml)
 sphinxcontrib-applehelp==1.0.8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ attrs==23.2.0
     #   referencing
 babel==2.15.0
     # via sphinx
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -66,8 +66,11 @@ sphinx==7.3.7
     # via
     #   civis (pyproject.toml)
     #   numpydoc
+    #   sphinx-copybutton
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
+sphinx-copybutton==0.5.2
+    # via civis (pyproject.toml)
 sphinx-rtd-theme==2.0.0
     # via civis (pyproject.toml)
 sphinxcontrib-applehelp==1.0.8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ imagesize==1.4.1
     # via sphinx
 jinja2==3.1.4
     # via sphinx
-joblib==1.2.0
+joblib==1.4.2
     # via civis (pyproject.toml)
 jsonref==1.1.0
     # via civis (pyproject.toml)
@@ -52,7 +52,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.1
+requests==2.32.3
     # via
     #   civis (pyproject.toml)
     #   sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinx_toggleprompt",
+    "sphinx_copybutton",
 ]
 
 autosummary_generate = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -365,7 +365,7 @@ def _write_resources_rst(class_names, filename, civis_module):
                 endpoint_name = class_name.title()
                 full_path = '.'.join((civis_module, endpoint_name))
                 endpoint_rst_file.write(
-                    f"{endpoint_name}\n"
+                    f"{endpoint_name.replace('_', ' ')}\n"
                     f"{'=' * len(endpoint_name)}\n\n"
                 )
                 endpoint_rst_file.write(_autodoc_fmt.format(full_path, full_path))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinx_copybutton",
 ]
 
 autosummary_generate = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,53 +21,58 @@ import civis
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.intersphinx', 'sphinx.ext.viewcode', 'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary', 'sphinx.ext.doctest', 'numpydoc.numpydoc'
+    "numpydoc.numpydoc",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx_toggleprompt",
 ]
 
 autosummary_generate = True
 
 intersphinx_mapping = {
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
-    'python': ('https://docs.python.org/3', None),
-    'requests': ('https://docs.python-requests.org/en/latest/', None),
-    'sklearn': ('https://scikit-learn.org/stable', None),
-    'joblib': ('https://joblib.readthedocs.io/en/latest/', None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "python": ("https://docs.python.org/3", None),
+    "requests": ("https://docs.python-requests.org/en/latest/", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+    "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
 current_year = datetime.datetime.now().year
-project = 'Civis API Python Client'
-copyright = '2016-%d, Civis Analytics' % current_year
-author = 'Civis Analytics'
+project = "Civis API Python Client"
+copyright = "2016-%d, Civis Analytics" % current_year
+author = "Civis Analytics"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-major_version, minor_version, _ = civis.__version__.split('.')
+major_version, minor_version, _ = civis.__version__.split(".")
 # The short X.Y version.
-version = '%s.%s' % (major_version, minor_version)
+version = "%s.%s" % (major_version, minor_version)
 # The full version, including alpha/beta/rc tags.
 release = civis.__version__
 
@@ -80,9 +85,9 @@ language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,27 +95,27 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -118,156 +123,155 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/civis.svg'
+html_logo = "_static/civis.svg"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/civis.ico'
+html_favicon = "_static/civis.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'CivisClientdoc'
+htmlhelp_basename = "CivisClientdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'CivisClient.tex', 'Civis Client Documentation',
-   'Civis Analytics', 'manual'),
+    (
+        master_doc,
+        "CivisClient.tex",
+        "Civis Client Documentation",
+        "Civis Analytics",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'civisclient', 'Civis Client Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "civisclient", "Civis Client Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -276,53 +280,64 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'CivisClient', 'Civis Client Documentation',
-   author, 'CivisClient', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        master_doc,
+        "CivisClient",
+        "Civis Client Documentation",
+        author,
+        "CivisClient",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 nitpick_ignore = [
-    ('envvar', 'CIVIS_API_KEY'),
-    ('py:class', 'concurrent.futures._base.Future'),
-    ('py:class', 'civis.base.CivisAsyncResultBase')
+    ("envvar", "CIVIS_API_KEY"),
+    ("py:class", "concurrent.futures._base.Future"),
+    ("py:class", "civis.base.CivisAsyncResultBase"),
 ]
 # Show tables of functions for each Resource class.
 numpydoc_show_class_members = True
 
 # Preserve signatures of a few methods wrapped with lru_cache. Need to set
 # this before we import civis. See https://stackoverflow.com/a/28371786.
-import functools
-import inspect
+import functools  # noqa: E402
+import inspect  # noqa: E402
+
 
 def noop_lru_cache(*args, **kwargs):
     def wrapper(func):
         def f(*args, **kwargs):
             return func(*args, **kwargs)
+
         f.__doc__ = func.__doc__
         f.__signature__ = inspect.signature(func)
         return f
+
     return wrapper
+
+
 functools.lru_cache = noop_lru_cache
 
 
 # Special functionality to accommodate autogenerated client.
 def _make_attr_docs(class_names, module_path):
-    doc = '\n    Attributes\n    ----------\n'
-    doc_fmt = '    {}\n        An instance of the {} endpoint\n'
+    doc = "\n    Attributes\n    ----------\n"
+    doc_fmt = "    {}\n        An instance of the {} endpoint\n"
     for name in class_names:
-        ref_link = ':class:`~{}.{}`'.format(module_path, name.title())
+        ref_link = ":class:`~{}.{}`".format(module_path, name.title())
         doc += doc_fmt.format(name, ref_link)
     return doc
 
@@ -332,14 +347,16 @@ def _attach_classes_to_module(module, class_data):
         setattr(module, class_name.title(), cls)
 
 
-_autodoc_fmt = ('.. autoclass:: {}\n'
-                '   :members:\n'
-                '   :exclude-members: __init__\n\n'
-                '   .. generatedautosummary:: {}\n\n')
+_autodoc_fmt = (
+    ".. autoclass:: {}\n"
+    "   :members:\n"
+    "   :exclude-members: __init__\n\n"
+    "   .. generatedautosummary:: {}\n\n"
+)
 
 
 def _write_resources_rst(class_names, filename, civis_module):
-    with open(filename, 'w') as resources_rst_file:
+    with open(filename, "w") as resources_rst_file:
         resources_rst_file.write(
             ".. _api_resources:\n\n"
             "API Resources\n"
@@ -359,11 +376,9 @@ def _write_resources_rst(class_names, filename, civis_module):
             endpoint_rst_filename = f"{endpoint_rst_filename_no_ext}.rst"
             resources_rst_file.write(f"   {endpoint_rst_filename_no_ext}\n")
             with open(endpoint_rst_filename, "w") as endpoint_rst_file:
-                endpoint_rst_file.write(
-                    f".. _{endpoint_rst_filename_no_ext}:\n\n"
-                )
+                endpoint_rst_file.write(f".. _{endpoint_rst_filename_no_ext}:\n\n")
                 endpoint_name = class_name.title()
-                full_path = '.'.join((civis_module, endpoint_name))
+                full_path = ".".join((civis_module, endpoint_name))
                 endpoint_rst_file.write(
                     f"{endpoint_name.replace('_', ' ')}\n"
                     f"{'=' * len(endpoint_name)}\n\n"
@@ -371,16 +386,18 @@ def _write_resources_rst(class_names, filename, civis_module):
                 endpoint_rst_file.write(_autodoc_fmt.format(full_path, full_path))
 
 
-import civis
+import civis  # noqa: E402
+
 _generated_attach_point = civis.resources._resources
-_generated_attach_path = 'civis.resources._resources'
-_rst_basename = 'api_resources.rst'
+_generated_attach_path = "civis.resources._resources"
+_rst_basename = "api_resources.rst"
 
 if os.getenv("FETCH_REMOTE_RESOURCES", "false").lower() == "true":
     api_key = os.environ.get("CIVIS_API_KEY")
     api_version = "1.0"
     extra_classes = civis.resources._resources.generate_classes(
-        api_key=api_key, api_version=api_version)
+        api_key=api_key, api_version=api_version
+    )
 else:
     import json
     from collections import OrderedDict
@@ -388,15 +405,12 @@ else:
     from civis.resources import API_SPEC_PATH
 
     with open(API_SPEC_PATH) as _raw:
-        api_spec = JsonRef.replace_refs(
-            json.load(_raw, object_pairs_hook=OrderedDict))
-    extra_classes = civis.resources._resources.parse_api_spec(
-        api_spec, '1.0')
+        api_spec = JsonRef.replace_refs(json.load(_raw, object_pairs_hook=OrderedDict))
+    extra_classes = civis.resources._resources.parse_api_spec(api_spec, "1.0")
 
 sorted_class_names = sorted(extra_classes.keys())
 
-civis.APIClient.__doc__ += _make_attr_docs(sorted_class_names,
-                                           _generated_attach_path)
+civis.APIClient.__doc__ += _make_attr_docs(sorted_class_names, _generated_attach_path)
 
 # TODO: The API endpoint doc details are in the stub file civis/client.pyi,
 #   but Sphinx still doesn't really support stub files
@@ -411,8 +425,9 @@ _write_resources_rst(sorted_class_names, _rst_basename, _generated_attach_path)
 
 # The following directive makes all (public) methods of an Endpoint
 # auto-discoverable. See https://stackoverflow.com/a/30783465
-from sphinx.ext.autosummary import Autosummary, get_documenter
-from sphinx.util.inspect import safe_getattr
+from sphinx.ext.autosummary import Autosummary, get_documenter  # noqa: E402
+from sphinx.util.inspect import safe_getattr  # noqa: E402
+
 
 class GeneratedAutosummary(Autosummary):
     """Helper for documenting all methods of an auto-generated endpoint."""
@@ -423,7 +438,7 @@ class GeneratedAutosummary(Autosummary):
     def get_members(obj, typ, public_only=True):
         items = []
         for name in dir(obj):
-            if public_only and name.startswith('_'):
+            if public_only and name.startswith("_"):
                 continue
             try:
                 documenter = get_documenter(None, safe_getattr(obj, name), obj)
@@ -435,12 +450,11 @@ class GeneratedAutosummary(Autosummary):
 
     def run(self):
         input_name = self.arguments[0]
-        module_name, class_name = input_name.rsplit('.', 1)
+        module_name, class_name = input_name.rsplit(".", 1)
         module = __import__(module_name, globals(), locals(), [class_name])
         klass = getattr(module, class_name)
-        methods = self.get_members(klass, 'method')
-        self.content = ['~{}.{}'.format(input_name, method)
-                        for method in methods]
+        methods = self.get_members(klass, "method")
+        self.content = ["~{}.{}".format(input_name, method) for method in methods]
         return super().run()
 
 
@@ -450,26 +464,31 @@ class GeneratedAutosummary(Autosummary):
 # There is a global `add_module_name` parameter that we want to set to False
 # for the autogenerated classes only. This needs to be done at the `Domain`
 # level since that is where the rst is actually parsed into nodes.
-from sphinx.domains.python import PythonDomain, PyClasslike
+from sphinx.domains.python import PythonDomain, PyClasslike  # noqa: E402
 
 _extra_class_titles = [klass.title() for klass in extra_classes.keys()]
+
 
 class MaybeHiddenModulePyClasslike(PyClasslike):
 
     def handle_signature(self, sig, signode):
         add_module_orig = self.env.config.add_module_names
         # Is this an autogenerated class?
-        toggle = (any(sig.startswith(title) for title in _extra_class_titles)
-                  and 'session' in sig and 'return_type' in sig)
+        toggle = (
+            any(sig.startswith(title) for title in _extra_class_titles)
+            and "session" in sig
+            and "return_type" in sig
+        )
         if toggle:
             self.env.config.add_module_names = False
         result = super().handle_signature(sig, signode)
         self.env.config.add_module_names = add_module_orig
         return result
 
-PythonDomain.directives['class'] = MaybeHiddenModulePyClasslike
+
+PythonDomain.directives["class"] = MaybeHiddenModulePyClasslike
 
 
 def setup(app):
-    app.add_directive('generatedautosummary', GeneratedAutosummary)
-    app.add_css_file('custom.css')
+    app.add_directive("generatedautosummary", GeneratedAutosummary)
+    app.add_css_file("custom.css")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,12 @@
 Civis API Python Client
 =======================
 
+.. meta::
+   :description:
+      The Civis API Python Client allows users to interact with Civis Platform programmatically using Python.
+   :keywords:
+      civis, civis platform, civis analytics, civis api, civis python,
+      data science, data engineering, data analysis, data analytics, machine learning
 
 .. include:: ../../README.rst
   :start-after: start-include-marker-introductory-paragraph

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Civis API Python Client
 
 .. meta::
    :description:
-      The Civis API Python Client allows users to interact with Civis Platform programmatically using Python.
+      The Civis API Python Client provides an interface in Python to interact with Civis Platform programmatically.
    :keywords:
       civis, civis platform, civis analytics, civis api, civis python,
       data science, data engineering, data analysis, data analytics, machine learning

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -166,7 +166,7 @@ by creating and registering a backend factory and entering a
 ``with parallel_config('civis')`` context. The code below will start
 seven different jobs in Civis Platform (with up to five running at once).
 Each job will call the function ``expensive_calculation`` with a
-different set of arguments from the list ``args``.::
+different set of arguments from the list ``args``::
 
     >>> def expensive_calculation(num1, num2):
     ...     return 2 * num1 + num2

--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -186,7 +186,7 @@ that can accept ``'generator'`` or ``'generator_unordered'``
 (default is ``'list'``, whose behavior is shown in the examples above).
 Returning a generator, especially the "unordered" version, instead of a list
 is useful for getting (partial) results back from Civis Platform faster
-as soon as any child job finishes (as opposed to having to waiting for _all_ child jobs
+as soon as any child job finishes (as opposed to having to waiting for `all` child jobs
 to finish before you get a resulting list). With ``return_as='generator_unordered'``,
 you might want to keep track of the ordering of the child jobs' results
 using :func:`enumerate`:
@@ -195,7 +195,6 @@ using :func:`enumerate`:
 
     >>> import inspect
     >>> import time
-    >>> # In your function, you might want an "order" index arg and return it at the end
     >>> def expensive_calculation(order, num):
     ...     # lower order for a longer sleep to simulate a longer job
     ...     time.sleep(10 ** (2 - order))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ docs = [
     # docs/requirements.txt pins all transitive dependencies for a reproducible doc build.
     "numpydoc == 1.7.0",
     "Sphinx == 7.3.7",
-    "sphinx-copybutton == 0.5.2",
     "sphinx-rtd-theme == 2.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,8 @@ docs = [
     # docs/requirements.txt pins all transitive dependencies for a reproducible doc build.
     "numpydoc == 1.7.0",
     "Sphinx == 7.3.7",
+    "sphinx-copybutton == 0.5.2",
     "sphinx-rtd-theme == 2.0.0",
-    "sphinx-toggleprompt == 0.5.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ docs = [
     "numpydoc == 1.7.0",
     "Sphinx == 7.3.7",
     "sphinx-rtd-theme == 2.0.0",
+    "sphinx-toggleprompt == 0.5.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = { text = "BSD-3-Clause" }
 dependencies = [
     "click >= 6.0",
     "cloudpickle >= 0.2",
-    "joblib >= 0.11",
+    "joblib >= 1.3.0",
     "jsonref >= 0.1",
     "jsonschema >= 2.5.1",
     "PyYAML >= 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ requires-python = ">= 3.9"
 authors = [ { name = "Civis Analytics", email = "opensource@civisanalytics.com" } ]
 license = { text = "BSD-3-Clause" }
 dependencies = [
-    "PyYAML >= 3.0",
     "click >= 6.0",
-    "jsonref >= 0.1",
-    "requests >= 2.12.0",
-    "jsonschema >= 2.5.1",
-    "joblib >= 1.3.0",
     "cloudpickle >= 0.2",
+    "joblib >= 0.11",
+    "jsonref >= 0.1",
+    "jsonschema >= 2.5.1",
+    "PyYAML >= 3.0",
+    "requests >= 2.32.3",
     "tenacity >= 6.2",
 ]
 classifiers = [
@@ -42,25 +42,27 @@ civis_joblib_worker = "civis.run_joblib_func:main"
 
 [project.optional-dependencies]
 dev-core = [
+    "bandit",  # Install the latest version.
     "black == 24.4.2",
-    "flake8 == 7.0.0",
-    "pytest == 8.2.0",
-    "pytest-cov == 5.0.0",
-    "twine == 5.0.0",
     "build == 1.2.1",
+    "flake8 == 7.0.0",
     "pandas == 2.2.2",
+    "pip-audit",  # Install the latest version.
+    "pytest == 8.2.1",
+    "pytest-cov == 5.0.0",
+    "twine == 5.1.0",
 ]
 dev-civisml = [
-    "numpy == 1.26.4",
-    "scikit-learn == 1.4.2",
-    "scipy == 1.13.0",
     "feather-format == 0.4.1",
+    "numpy == 1.26.4",
+    "scikit-learn == 1.5.0",
+    "scipy == 1.13.1",
 ]
 docs = [
     # docs/requirements.txt pins all transitive dependencies for a reproducible doc build.
+    "numpydoc == 1.7.0",
     "Sphinx == 7.3.7",
     "sphinx-rtd-theme == 2.0.0",
-    "numpydoc == 1.7.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -70,5 +72,5 @@ where = [ "src" ]
 civis = ["resources/*.json", "py.typed", "**/*.pyi"]
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --ignore=src/docs -vv --cov=src/civis"
+addopts = "--strict-markers -vv --cov=src/civis"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "jsonref >= 0.1",
     "requests >= 2.12.0",
     "jsonschema >= 2.5.1",
-    "joblib >= 0.11, < 1.3.0",
+    "joblib >= 1.3.0",
     "cloudpickle >= 0.2",
     "tenacity >= 6.2",
 ]

--- a/src/civis/base.py
+++ b/src/civis/base.py
@@ -49,7 +49,7 @@ class CivisJobFailure(Exception):
 
 def _err_msg_with_job_run_ids(err_msg, job_id, run_id) -> str:
     if job_id is None and run_id is None:
-        return err_msg
+        return str(err_msg)
     elif run_id is None:
         return f"(From job {job_id}) {err_msg}"
     else:

--- a/src/civis/base.py
+++ b/src/civis/base.py
@@ -49,7 +49,7 @@ class CivisJobFailure(Exception):
 
 def _err_msg_with_job_run_ids(err_msg, job_id, run_id) -> str:
     if job_id is None and run_id is None:
-        return str(err_msg)
+        return err_msg
     elif run_id is None:
         return f"(From job {job_id}) {err_msg}"
     else:

--- a/src/civis/futures.py
+++ b/src/civis/futures.py
@@ -685,11 +685,14 @@ class CustomScriptExecutor(_CivisExecutor):
     inc_script_names: bool, optional
         If ``True``, a counter will be added to the ``name`` to create
         the script names for each submission.
+    **kwargs:
+        Additional keyword arguments will be passed
+        directly to :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
 
     See Also
     --------
     civis.APIClient.scripts.post_custom
-    """
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -701,9 +704,11 @@ class CustomScriptExecutor(_CivisExecutor):
         client=None,
         polling_interval=None,
         inc_script_names=False,
+        **kwargs,
     ):
         self.from_template_id = from_template_id
         self.arguments = arguments
+        self.kwargs = kwargs
 
         if name is None:
             date_str = datetime.datetime.today().strftime("%Y-%m-%d")
@@ -747,5 +752,6 @@ class CustomScriptExecutor(_CivisExecutor):
             name=name,
             arguments=combined_args,
             hidden=self.hidden,
+            **self.kwargs,
         )
         return job

--- a/src/civis/futures.py
+++ b/src/civis/futures.py
@@ -503,15 +503,15 @@ class _ContainerShellExecutor(_CivisExecutor):
     Script inputs rather than over functions.
 
     Jobs created through this executor will have environment variables
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
-    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
-    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` with the contents
+    of the ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID`` of the environment which
+    created them. If the code doesn't have ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID``
     environment variables available, the child will not have
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` environment variables.
 
     .. note:: If you expect to run a large number of jobs, you may
               wish to set automatic retries of failed jobs
-              (via `max_n_retries`) to protect against network and
+              (via ``max_n_retries``) to protect against network and
               infrastructure failures. Be careful with this if your
               jobs cause side effects other than returning a result;
               retries may cause any operations executed by your jobs
@@ -550,13 +550,9 @@ class _ContainerShellExecutor(_CivisExecutor):
         If ``True``, a counter will be added to the ``name`` to create
         the script names for each submission.
     **kwargs:
-        Additional keyword arguments will be passed
-        directly to :func:`~civis.APIClient.scripts.post_containers`.
-
-    See Also
-    --------
-    civis.APIClient.scripts.post_containers
-    """
+        Additional keyword arguments will be passed directly to
+        :func:`civis.APIClient.scripts.post_containers<civis.resources._resources.Scripts.post_containers>`.
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -643,15 +639,15 @@ class CustomScriptExecutor(_CivisExecutor):
     :ref:`concurrent.futures`.
 
     If your template has settable parameters "CIVIS_PARENT_JOB_ID" and
-    "CIVIS_PARENT_RUN_ID", then this executor will fill them with the contents
-    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
-    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    ``CIVIS_PARENT_RUN_ID``, then this executor will fill them with the contents
+    of the ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID`` of the environment which
+    created them. If the code doesn't have ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID``
     environment variables available, the child will not have
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` environment variables.
 
     .. note:: If you expect to run a large number of jobs, you may
               wish to set automatic retries of failed jobs
-              (via `max_n_retries`) to protect against network and
+              (via ``max_n_retries``) to protect against network and
               infrastructure failures. Be careful with this if your
               jobs cause side effects other than returning a result;
               retries may cause any operations executed by your jobs
@@ -661,7 +657,7 @@ class CustomScriptExecutor(_CivisExecutor):
     ----------
     from_template_id: int
         Create jobs as Custom Scripts from the given template ID.
-    name: str
+    name: str, optional
         The name for containers in Civis.
     hidden: bool, optional
         The hidden status of the object. Setting this to ``True`` hides it
@@ -686,12 +682,8 @@ class CustomScriptExecutor(_CivisExecutor):
         If ``True``, a counter will be added to the ``name`` to create
         the script names for each submission.
     **kwargs:
-        Additional keyword arguments will be passed
-        directly to :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
-
-    See Also
-    --------
-    civis.APIClient.scripts.post_custom
+        Additional keyword arguments will be passed directly to
+        :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
     """  # noqa: E501
 
     def __init__(

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -12,11 +12,6 @@ import warnings
 
 import cloudpickle
 from joblib._parallel_backends import ParallelBackendBase
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    from joblib.my_exceptions import TransportableException
-
 from joblib import register_parallel_backend as _joblib_reg_para_backend
 import requests
 
@@ -794,9 +789,9 @@ class _CivisBackendResult:
 
         Raises
         ------
-        TransportableException
+        CivisJobFailure
             Any error in the remote job will result in a
-            ``TransportableException``, to be handled by ``Parallel.retrieve``.
+            ``CivisJobFailure``, to be handled by ``Parallel.retrieve``.
         futures.CancelledError
             If the remote job was cancelled before completion
         """
@@ -814,10 +809,7 @@ class _CivisBackendResult:
             if self.result is not None:
                 raise self.result
             else:
-                # Use repr for the message because the API exception
-                # typically has str(exc)==None.
-                exc = self._future.exception()
-                raise TransportableException(repr(exc), type(exc))
+                raise self._future.exception()
 
         return self.result
 

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -676,19 +676,19 @@ class _CivisBackendResult:
             """
             if fut.succeeded():
                 log.debug(
-                    "Ran job through Civis. Job ID: %d, run ID: %d;" " job succeeded!",
+                    "Ran job through Civis. Job ID: %d, run ID: %d; job succeeded!",
                     fut.job_id,
                     fut.run_id,
                 )
             elif fut.cancelled():
                 log.debug(
-                    "Ran job through Civis. Job ID: %d, run ID: %d;" " job cancelled!",
+                    "Ran job through Civis. Job ID: %d, run ID: %d; job cancelled!",
                     fut.job_id,
                     fut.run_id,
                 )
             else:
                 log.error(
-                    "Ran job through Civis. Job ID: %d, run ID: %d;" " job failure!",
+                    "Ran job through Civis. Job ID: %d, run ID: %d; job failure!",
                     fut.job_id,
                     fut.run_id,
                 )
@@ -780,7 +780,7 @@ class _CivisBackend(ParallelBackendBase):
     uses_threads = False
     supports_sharedmem = False
     supports_timeout = True
-    supports_retrieve_callback = False
+    supports_retrieve_callback = True
     supports_return_generator = True
 
     def __init__(
@@ -859,6 +859,17 @@ class _CivisBackend(ParallelBackendBase):
     def terminate(self):
         """Shutdown the workers and free the shared memory."""
         return self.abort_everything(ensure_ready=True)
+
+    def retrieve_result_callback(self, out):
+        """Called within the callback function passed in apply_async.
+
+        The argument of this function is the argument given to a callback in
+        the considered backend. It is supposed to return the outcome of a task
+        if it succeeded or raise the exception if it failed.
+        """
+        if isinstance(out, BaseException):
+            raise out
+        return out
 
     def apply_async(self, func, callback=None):
         """Schedule func to be run"""

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -313,8 +313,8 @@ def make_backend_factory(
         value ``'civis'``, one can potentially use more jobs than specified by
         ``n_jobs``.
     **kwargs:
-        Additional keyword arguments will be passed
-        directly to :func:`civis.APIClient.scripts.post_containers<civis.resources._resources.Scripts.post_containers>`.
+        Additional keyword arguments will be passed directly to
+        :func:`civis.APIClient.scripts.post_containers<civis.resources._resources.Scripts.post_containers>`.
 
     Examples
     --------
@@ -455,8 +455,8 @@ def make_backend_template_factory(
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
     **kwargs:
-        Additional keyword arguments will be passed
-        directly to :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
+        Additional keyword arguments will be passed directly to
+        :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
     """  # noqa: E501
 
     def backend_factory():
@@ -748,8 +748,7 @@ class _CivisBackendResult:
         Raises
         ------
         CivisJobFailure
-            Any error in the remote job will result in a
-            ``CivisJobFailure``, to be handled by ``Parallel.retrieve``.
+            Any error in the remote job will result in a ``CivisJobFailure``.
         futures.CancelledError
             If the remote job was cancelled before completion
         """

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -56,20 +56,20 @@ def infer_backend_factory(
 
     This function helps you run additional jobs from code which executes
     inside a Civis container job. The function reads settings for
-    relevant parameters (e.g. the Docker image) of the container
+    relevant parameters (e.g., the Docker image) of the container
     it's running inside of.
 
     Jobs created through this backend will have environment variables
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
-    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
-    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` with the contents
+    of the ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID`` of the environment which
+    created them. If the code doesn't have ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID``
     environment variables available, the child will not have
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` environment variables.
 
     .. note:: This function will read the state of the parent
               container job at the time this function executes. If the
               user has modified the container job since the run started
-              (e.g. by changing the GitHub branch in the container's GUI),
+              (e.g., by changing the GitHub branch in the container's GUI),
               this function may infer incorrect settings for the child jobs.
 
     Keyword arguments inferred from the existing script's state are
@@ -79,14 +79,13 @@ def infer_backend_factory(
     ----------
     required_resources : dict or None, optional
         The resources needed by the container. See the
-        `container scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
+        :ref:`container scripts API documentation<api_scripts_endpoint>`
         for details. Resource requirements not specified will
         default to the requirements of the current job.
     params : list or None, optional
         A definition of the parameters this script accepts in the
-        arguments field. See the `container scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
+        arguments field. See the
+        :ref:`container scripts API documentation<api_scripts_endpoint>`
         for details.
 
         Parameters of the child jobs will default to the parameters
@@ -94,31 +93,30 @@ def infer_backend_factory(
         parameters of the same name from the current job.
     arguments : dict or None, optional
         Dictionary of name/value pairs to use to run this script.
-        Only settable if this script has defined params. See the `container
-        scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
+        Only settable if this script has defined params. See the
+        :ref:`container scripts API documentation<api_scripts_endpoint>`
         for details.
 
         Arguments will default to the arguments of the current job.
         Anything provided here will override portions of the current job's
         arguments.
-    client : `civis.APIClient` instance or None, optional
+    client : ``civis.APIClient`` instance or None, optional
         An API Client object to use.
     polling_interval : int, optional
         The polling interval, in seconds, for checking container script status.
         If you have many jobs, you may want to set this higher (e.g., 300) to
-        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        avoid `rate-limiting <https://platform.civisanalytics.com/spa/#/api>`_.
     setup_cmd : str, optional
         A shell command or sequence of commands for setting up the environment.
         These will precede the commands used to run functions in joblib.
         This is primarily for installing dependencies that are not available
-        in the dockerhub repo (e.g., "cd /app && pip install ."
-        or "pip install gensim").
+        in the Docker image (e.g., ``cd /app && pip install .``
+        or ``pip install gensim``).
 
         With no GitHub repo input, the setup command will
         default to a command that does nothing. If a ``repo_http_uri``
         is provided, the default setup command will attempt to run
-        "pip install .". If this command fails, execution
+        ``pip install .``. If this command fails, execution
         will still continue.
     max_submit_retries : int, optional
         The maximum number of retries for submitting each job. This is to help
@@ -134,16 +132,16 @@ def infer_backend_factory(
         These retries assist with jobs which may have failed because
         of network or worker failures.
     hidden: bool, optional
-        The hidden status of the object. Setting this to true
+        The hidden status of the object. Setting this to True
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential
+        container. The default of ``'sequential'`` uses the joblib sequential
         backend in the container. The value 'civis' uses an exact copy of the
         Civis joblib backend that launched the container. Note that with the
-        value 'civis', one can potentially use more jobs than specified by
+        value ``'civis'``, one can potentially use more jobs than specified by
         ``n_jobs``.
     **kwargs:
         Additional keyword arguments will be passed directly to
@@ -246,22 +244,22 @@ def make_backend_factory(
     remote_backend="sequential",
     **kwargs,
 ):
-    """Create a joblib backend factory that uses Civis Container Scripts
+    """Create a joblib backend factory that uses Civis Container Scripts.
 
     Jobs created through this backend will have environment variables
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" with the contents
-    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
-    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` with the contents
+    of the ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID`` of the environment which
+    created them. If the code doesn't have ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID``
     environment variables available, the child will not have
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` environment variables.
 
-    .. note:: The total size of function parameters in `Parallel()`
+    .. note:: The total size of function parameters in ``Parallel()``
               calls on this backend must be less than 5 GB due to
               AWS file size limits.
 
-    .. note:: The maximum number of concurrent jobs in the Civis Platform
+    .. note:: The maximum number of concurrent jobs in Civis Platform
               is controlled by both the ``n_jobs`` and ``pre_dispatch``
-              parameters of ``joblib.Parallel``.
+              parameters of :class:`joblib.Parallel`.
               Set ``pre_dispatch="n_jobs"`` to have a maximum of
               ``n_jobs`` processes running at once.
               (The default is ``pre_dispatch="2*n_jobs"``.)
@@ -271,23 +269,23 @@ def make_backend_factory(
     docker_image_name : str, optional
         The image for the container script. You may also wish to specify
         a ``docker_image_tag`` in the keyword arguments.
-    client : `civis.APIClient` instance or None, optional
+    client : ``civis.APIClient`` instance or None, optional
         An API Client object to use.
     polling_interval : int, optional
         The polling interval, in seconds, for checking container script status.
         If you have many jobs, you may want to set this higher (e.g., 300) to
-        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        avoid `rate-limiting <https://platform.civisanalytics.com/spa/#/api>`_.
     setup_cmd : str, optional
         A shell command or sequence of commands for setting up the environment.
         These will precede the commands used to run functions in joblib.
         This is primarily for installing dependencies that are not available
-        in the dockerhub repo (e.g., "cd /app && pip install ."
-        or "pip install gensim").
+        in the dockerhub repo (e.g., ``cd /app && pip install .``
+        or ``pip install gensim``).
 
         With no GitHub repo input, the setup command will
-        default to a command that does nothing. If a `repo_http_uri`
+        default to a command that does nothing. If a ``repo_http_uri``
         is provided, the default setup command will attempt to run
-        "pip install .". If this command fails, execution
+        ``pip install .``. If this command fails, execution
         will still continue.
     max_submit_retries : int, optional
         The maximum number of retries for submitting each job. This is to help
@@ -297,7 +295,7 @@ def make_backend_factory(
         whether they are run once or many times).
     max_job_retries : int, optional
         Retry failed jobs this number of times before giving up.
-        Even more than with `max_submit_retries`, this should only
+        Even more than with ``max_submit_retries``, this should only
         be used for jobs which are idempotent, as the job may have
         caused side effects (if any) before failing.
         These retries assist with jobs which may have failed because
@@ -309,10 +307,10 @@ def make_backend_factory(
     remote_backend : str or object, optional
         The name of a joblib backend or a joblib backend itself. This parameter
         is the joblib backend to use when executing code within joblib in the
-        container. The default of 'sequential' uses the joblib sequential
-        backend in the container. The value 'civis' uses an exact copy of the
+        container. The default of ``'sequential'`` uses the joblib sequential
+        backend in the container. The value ``'civis'`` uses an exact copy of the
         Civis joblib backend that launched the container. Note that with the
-        value 'civis', one can potentially use more jobs than specified by
+        value ``'civis'``, one can potentially use more jobs than specified by
         ``n_jobs``.
     **kwargs:
         Additional keyword arguments will be passed
@@ -376,8 +374,8 @@ def make_backend_factory(
     deserialize the jobs they are given, including the data and all the
     necessary Python objects (e.g., if you pass a Pandas data frame, the image
     must have Pandas installed). You may use functions and classes
-    dynamically defined in the code (e.g. lambda functions), but
-    if your joblib-parallized function calls code imported from another
+    dynamically defined in the code (e.g., lambda functions), but
+    if your joblib-parallelized function calls code imported from another
     module, that module must be installed in the remote environment.
 
     See Also
@@ -417,12 +415,12 @@ def make_backend_template_factory(
 ):
     """Create a joblib backend factory that uses Civis Custom Scripts.
 
-    If your template has settable parameters "CIVIS_PARENT_JOB_ID" and
-    "CIVIS_PARENT_RUN_ID", then this executor will fill them with the contents
-    of the "CIVIS_JOB_ID" and "CIVIS_RUN_ID" of the environment which
-    created them. If the code doesn't have "CIVIS_JOB_ID" and "CIVIS_RUN_ID"
+    If your template has settable parameters ``CIVIS_PARENT_JOB_ID`` and
+    ``CIVIS_PARENT_RUN_ID``, then this executor will fill them with the contents
+    of the ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID`` of the environment which
+    created them. If the code doesn't have ``CIVIS_JOB_ID`` and ``CIVIS_RUN_ID``
     environment variables available, the child will not have
-    "CIVIS_PARENT_JOB_ID" and "CIVIS_PARENT_RUN_ID" environment variables.
+    ``CIVIS_PARENT_JOB_ID`` and ``CIVIS_PARENT_RUN_ID`` environment variables.
 
     Parameters
     ----------
@@ -433,16 +431,15 @@ def make_backend_template_factory(
         to the documentation for details.
     arguments : dict or None, optional
         Dictionary of name/value pairs to use to run this script.
-        Only settable if this script has defined params. See the `container
-        scripts API documentation
-        <https://platform.civisanalytics.com/api#resources-scripts>`
+        Only settable if this script has defined params. See the
+        :ref:`container scripts API documentation<api_scripts_endpoint>`
         for details.
-    client : `civis.APIClient` instance or None, optional
+    client : ``civis.APIClient`` instance or None, optional
         An API Client object to use.
     polling_interval : int, optional
         The polling interval, in seconds, for checking container script status.
         If you have many jobs, you may want to set this higher (e.g., 300) to
-        avoid `rate-limiting <https://platform.civisanalytics.com/api#basics>`.
+        avoid `rate-limiting <https://platform.civisanalytics.com/spa/#/api>`_.
     max_submit_retries : int, optional
         The maximum number of retries for submitting each job. This is to help
         avoid a large set of jobs failing because of a single 5xx error. A
@@ -451,13 +448,13 @@ def make_backend_template_factory(
         whether they are run once or many times).
     max_job_retries : int, optional
         Retry failed jobs this number of times before giving up.
-        Even more than with `max_submit_retries`, this should only
+        Even more than with ``max_submit_retries``, this should only
         be used for jobs which are idempotent, as the job may have
         caused side effects (if any) before failing.
         These retries assist with jobs which may have failed because
         of network or worker failures.
     hidden: bool, optional
-        The hidden status of the object. Setting this to true
+        The hidden status of the object. Setting this to True
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
     """
@@ -477,6 +474,8 @@ def make_backend_template_factory(
 
 
 class JobSubmissionError(Exception):
+    """An error occurred while submitting a job to Civis Platform."""
+
     pass
 
 

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -314,7 +314,7 @@ def make_backend_factory(
         ``n_jobs``.
     **kwargs:
         Additional keyword arguments will be passed
-        directly to :func:`~civis.APIClient.scripts.post_containers`.
+        directly to :func:`civis.APIClient.scripts.post_containers<civis.resources._resources.Scripts.post_containers>`.
 
     Examples
     --------
@@ -377,11 +377,7 @@ def make_backend_factory(
     dynamically defined in the code (e.g., lambda functions), but
     if your joblib-parallelized function calls code imported from another
     module, that module must be installed in the remote environment.
-
-    See Also
-    --------
-    civis.APIClient.scripts.post_containers
-    """
+    """  # noqa: E501
     if setup_cmd is None:
         if kwargs.get("repo_http_uri"):
             setup_cmd = _DEFAULT_REPO_SETUP_CMD
@@ -412,6 +408,7 @@ def make_backend_template_factory(
     max_submit_retries=0,
     max_job_retries=0,
     hidden=True,
+    **kwargs,
 ):
     """Create a joblib backend factory that uses Civis Custom Scripts.
 
@@ -457,7 +454,10 @@ def make_backend_template_factory(
         The hidden status of the object. Setting this to True
         hides it from most API endpoints. The object can still
         be queried directly by ID. Defaults to True.
-    """
+    **kwargs:
+        Additional keyword arguments will be passed
+        directly to :func:`civis.APIClient.scripts.post_custom<civis.resources._resources.Scripts.post_custom>`.
+    """  # noqa: E501
 
     def backend_factory():
         return _CivisBackend(
@@ -468,6 +468,7 @@ def make_backend_template_factory(
             max_submit_retries=max_submit_retries,
             max_n_retries=max_job_retries,
             hidden=hidden,
+            **kwargs,
         )
 
     return backend_factory

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -781,6 +781,8 @@ class _CivisBackend(ParallelBackendBase):
     uses_threads = False
     supports_sharedmem = False
     supports_timeout = True
+    supports_retrieve_callback = False
+    supports_return_generator = True
 
     def __init__(
         self,
@@ -792,6 +794,7 @@ class _CivisBackend(ParallelBackendBase):
         nesting_level=0,
         **executor_kwargs,
     ):
+        super().__init__()
         self.setup_cmd = setup_cmd
         self.from_template_id = from_template_id
         self.max_submit_retries = max_submit_retries

--- a/src/civis/run_joblib_func.py
+++ b/src/civis/run_joblib_func.py
@@ -16,13 +16,7 @@ import sys
 
 import civis
 import cloudpickle
-
-try:
-    from joblib import parallel_config
-except ImportError:
-    # Since joblib v1.3.0, parallel_config has become available
-    # and is the recommended option over the deprecated parallel_backend.
-    from joblib import parallel_backend as parallel_config
+from joblib import parallel_config
 
 from civis.parallel import (
     _robust_pickle_download,

--- a/src/civis/run_joblib_func.py
+++ b/src/civis/run_joblib_func.py
@@ -17,12 +17,6 @@ import warnings
 
 import civis
 import cloudpickle
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    from joblib.my_exceptions import TransportableException
-
-from joblib.format_stack import format_exc
 from joblib import parallel_backend as _joblib_para_backend
 
 try:
@@ -88,13 +82,9 @@ def worker_func(func_file_id):
             with _sklearn_para_backend(_backend):
                 with _joblib_para_backend(_backend):
                     result = func()
-    except Exception:
+    except Exception as exc:
         print("Error! Attempting to record exception.")
-        # Wrap the exception in joblib's TransportableException
-        # so that joblib can properly display the results.
-        e_type, e_value, e_tb = sys.exc_info()
-        text = format_exc(e_type, e_value, e_tb, context=10, tb_offset=1)
-        result = TransportableException(text, e_type)
+        result = exc  # TODO check how this exc result is going to be used downstream
         raise
     finally:
         # Serialize the result and upload it to the Files API.

--- a/src/civis/run_joblib_func.py
+++ b/src/civis/run_joblib_func.py
@@ -48,7 +48,7 @@ def worker_func(func_file_id):
             result = func()
     except Exception as exc:
         print("Error! Attempting to record exception.")
-        result = exc  # TODO check how this exc result is going to be used downstream
+        result = exc
         raise
     finally:
         # Serialize the result and upload it to the Files API.

--- a/src/civis/run_joblib_func.py
+++ b/src/civis/run_joblib_func.py
@@ -13,32 +13,10 @@ from io import BytesIO
 import os
 import pickle  # nosec
 import sys
-import warnings
 
 import civis
 import cloudpickle
-from joblib import parallel_backend as _joblib_para_backend
-
-try:
-    with warnings.catch_warnings():
-        # Ignore the warning: "DeprecationWarning: sklearn.externals.joblib is
-        # deprecated in 0.21 and will be removed in 0.23. Please import this
-        # functionality directly from joblib, which can be installed with:
-        # pip install joblib. If this warning is raised when loading pickled
-        # models, you may need to re-serialize those models with
-        # scikit-learn 0.21+."
-        warnings.simplefilter("ignore", DeprecationWarning)
-        # sklearn 0.22 has switched from DeprecationWarning to FutureWarning
-        warnings.simplefilter("ignore", FutureWarning)
-        from sklearn.externals.joblib import parallel_backend as _sklearn_para_backend
-
-        # NO_SKLEARN_BACKEND would be a better name here since it'll be true
-        # for future scikit-learn versions that won't include the joblib
-        # module as well as when scikit-learn isn't installed, but changing
-        # the name would technically be a breaking change.
-        NO_SKLEARN = False
-except ImportError:
-    NO_SKLEARN = True
+from joblib import parallel_backend
 
 from civis.parallel import (
     _robust_pickle_download,
@@ -66,22 +44,8 @@ def worker_func(func_file_id):
 
         _backend = _setup_remote_backend(remote_backend)
 
-        # graceful nested context managers are ~hard across python versions,
-        # this just works...
-        if NO_SKLEARN:
-            with _joblib_para_backend(_backend):
-                result = func()
-        else:
-            # we are using the nested context managers to set the joblib
-            # backend to the requested one in both copes of joblib, the
-            # package and the copy shipped by sklearn at
-            # `sklearn.externals.joblib`. joblib maintains the current
-            # backend as global state in the package and thus there are
-            # two backends to set when you have two copies of the package
-            # in play.
-            with _sklearn_para_backend(_backend):
-                with _joblib_para_backend(_backend):
-                    result = func()
+        with parallel_backend(_backend):
+            result = func()
     except Exception as exc:
         print("Error! Attempting to record exception.")
         result = exc  # TODO check how this exc result is going to be used downstream

--- a/src/civis/run_joblib_func.py
+++ b/src/civis/run_joblib_func.py
@@ -16,7 +16,13 @@ import sys
 
 import civis
 import cloudpickle
-from joblib import parallel_backend
+
+try:
+    from joblib import parallel_config
+except ImportError:
+    # Since joblib v1.3.0, parallel_config has become available
+    # and is the recommended option over the deprecated parallel_backend.
+    from joblib import parallel_backend as parallel_config
 
 from civis.parallel import (
     _robust_pickle_download,
@@ -44,7 +50,7 @@ def worker_func(func_file_id):
 
         _backend = _setup_remote_backend(remote_backend)
 
-        with parallel_backend(_backend):
+        with parallel_config(_backend):
             result = func()
     except Exception as exc:
         print("Error! Attempting to record exception.")

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -538,22 +538,12 @@ def test_result_running_and_cancel_requested(mock_civis):
 
 
 @mock.patch.object(civis.parallel, "civis")
-@mock.patch.object(civis.parallel, "_sklearn_reg_para_backend")
-@mock.patch.object(civis.parallel, "_joblib_reg_para_backend")
-def test_setup_remote_backend(mock_jl, mock_sk, mock_civis):
-    # Test that the civis backend is properly registered w/ joblib and sklearn.
-    for no_sk in [True, False]:
-        with mock.patch.object(civis.parallel, "NO_SKLEARN", no_sk):
-            backend = civis.parallel._CivisBackend()
-            backend_name = civis.parallel._setup_remote_backend(backend)
-            assert backend_name == "civis"
-            assert mock_jl.call_count == 1
-            if no_sk:
-                assert mock_sk.call_count == 0
-            else:
-                assert mock_sk.call_count == 1
-            mock_jl.reset_mock()
-            mock_sk.reset_mock()
+@mock.patch.object(civis.parallel, "register_parallel_backend")
+def test_setup_remote_backend(mock_register, mock_civis):
+    backend = civis.parallel._CivisBackend()
+    backend_name = civis.parallel._setup_remote_backend(backend)
+    assert backend_name == "civis"
+    assert mock_register.call_count == 1
 
 
 def test_civis_backend_from_existing():

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -457,7 +457,7 @@ def test_result_exception_no_result(m_sleep):
     )
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
-    fut._set_api_exception(CivisJobFailure(Response({"state": "failed"})))
+    fut._set_api_exception(CivisJobFailure(str(Response({"state": "failed"}))))
 
     with pytest.raises(CivisJobFailure) as exc:
         res.get()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,16 +1,11 @@
 from math import sqrt
 import io
 import pickle
-import warnings
 from unittest import mock
 
 import pytest
 from joblib import delayed, Parallel
 from joblib import parallel_backend, register_parallel_backend
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    from joblib.my_exceptions import TransportableException
 
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.response import Response
@@ -447,7 +442,7 @@ def test_result_exception(m_sleep, mock_civis):
 @mock.patch("civis.futures.time.sleep", side_effect=lambda x: None)
 def test_result_exception_no_result(m_sleep):
     # If the job errored but didn't write an output, we should get
-    # a generic TransportableException back.
+    # a CivisJobFailure back.
     callback = mock.MagicMock()
 
     mock_client = create_client_mock_for_container_tests(
@@ -457,7 +452,7 @@ def test_result_exception_no_result(m_sleep):
     res = civis.parallel._CivisBackendResult(fut, callback)
     fut._set_api_exception(CivisJobFailure(Response({"state": "failed"})))
 
-    with pytest.raises(TransportableException) as exc:
+    with pytest.raises(CivisJobFailure) as exc:
         res.get()
 
     assert "Response(state='failed')" in str(exc.value)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -5,14 +5,7 @@ from unittest import mock
 
 import pytest
 import requests
-from joblib import delayed, Parallel, register_parallel_backend
-
-try:
-    from joblib import parallel_config
-except ImportError:
-    # Since joblib v1.3.0, parallel_config has become available
-    # and is the recommended option over the deprecated parallel_backend.
-    from joblib import parallel_backend as parallel_config
+from joblib import delayed, Parallel, parallel_config, register_parallel_backend
 
 import civis.parallel
 from civis.base import CivisAPIError, CivisJobFailure
@@ -457,7 +450,7 @@ def test_result_exception_no_result(m_sleep):
     )
     fut = ContainerFuture(1, 2, client=mock_client)
     res = civis.parallel._CivisBackendResult(fut, callback)
-    fut._set_api_exception(CivisJobFailure(str(Response({"state": "failed"}))))
+    fut._set_api_exception(CivisJobFailure(Response({"state": "failed"})))
 
     with pytest.raises(CivisJobFailure) as exc:
         res.get()


### PR DESCRIPTION
Major changes from joblib v1.2.0 to v1.3.0 are incompatible with civis-python. This issue was first reported in #468, and was temporarily fixed by pinning joblib at < v1.3.0 in #469. This pull request updates civis-python so that now it works with joblib >= v1.3.0. After this pull request is merged, I will not make a new civis-python release yet (I have one or two more pull requests in mind before another release). For this pull request, copying notes from the changelog being updated:

### Changed
- Refactored the `civis.parallel` module and related unit tests due to major changes
  of joblib from v1.2.0 to v1.3.0 (API-breaking changes for dropping
  `joblib.my_exceptions.TransportableException` and `joblib.format_stack.format_exc`,
  as well as the substantial changes to the internals of `joblib.Parallel`).
- Bumped the minimum required version of `joblib` to v1.3.0,
  which is the version where `joblib.parallel_config` was introduced and
  `joblib.parallel_backend` was deprecated.

### Fixed
- Fixed `civis.parallel.make_backend_template_factory` so that
  keyword arguments are now accepted and passed to `client.scripts.post_custom`.

### Security
- Bumped the minimum required version of `requests` to the latest v2.32.3, 
  due to a security vulnerability for < v2.32.0 ([CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195)).


---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
