### PR TITLE
[CIVIS-9898] MAINT fix script for checking API spec changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fixed the tool for checking if the upstream Civis API spec has changed. (#505)
 
 ### Security
 

--- a/src/civis/resources/_api_spec.py
+++ b/src/civis/resources/_api_spec.py
@@ -40,7 +40,7 @@ def _compare(reference: dict, compared: dict) -> tuple[dict, dict]:
         "methods": defaultdict(set),
     }
     changed = {
-        "method signatures": defaultdict(set),
+        "method parameters": defaultdict(set),
         "method docstrings": defaultdict(set),
     }
     for endpoint_name in set(compared.keys()) - set(reference.keys()):
@@ -54,13 +54,16 @@ def _compare(reference: dict, compared: dict) -> tuple[dict, dict]:
         for meth_name in set(methods_compared.keys()) & set(methods_reference.keys()):
             method_compared = methods_compared[meth_name]
             method_reference = methods_reference[meth_name]
-            if signature(method_compared) != signature(method_reference):
-                changed["method signatures"][endpoint_name].add(meth_name)
+            if (
+                signature(method_compared).parameters
+                != signature(method_reference).parameters
+            ):
+                changed["method parameters"][endpoint_name].add(meth_name)
             if method_compared.__doc__ != method_reference.__doc__:
                 changed["method docstrings"][endpoint_name].add(meth_name)
     # Convert defaultdicts to regular dicts for nicer pprinting.
     new["methods"] = dict(new["methods"])
-    changed["method signatures"] = dict(changed["method signatures"])
+    changed["method parameters"] = dict(changed["method parameters"])
     changed["method docstrings"] = dict(changed["method docstrings"])
     return new, changed
 


### PR DESCRIPTION
This pull request fixes a bug in the script for checking whether the Civis API spec has been updated. For background, the script works by comparing the function signatures for all the `client.<endpoint>.<method>` methods between the versioned `civis_api_spec.json` and the live spec pulled from the upstream Civis API. Before this PR, the comparison was the equality test between `inspect.signature(method1)` and `inspect.signature(method2)`, which included the equality comparison of their return annotations. Since #501, these return annotations are dynamically generated classes (which has response attributes and their types, and has the class name beginning with `_Response`). What I missed was that even if two dynamically generated classes are defined identically, comparing them for equality returns `False`, which I hadn't realized:

```python
In [1]: some_class = type("F", (), {})

In [2]: some_other_class = type("F", (), {})

In [3]: some_class == some_other_class
Out[3]: False
```

The fix in this PR is to compare the API endpoint methods for only the parameters. We aren't really excluding return annotations for comparison, though, since the docstrings between two given methods are already compared (just one line below where I'm making a code change in this PR) and the return annotations are already part of the docstrings.

This PR would not trigger a new civis-python release, since it'd have no effect to the end users. So long as the `main` branch is fixed, all internal tools running within the Civis wall will work correctly.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- n/a If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
