### PR TITLE
[CIVIS-8658] PERF speed up startup time

### DIFF
--- a/src/civis/__init__.py
+++ b/src/civis/__init__.py
@@ -1,11 +1,28 @@
+import importlib
+import sys
 from importlib.metadata import version
 
 from civis.client import APIClient
 from civis.loggers import civis_logger
 from civis.response import find, find_one
 from civis.service_client import ServiceClient
-from civis import io, ml, parallel, utils
 
+
+def _lazy_import(name):
+    # https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
+
+
+io = _lazy_import("civis.io")
+ml = _lazy_import("civis.ml")
+parallel = _lazy_import("civis.parallel")
+utils = _lazy_import("civis.utils")
 
 __version__ = version("civis")
 __all__ = [

--- a/src/civis/_camel_to_snake.py
+++ b/src/civis/_camel_to_snake.py
@@ -1,0 +1,15 @@
+# The `camel_to_snake` function is used in multiple modules.
+# To avoid creating import overhead, it's defined in a separate module here
+# as opposed to in a module that itself has a fair amount of overhead.
+
+import re
+
+
+UNDERSCORER1 = re.compile(r"(.)([A-Z][a-z]+)")
+UNDERSCORER2 = re.compile("([a-z0-9])([A-Z])")
+
+
+def camel_to_snake(word):
+    # https://gist.github.com/jaytaylor/3660565
+    word = UNDERSCORER1.sub(r"\1_\2", word)
+    return UNDERSCORER2.sub(r"\1_\2", word).lower()

--- a/src/civis/_utils.py
+++ b/src/civis/_utils.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import time
 import uuid
 from random import random
@@ -28,10 +27,6 @@ def maybe_get_random_name(name):
     if not name:
         name = uuid.uuid4().hex
     return name
-
-
-def to_camelcase(s):
-    return re.sub(r"(^|_)([a-zA-Z])", lambda m: m.group(2).upper(), s)
 
 
 def get_api_key(api_key):

--- a/src/civis/_utils.py
+++ b/src/civis/_utils.py
@@ -16,8 +16,7 @@ from tenacity.wait import wait_base
 
 
 log = logging.getLogger(__name__)
-UNDERSCORER1 = re.compile(r"(.)([A-Z][a-z]+)")
-UNDERSCORER2 = re.compile("([a-z0-9])([A-Z])")
+
 MAX_RETRIES = 10
 
 _RETRY_CODES = [429, 502, 503, 504]
@@ -29,12 +28,6 @@ def maybe_get_random_name(name):
     if not name:
         name = uuid.uuid4().hex
     return name
-
-
-def camel_to_snake(word):
-    # https://gist.github.com/jaytaylor/3660565
-    word = UNDERSCORER1.sub(r"\1_\2", word)
-    return UNDERSCORER2.sub(r"\1_\2", word).lower()
 
 
 def to_camelcase(s):

--- a/src/civis/ml/_model.py
+++ b/src/civis/ml/_model.py
@@ -26,7 +26,7 @@ except ImportError:
     HAS_SKLEARN = False
 
 from civis import APIClient, find, find_one
-from civis._utils import camel_to_snake
+from civis._camel_to_snake import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
 import civis.io as cio
 from civis.futures import ContainerFuture

--- a/src/civis/resources/__init__.py
+++ b/src/civis/resources/__init__.py
@@ -5,7 +5,6 @@ from ._resources import (
     CACHED_SPEC_PATH,
     cache_api_spec,
     API_SPEC_PATH,
-    API_SPEC,
 )
 
 __all__ = [
@@ -15,5 +14,4 @@ __all__ = [
     "CACHED_SPEC_PATH",
     "cache_api_spec",
     "API_SPEC_PATH",
-    "API_SPEC",
 ]

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -11,7 +11,8 @@ import requests
 from requests import Request
 
 from civis.base import Endpoint, get_base_url, open_session
-from civis._utils import camel_to_snake, get_api_key, retry_request, MAX_RETRIES
+from civis._camel_to_snake import camel_to_snake
+from civis._utils import get_api_key, retry_request, MAX_RETRIES
 
 
 API_VERSIONS = frozenset({"1.0"})

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -44,6 +44,8 @@ ITERATOR_PARAM_DESC = (
 CACHED_SPEC_PATH = os.path.join(os.path.expanduser("~"), ".civis_api_spec.json")
 DEFAULT_ARG_VALUE = None
 
+_BRACKETED_REGEX = re.compile(r"^{.*}$")
+
 
 def exclude_resource(path, api_version):
     # TODO: api_version is not used here.
@@ -333,7 +335,7 @@ def raise_for_unexpected_kwargs(
 
 
 def bracketed(x):
-    return re.search("^{.*}$", x)
+    return _BRACKETED_REGEX.search(x)
 
 
 def parse_param(param):
@@ -456,7 +458,7 @@ def parse_method_name(verb, path):
     verb = "list" if verb == "get" and (not bracketed(final_elem)) else verb
     path_name = "_".join(name_elems)
     method_name = "_".join((verb, path_name)) if path_name else verb
-    return re.sub("-", "_", method_name)
+    return method_name.replace("-", "_")
 
 
 def parse_method(verb, operation, path):
@@ -487,7 +489,7 @@ def parse_path(path, operations, api_version):
     attached to the class as a method.
     """
     path = path.strip("/")
-    modified_base_path = re.sub("-", "_", path.split("/")[0].lower())
+    modified_base_path = path.split("/")[0].lower().replace("-", "_")
     methods = []
     if exclude_resource(path, api_version):
         return modified_base_path, methods

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -23,8 +23,6 @@ API_SPEC_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     "civis_api_spec.json",
 )
-with open(API_SPEC_PATH) as f:
-    API_SPEC = json.load(f, object_pairs_hook=OrderedDict)
 
 # "feature_flags" has a name collision with an APIClient instance.
 RESOURCES_TO_EXCLUDE = frozenset({"feature_flags"})

--- a/src/civis/response.py
+++ b/src/civis/response.py
@@ -4,7 +4,7 @@ import pprint
 
 import requests
 
-from civis._utils import camel_to_snake
+from civis._camel_to_snake import camel_to_snake
 
 
 _RETURN_TYPES = frozenset({"snake", "raw"})

--- a/src/civis/service_client.py
+++ b/src/civis/service_client.py
@@ -8,7 +8,6 @@ import requests
 from civis import APIClient
 from civis.base import CivisAPIError, Endpoint, tostr_urljoin
 from civis.resources._resources import parse_method
-from civis._utils import to_camelcase
 
 
 def _get_service(client):
@@ -199,3 +198,7 @@ class ServiceClient:
             spec = JsonRef.replace_refs(raw_spec)
             classes = parse_service_api_spec(spec, root_path=self._root_path)
         return classes
+
+
+def to_camelcase(s):
+    return re.sub(r"(^|_)([a-zA-Z])", lambda m: m.group(2).upper(), s)

--- a/src/civis/service_client.py
+++ b/src/civis/service_client.py
@@ -10,6 +10,9 @@ from civis.base import CivisAPIError, Endpoint, tostr_urljoin
 from civis.resources._resources import parse_method
 
 
+_TO_CAMELCASE_REGEX = re.compile(r"(^|_)([a-zA-Z])")
+
+
 def _get_service(client):
     if client._api_key:
         api_client = APIClient(client._api_key)
@@ -34,7 +37,7 @@ def _parse_service_path(path, operations, root_path=None):
     if root_path is not None:
         path = path.replace(root_path, "")
     path = path.strip("/")
-    modified_base_path = re.sub("-", "_", path.split("/")[0].lower())
+    modified_base_path = path.split("/")[0].lower().replace("-", "_")
     methods = []
     for verb, op in operations.items():
         method = parse_method(verb, op, path)
@@ -201,4 +204,4 @@ class ServiceClient:
 
 
 def to_camelcase(s):
-    return re.sub(r"(^|_)([a-zA-Z])", lambda m: m.group(2).upper(), s)
+    return _TO_CAMELCASE_REGEX.sub(lambda m: m.group(2).upper(), s)

--- a/tests/test_camel_to_snake.py
+++ b/tests/test_camel_to_snake.py
@@ -1,0 +1,12 @@
+from civis._camel_to_snake import camel_to_snake
+
+
+def test_camel_to_snake():
+    test_cases = [
+        ("CAMELCase", "camel_case"),
+        ("camelCase", "camel_case"),
+        ("CamelCase", "camel_case"),
+        ("c__amel", "c__amel"),
+    ]
+    for in_word, out_word in test_cases:
+        assert camel_to_snake(in_word) == out_word

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,15 @@
+import json
+from collections import OrderedDict
 from unittest import mock
 
 import pytest
 
 from civis import APIClient
-from civis.resources import API_SPEC
+from civis.resources import API_SPEC_PATH
 
-api_import_str = "civis.resources._resources.get_api_spec"
+
+with open(API_SPEC_PATH) as f:
+    API_SPEC = json.load(f, object_pairs_hook=OrderedDict)
 
 
 class FakeUsersEndpoint:

--- a/tests/test_ml/test_model.py
+++ b/tests/test_ml/test_model.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-from civis._utils import camel_to_snake
+from civis._camel_to_snake import camel_to_snake
 from civis.base import CivisAPIError, CivisJobFailure
 from civis.response import Response
 from civis.tests import create_client_mock, create_client_mock_for_container_tests

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from collections import defaultdict, OrderedDict
@@ -8,9 +9,13 @@ from jsonref import JsonRef
 from requests.exceptions import HTTPError
 
 from civis.base import Endpoint
-from civis.resources import _resources, API_SPEC, API_SPEC_PATH
+from civis.resources import _resources, API_SPEC_PATH
 from civis.resources._client_pyi import generate_client_pyi, CLIENT_PYI_PATH
 from civis.tests import create_client_mock
+
+
+with open(API_SPEC_PATH) as f:
+    API_SPEC = json.load(f, object_pairs_hook=OrderedDict)
 
 
 RESPONSE_DOC = """Returns

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -17,7 +17,7 @@ from civis.response import (
     CivisImmutableResponseError,
     find,
 )
-from civis._utils import camel_to_snake
+from civis._camel_to_snake import camel_to_snake
 
 
 def _create_mock_response(data, headers):

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -11,6 +11,7 @@ from civis.service_client import (
     _get_service,
     _parse_service_path,
     parse_service_api_spec,
+    to_camelcase,
 )
 import pytest
 
@@ -317,3 +318,13 @@ def test_make_request(auth_mock, request_mock):
     response = se._make_request("get", "resources/resources")
 
     assert response.json == expected_value
+
+
+def test_tocamlecase():
+    test_cases = [
+        ("snake_case", "SnakeCase"),
+        ("Snake_Case", "SnakeCase"),
+        ("snakecase", "Snakecase"),
+    ]
+    for in_word, out_word in test_cases:
+        assert to_camelcase(in_word) == out_word

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,23 +5,12 @@ from requests import ConnectionError, ConnectTimeout
 from datetime import datetime
 from math import floor
 
-from civis._utils import camel_to_snake, to_camelcase, maybe_get_random_name
+from civis._utils import to_camelcase, maybe_get_random_name
 from civis._utils import retry
 from civis._utils import retry_request
 from civis._utils import _RETRY_VERBS, _RETRY_CODES, _POST_RETRY_CODES
 
 import pytest
-
-
-def test_camel_to_snake():
-    test_cases = [
-        ("CAMELCase", "camel_case"),
-        ("camelCase", "camel_case"),
-        ("CamelCase", "camel_case"),
-        ("c__amel", "c__amel"),
-    ]
-    for in_word, out_word in test_cases:
-        assert camel_to_snake(in_word) == out_word
 
 
 def test_tocamlecase():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,22 +5,12 @@ from requests import ConnectionError, ConnectTimeout
 from datetime import datetime
 from math import floor
 
-from civis._utils import to_camelcase, maybe_get_random_name
+from civis._utils import maybe_get_random_name
 from civis._utils import retry
 from civis._utils import retry_request
 from civis._utils import _RETRY_VERBS, _RETRY_CODES, _POST_RETRY_CODES
 
 import pytest
-
-
-def test_tocamlecase():
-    test_cases = [
-        ("snake_case", "SnakeCase"),
-        ("Snake_Case", "SnakeCase"),
-        ("snakecase", "Snakecase"),
-    ]
-    for in_word, out_word in test_cases:
-        assert to_camelcase(in_word) == out_word
 
 
 @mock.patch("civis._utils.uuid")


### PR DESCRIPTION
The startup time when just running `import civis` in a fresh Python interpreter session appears to be long. This is especially noticeable in an interactive environment (the regular Python interactive interpreter, IPython, or a Jupyter notebook), which isn't great for user experience. This pull request applies lazy imports to the top-level `civis.*` modules, for a speed boost of about 5x. The relatively long startup time was due to importing dependencies like pandas through `civis.io` and other pydata packages (numpy, scipy) through `civis.ml`.

We can use `python -X importtime -c 'import civis'` to get the import time details. Before this pull request (for brevity, just showing the final line for the top-level `civis` import):

```
import time: self [us] | cumulative | imported package
...
import time:     14290 |    3144744 | civis
```

After this PR:

```
import time: self [us] | cumulative | imported package
...
import time:      5978 |     606370 | civis
```

It's potentially possible to speed things up further by coating a few more things along the import paths with lazy imports. I tried that with some success, but I started to have to make _other_ changes as well to have the test suite pass (e.g., `ModuleNotFoundError` for existing working imports, where tweaking the import syntax here and there might resolve the issue). That suggested to me that it's not worth the effort. Keeping the lazy import implementation simple for a 5x speed-up is good enough.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
