### PR TITLE
[CIVIS-9155] ENH support `description` in file upload CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The helper I/O functions that create a Civis file
   (i.e., `civis.io.file_to_civis`, `civis.io.dataframe_to_file`, and `civis.io.json_to_file`)
   accept a new `description` keyword argument for the new `description` attribute
-  of Civis file objects. (#498)
+  of Civis file objects. (#498, #500)
 
 ### Changed
 ### Deprecated

--- a/src/civis/cli/_cli_commands.py
+++ b/src/civis/cli/_cli_commands.py
@@ -64,26 +64,34 @@ _FOLLOW_POLL_INTERVAL_SEC = 3
         "The date and time the file will expire "
         '(ISO-8601 format, e.g., "2017-01-15" or '
         '"2017-01-15T15:25:10Z"). '
-        'Set "never" for the file to not expire.'
+        'Set "never" for the file to not expire. '
         "The default is the default in Civis (30 days)."
     ),
 )
-def files_upload_cmd(path, name, expires_at):
+@click.option(
+    "--description",
+    type=str,
+    default=None,
+    help="Description (max length: 512 characters) of the file object",
+)
+def files_upload_cmd(path, name, expires_at, description):
     """Upload a local file to Civis and get back the File ID."""
 
     if name is None:
         name = os.path.basename(path)
 
+    kwargs = {"description": description}
+
     if expires_at is None:
-        # Use the default in Civis platform (30 days).
-        expires_kwarg = {}
+        # Let file_to_civis use the default in Civis platform (30 days).
+        pass
     elif expires_at.lower() == "never":
-        expires_kwarg = {"expires_at": None}
+        kwargs = {"expires_at": None}
     else:
-        expires_kwarg = {"expires_at": expires_at}
+        kwargs = {"expires_at": expires_at}
 
     with open(path, "rb") as f:
-        file_id = file_to_civis(f, name=name, **expires_kwarg)
+        file_id = file_to_civis(f, name=name, **kwargs)
     print(file_id)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ def test_generate_cli_civis(mock_retrieve_spec_dict):
     assert not list_runs_cmd.params[1].required
 
     # Check that the extra files upload command was added
-    expected_names = {"path", "name", "expires_at"}
+    expected_names = {"path", "name", "expires_at", "description"}
     files_upload_params = cli.commands["files"].commands["upload"].params
     assert {_.name for _ in files_upload_params} == expected_names
 


### PR DESCRIPTION
In #498, I added support for `description` in the `civis.io.*` functions that upload to a Civis file, but forgot to handle the file upload command in the command-line interface. This pull request addresses this.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
