### PR TITLE
[CIVIS-1949] PERF more efficient polling at future objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved the startup time of `import civis` with a 5x speed boost. (#490)
 - The downloaded API spec due to the `civis.APIClient` instantiation is now
   a time-to-live cache in memory (15 minutes for interactive Python, or 24 hours in scripts). (#491)
+- Polling at `PollableResult` (and consequently its subclasses as well: `CivisFuture`,
+  `ContainerFuture`, and `ModelFuture`) now defaults to geometrically increased polling
+  intervals and is capped at 15 seconds. Short-running jobs' `future.result()` can now
+  return faster and longer-running jobs have a capped polling interval of 15 seconds. (#492)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   a time-to-live cache in memory (15 minutes for interactive Python, or 24 hours in scripts). (#491)
 - Polling at `PollableResult` (and consequently its subclasses as well: `CivisFuture`,
   `ContainerFuture`, and `ModelFuture`) now defaults to geometrically increased polling
-  intervals and is capped at 15 seconds. Short-running jobs' `future.result()` can now
-  return faster and longer-running jobs have a capped polling interval of 15 seconds. (#492)
+  intervals. Short-running jobs' `future.result()` can now return faster, while
+  longer-running jobs have a capped polling interval of 15 seconds. (#492)
 
 ### Deprecated
 ### Removed

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -161,7 +161,7 @@ data to export. Then we create the export job and run it.
    >>> export_future = civis.utils.run_job(export_job.id)
 
 ``export_future`` is a :class:`CivisFuture <civis.futures.CivisFuture>` object
-(see :ref:`civis_futures`_  above). Calling ``.result()`` on ``export_future``
+(see :ref:`civis_futures`  above). Calling ``.result()`` on ``export_future``
 blocks the program until the SQL run has completed.
 
 .. code:: python

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -34,6 +34,7 @@ uploads the data back into Civis:
    ...                                   table="my_schema.my_correlations")
    >>> fut.result()
 
+.. _civis_futures:
 
 Civis Futures
 =============
@@ -157,28 +158,17 @@ data to export. Then we create the export job and run it.
                                             remote_host_id=db_id,
                                             credential_id=cred_id,
                                             sql=generate_table)
-   >>> export_run = client.scripts.post_sql_runs(export_job.id)
+   >>> export_future = civis.utils.run_job(export_job.id)
 
-We can then poll and wait for the export to be completed.
-
-.. code:: python
-
-   >>> import time
-   >>> export_state = client.scripts.get_sql_runs(export_job.id,
-   ...                                            export_run.id)
-   >>> while export_state.state in ['queued', 'running']:
-   ...    time.sleep(60)
-   ...    export_state = client.scripts.get_sql_runs(export_job.id,
-   ...                                               export_run.id)
-
-Now, we can get the URL of the exported csv. First, we grab the result of our
-export job.
+``export_future`` is a :class:`CivisFuture <civis.futures.CivisFuture>` object
+(see :ref:`civis_futures`_  above). Calling ``.result()`` on ``export_future``
+blocks the program until the SQL run has completed.
 
 .. code:: python
 
-   >>> export_result = client.scripts.get_sql_runs(export_job.id,
-   ...                                             export_run.id)
+   >>> export_result = export_future.result()
 
+Now, we can get the URL of the exported csv.
 In the future, a script may export multiple jobs, so the output of this is a
 list.
 

--- a/src/civis/__init__.py
+++ b/src/civis/__init__.py
@@ -5,7 +5,6 @@ from importlib.metadata import version
 from civis.client import APIClient
 from civis.loggers import civis_logger
 from civis.response import find, find_one
-from civis.service_client import ServiceClient
 
 
 def _lazy_import(name):
@@ -19,6 +18,7 @@ def _lazy_import(name):
     return module
 
 
+futures = _lazy_import("civis.futures")
 io = _lazy_import("civis.io")
 ml = _lazy_import("civis.ml")
 parallel = _lazy_import("civis.parallel")

--- a/src/civis/__init__.py
+++ b/src/civis/__init__.py
@@ -5,6 +5,7 @@ from importlib.metadata import version
 from civis.client import APIClient
 from civis.loggers import civis_logger
 from civis.response import find, find_one
+from civis.service_client import ServiceClient
 
 
 def _lazy_import(name):

--- a/src/civis/base.py
+++ b/src/civis/base.py
@@ -173,39 +173,7 @@ class CivisAsyncResultBase(futures.Future):
     the result. The `_result_` object needs to be set to an object with a
     ``state`` attribute. Alternatively the `_check_result` method can be
     overwritten to change how the state of the object is returned.
-
-    Parameters
-    ----------
-    poller : func
-        A function which returns an object that has a ``state`` attribute.
-    poller_args : tuple
-        The arguments with which to call the poller function.
-    polling_interval : int or float
-        The number of seconds between API requests to check whether a result
-        is ready.
-    client : :class:`civis.APIClient`, optional
-        If not provided, an :class:`civis.APIClient` object will be
-        created from the :envvar:`CIVIS_API_KEY`.
-    poll_on_creation : bool, optional
-        If ``True`` (the default), it will poll upon calling ``result()`` the
-        first time. If ``False``, it will wait the number of seconds specified
-        in `polling_interval` from object creation before polling.
     """
-
-    def __init__(
-        self,
-        poller,
-        poller_args,
-        polling_interval=None,
-        client=None,
-        poll_on_creation=True,
-    ):
-        super().__init__()
-        self.poller = poller
-        self.poller_args = poller_args
-        self.polling_interval = polling_interval
-        self.client = client
-        self.poll_on_creation = poll_on_creation
 
     def __repr__(self):
         # Almost the same as the superclass's __repr__, except we use

--- a/src/civis/futures.py
+++ b/src/civis/futures.py
@@ -32,7 +32,12 @@ class CivisFuture(PollableResult):
         The arguments with which to call the poller function.
     polling_interval : int or float, optional
         The number of seconds between API requests to check whether a result
-        is ready.
+        is ready. If an integer or float is provided, this number will be used
+        as the polling interval. If ``None`` (the default), the polling interval will
+        start at 1 second and increase geometrically up to 15 seconds. The ratio of
+        the increase is 1.2, resulting in polling intervals in seconds of
+        1, 1.2, 1.44, 1.728, etc. This default behavior allows for a faster return for
+        a short-running job and a capped polling interval for longer-running jobs.
     client : :class:`civis.APIClient`, optional
     poll_on_creation : bool, optional
         If ``True`` (the default), it will poll upon calling ``result()`` the
@@ -231,9 +236,14 @@ class ContainerFuture(CivisFuture):
         The ID for the run to monitor
     max_n_retries : int, optional
         If the job generates an exception, retry up to this many times
-    polling_interval: int or float, optional
+    polling_interval : int or float, optional
         The number of seconds between API requests to check whether a result
-        is ready.
+        is ready. If an integer or float is provided, this number will be used
+        as the polling interval. If ``None`` (the default), the polling interval will
+        start at 1 second and increase geometrically up to 15 seconds. The ratio of
+        the increase is 1.2, resulting in polling intervals in seconds of
+        1, 1.2, 1.44, 1.728, etc. This default behavior allows for a faster return for
+        a short-running job and a capped polling interval for longer-running jobs.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.

--- a/src/civis/ml/_model.py
+++ b/src/civis/ml/_model.py
@@ -555,7 +555,7 @@ class ModelFuture(ContainerFuture):
         self.client = APIClient()
         self.poller = self.client.scripts.get_containers_runs
         self._next_polling_interval = 1
-        self._use_exponential_polling = True
+        self._use_geometric_polling = True
         self._begin_tracking()
         self.add_done_callback(self._set_job_exception)
 

--- a/src/civis/ml/_model.py
+++ b/src/civis/ml/_model.py
@@ -393,7 +393,12 @@ class ModelFuture(ContainerFuture):
         run, and ``train_run_id`` will equal ``run_id``.
     polling_interval : int or float, optional
         The number of seconds between API requests to check whether a result
-        is ready.
+        is ready. If an integer or float is provided, this number will be used
+        as the polling interval. If ``None`` (the default), the polling interval will
+        start at 1 second and increase geometrically up to 15 seconds. The ratio of
+        the increase is 1.2, resulting in polling intervals in seconds of
+        1, 1.2, 1.44, 1.728, etc. This default behavior allows for a faster return for
+        a short-running job and a capped polling interval for longer-running jobs.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.

--- a/src/civis/ml/_model.py
+++ b/src/civis/ml/_model.py
@@ -1,7 +1,6 @@
 """Run CivisML jobs and retrieve the results"""
 
 import builtins
-from builtins import super
 import collections
 from functools import lru_cache
 import io
@@ -555,6 +554,8 @@ class ModelFuture(ContainerFuture):
         self._condition = threading.Condition()
         self.client = APIClient()
         self.poller = self.client.scripts.get_containers_runs
+        self._next_polling_interval = 1
+        self._use_exponential_polling = True
         self._begin_tracking()
         self.add_done_callback(self._set_job_exception)
 

--- a/src/civis/polling.py
+++ b/src/civis/polling.py
@@ -158,9 +158,10 @@ class PollableResult(CivisAsyncResultBase):
                     # Choosing a common ratio of 1.2 for these polling intervals:
                     #   1, 1.2, 1.44, 1.73, 2.07, 2.49, 2.99, ..., and capped at 15.
                     # Within the first 15 secs by wall time, we call the poller 7 times,
-                    # which gives a short-running job a chance to finish quickly.
-                    # The polling interval will be 15 secs when by wall time 87 secs
-                    # have passed.
+                    # which gives a short-running job's future.result()
+                    # a higher chance to return faster.
+                    # For longer running jobs, the polling interval will be capped
+                    # at 15 secs when by wall time 87 secs have passed.
                     self._next_polling_interval *= 1.2
                     if self._next_polling_interval > _MAX_POLLING_INTERVAL:
                         self._next_polling_interval = _MAX_POLLING_INTERVAL

--- a/src/civis/polling.py
+++ b/src/civis/polling.py
@@ -51,9 +51,14 @@ class PollableResult(CivisAsyncResultBase):
         A function which returns an object that has a ``state`` attribute.
     poller_args : tuple
         The arguments with which to call the poller function.
-    polling_interval : int or float
+    polling_interval : int or float, optional
         The number of seconds between API requests to check whether a result
-        is ready.
+        is ready. If an integer or float is provided, this number will be used
+        as the polling interval. If ``None`` (the default), the polling interval will
+        start at 1 second and increase geometrically up to 15 seconds. The ratio of
+        the increase is 1.2, resulting in polling intervals in seconds of
+        1, 1.2, 1.44, 1.728, etc. This default behavior allows for a faster return for
+        a short-running job and a capped polling interval for longer-running jobs.
     client : :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
@@ -101,13 +106,14 @@ class PollableResult(CivisAsyncResultBase):
         client=None,
         poll_on_creation=True,
     ):
-        super().__init__(
-            poller=poller,
-            poller_args=poller_args,
-            polling_interval=polling_interval,
-            client=client,
-            poll_on_creation=poll_on_creation,
-        )
+        super().__init__()
+
+        self.poller = poller
+        self.poller_args = poller_args
+        self.polling_interval = polling_interval
+        self.client = client
+        self.poll_on_creation = poll_on_creation
+
         if self.polling_interval is not None and self.polling_interval <= 0:
             raise ValueError("The polling interval must be positive.")
 

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -77,7 +77,7 @@ class TestPolling(unittest.TestCase):
 
     def test_poller_returns_none(self):
         poller = mock.Mock(side_effect=[None, None, Response({"state": "success"})])
-        polling_thread = _ResultPollingThread(poller, (), polling_interval=0.01)
+        polling_thread = _ResultPollingThread(poller, polling_interval=0.01)
         polling_thread.run()
         assert poller.call_count == 3
 

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -131,7 +131,7 @@ class TestPolling(unittest.TestCase):
             actual_intervals.append(
                 timestamp - (poller_timestamps[i - 1] if i else start_time)
             )
-        assert actual_intervals == pytest.approx(expected_intervals, rel=0.01)
+        assert actual_intervals == pytest.approx(expected_intervals, abs=0.02)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request makes polling at future objects more efficient, in that a short-running job's `future.result()` should return faster than before.

Before this PR, the default polling interval was a constant of 15 seconds. After this PR, the default polling interval starts at 1 second, increases geometrically for subsequent polls, and is capped at a maximum of 15 seconds. If the user provides a number to the `polling_interval` argument, the polling interval will be a constant of this number (so no change from before this PR).

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
