### PR TITLE
[CIVIS-9806] MAINT bump version to v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## 2.4.0 - 2024-11-11
+
+### Added
 - The new kwarg `retries` has been added to `civis.APIClient` so that
   a `tenacity.Retrying` instance can be provided to customize retries. (#495)
 - Added `civis.workflows.validate_workflow_yaml`
@@ -44,8 +58,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - In `Response` object instantiation, an API response that represents a JSONValue object
   now has its `value` attribute unmodified as the Python object representation
   of the deserialized JSON form (as opposed to being converted to a `Response`-based form). (#501)
-
-### Security
 
 ## 2.3.0 - 2024-06-14
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.3.0"
+version = "2.4.0"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.10"


### PR DESCRIPTION
This pull request bumps version to v2.4.0 for a new release!

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
