### PR TITLE
[CIVIS-10251] Add `civis.utils.job_logs()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added `civis.utils.job_logs()` function to return a generator of log messages for a job run (#509)
-
 ### Changed
-
-- Revised the CLI commands `civis jobs follow-log` and `civis jobs follow-run-log` to not skip log messages for running jobs (#509)
 
 ### Deprecated
 
@@ -21,6 +17,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 ### Security
+
+## 2.5.0 - 2025-02-21
+
+### Added
+
+- Added `civis.utils.job_logs()` function to return a generator of log messages for a job run (#509)
+
+### Changed
+
+- Revised the CLI commands `civis jobs follow-log` and `civis jobs follow-run-log` to not skip log messages for running jobs (#509)
 
 ## 2.4.3 - 2025-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `civis.utils.job_logs()` function to return a generator of log messages for a job run (#509)
+
 ### Changed
+
+- Revised the CLI commands `civis jobs follow-log` and `civis jobs follow-run-log` to not skip log messages for running jobs (#509)
 
 ### Deprecated
 
@@ -114,7 +118,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   top-level and nested response objects. (#493)
 
 ### Security
-- Bumped the minimum required version of `requests` to the latest v2.32.3, 
+- Bumped the minimum required version of `requests` to the latest v2.32.3,
   due to a security vulnerability for < v2.32.0
   ([CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195)). (#488)
 
@@ -181,7 +185,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated references from 'master' to 'main' (#460)
-- Clarified the usage example for `civis.io.civis_to_multifile_csv`. Updated 
+- Clarified the usage example for `civis.io.civis_to_multifile_csv`. Updated
   CircleCI config so dev-requirements is only used when needed. (#452)
 - Removed unneeded `time.sleep` calls and `pytest.mark` calls and mocked `time.sleep` calls to optimize tests. (#453)
 - Refactored tests to remove dependency on the vcr library. (#456)
@@ -227,7 +231,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Added a warning message when using `civis.io.file_to_civis` with file size of 0 bytes (#451)
 - Specified that `civis.io.civis_file_to_table` can handle compressed files (#450)
-- Explicitly stated CSV-like civis file format requirement in 
+- Explicitly stated CSV-like civis file format requirement in
   `civis.io.civis_file_to_table`'s docstring (#445)
 - Called out the fact that `joblib.Parallel`'s `pre_dispatch` defaults to `"2*n_jobs"`
   in the Sphinx docs (#443)
@@ -247,7 +251,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   has `VARCHAR` (#439)
 - Updated info about MacOS shell configuration file to be `~/.zshrc` (#444)
 - Fixed the Sphinx docs to show details of multi-word API endpoints (#442)
-- Dropped the buggy/unnecessary `_get_headers` in `civis.io.read_civis_sql` (#415) 
+- Dropped the buggy/unnecessary `_get_headers` in `civis.io.read_civis_sql` (#415)
 - Clarified the `table_columns` parameter in `civis.io.*` functions (#434)
 - Warned about the `retry_total` parameter of `civis.APIClient` being inactive and deprecated (#431)
 - Converted `assert` statements in non-test code into proper error handling (#430, #435)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Security
 
-## 2.5.0 - 2025-02-21
+## 2.5.0 - 2025-02-24
 
 ### Added
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -11,3 +11,4 @@ and templates on the Civis Platform.
 
    run_job
    run_template
+   job_logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.4.3"
+version = "2.5.0"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.10"

--- a/src/civis/cli/_cli_commands.py
+++ b/src/civis/cli/_cli_commands.py
@@ -4,10 +4,8 @@
 Additional commands to add to the CLI beyond the OpenAPI spec.
 """
 import functools
-import operator
 import os
 import sys
-import time
 
 import click
 import requests
@@ -15,6 +13,7 @@ import webbrowser
 
 import civis
 from civis.io import file_to_civis, civis_to_file
+from civis.utils import job_logs
 
 
 # From http://patorjk.com/software/taag/#p=display&f=3D%20Diagonal&t=CIVIS
@@ -41,11 +40,8 @@ If the job is still running, this command will continue outputting logs
 until the run is done and then exit. If the run is already finished, it
 will output all the logs from that run and then exit.
 
-NOTE: This command could miss some log entries from a currently-running
-job. It does not re-fetch logs that might have been saved out of order, to
-preserve the chronological order of the logs and without duplication.
+NOTE: Log entries may appear our of order, particularly at the end of a run.
 """
-_FOLLOW_POLL_INTERVAL_SEC = 3
 
 
 @click.command("upload")
@@ -219,13 +215,13 @@ def _str_table_result(cols, rows):
 )
 @click.argument("id", type=int)
 def jobs_follow_log(id):
-    client = civis.APIClient()
-    runs = client.jobs.list_runs(id, limit=1, order="id", order_dir="desc")
+    raw_client = civis.APIClient(return_type="raw")
+    runs = raw_client.jobs.list_runs(id, limit=1, order="id", order_dir="desc").json()
     if not runs:
         raise click.ClickException("No runs found for that job ID.")
-    run_id = runs[0].id
+    run_id = runs[0]["id"]
     print("Run ID: " + str(run_id))
-    _jobs_follow_run_log(id, run_id)
+    _jobs_follow_run_log(id, run_id, raw_client=raw_client)
 
 
 @click.command("follow-run-log", help="Output live run log." + _FOLLOW_LOG_NOTE)
@@ -235,42 +231,9 @@ def jobs_follow_run_log(id, run_id):
     _jobs_follow_run_log(id, run_id)
 
 
-def _jobs_follow_run_log(id, run_id):
-    client = civis.APIClient(return_type="raw")
-    local_max_log_id = 0
-    continue_polling = True
-
-    while continue_polling:
-        # This call gets all available log messages since last_id up to
-        # the page size, ordered by log ID. We leave it to Platform to decide
-        # the best page size.
-        response = client.jobs.list_runs_logs(id, run_id, last_id=local_max_log_id)
-        if "civis-max-id" in response.headers:
-            remote_max_log_id = int(response.headers["civis-max-id"])
-        else:
-            # Platform hasn't seen any logs at all yet
-            remote_max_log_id = None
-        logs = response.json()
-        if logs:
-            local_max_log_id = max(log["id"] for log in logs)
-            logs.sort(key=operator.itemgetter("createdAt", "id"))
-        for log in logs:
-            print(" ".join((log["createdAt"], log["message"].rstrip())))
-        # if output is a pipe, write the buffered output immediately:
-        sys.stdout.flush()
-
-        log_finished = response.headers["civis-cache-control"] != "no-store"
-        if remote_max_log_id is None:
-            remote_has_more_logs_to_get_now = False
-        elif local_max_log_id == remote_max_log_id:
-            remote_has_more_logs_to_get_now = False
-            if log_finished:
-                continue_polling = False
-        else:
-            remote_has_more_logs_to_get_now = True
-
-        if continue_polling and not remote_has_more_logs_to_get_now:
-            time.sleep(_FOLLOW_POLL_INTERVAL_SEC)
+def _jobs_follow_run_log(id, run_id, raw_client=None):
+    for log in job_logs(id, run_id, raw_client=raw_client):
+        print(" ".join((log["createdAt"], log["message"].rstrip())), flush=True)
 
 
 @click.command("download")

--- a/src/civis/cli/_cli_commands.py
+++ b/src/civis/cli/_cli_commands.py
@@ -215,13 +215,13 @@ def _str_table_result(cols, rows):
 )
 @click.argument("id", type=int)
 def jobs_follow_log(id):
-    raw_client = civis.APIClient(return_type="raw")
-    runs = raw_client.jobs.list_runs(id, limit=1, order="id", order_dir="desc").json()
+    client = civis.APIClient()
+    runs = client.jobs.list_runs(id, limit=1, order="id", order_dir="desc")
     if not runs:
         raise click.ClickException("No runs found for that job ID.")
-    run_id = runs[0]["id"]
+    run_id = runs[0].id
     print("Run ID: " + str(run_id))
-    _jobs_follow_run_log(id, run_id, raw_client=raw_client)
+    _jobs_follow_run_log(id, run_id)
 
 
 @click.command("follow-run-log", help="Output live run log." + _FOLLOW_LOG_NOTE)
@@ -231,8 +231,8 @@ def jobs_follow_run_log(id, run_id):
     _jobs_follow_run_log(id, run_id)
 
 
-def _jobs_follow_run_log(id, run_id, raw_client=None):
-    for log in job_logs(id, run_id, raw_client=raw_client):
+def _jobs_follow_run_log(id, run_id):
+    for log in job_logs(id, run_id):
         print(" ".join((log["createdAt"], log["message"].rstrip())), flush=True)
 
 

--- a/src/civis/utils/__init__.py
+++ b/src/civis/utils/__init__.py
@@ -1,3 +1,3 @@
-from civis.utils._jobs import run_job, run_template
+from civis.utils._jobs import run_job, run_template, job_logs
 
-__all__ = ["run_job", "run_template"]
+__all__ = ["run_job", "run_template", "job_logs"]

--- a/src/civis/utils/_jobs.py
+++ b/src/civis/utils/_jobs.py
@@ -163,7 +163,7 @@ def _job_finished_past_timeout(job_id, run_id, finished_timeout, raw_client):
     return result
 
 
-def job_logs(job_id, run_id=None, raw_client=None, finished_timeout=None):
+def job_logs(job_id, run_id=None, finished_timeout=None):
     """Return a generator of log message dictionaries for a given run.
 
     Parameters
@@ -173,12 +173,6 @@ def job_logs(job_id, run_id=None, raw_client=None, finished_timeout=None):
     run_id : int or None
         The ID of the run to retrieve log messages for.
         If None, the ID for the most recent run will be used.
-    raw_client: :class:`civis.APIClient`, optional
-        If not provided, an :class:`civis.APIClient` object will be
-        created from the :envvar:`CIVIS_API_KEY`.
-        The return_type should be set to "raw", which is needed to check
-        the "civis-cache-control" and "civis-max-id" headers when
-        list_runs_logs returns an empty list of new messages.
     finished_timeout: int or None
         If not None, then this function will return once the run has
         been finished for the specified number of seconds.
@@ -194,8 +188,13 @@ def job_logs(job_id, run_id=None, raw_client=None, finished_timeout=None):
         provided by the job logs endpoint. Note that this will block execution
         until the job has stopped and all log messages are retrieved.
     """
-    if raw_client is None:
-        raw_client = APIClient(return_type="raw")
+    # The return_type for the client is "raw" in order to check
+    # the "civis-cache-control" and "civis-max-id" headers when
+    # list_runs_logs returns an empty list of new messages.
+    # Caching of the endpoint information in
+    # civis.resources.generate_classes_maybe_cached avoids extra API calls.
+    raw_client = APIClient(return_type="raw")
+
     if run_id is None:
         run_id = raw_client.jobs.list_runs(
             job_id, limit=1, order="id", order_dir="desc"

--- a/src/civis/utils/_jobs.py
+++ b/src/civis/utils/_jobs.py
@@ -191,12 +191,6 @@ def job_logs(job_id, run_id=None, raw_client=None, finished_timeout=None):
         A log message dictionary with "message", "createdAt" and other attributes
         provided by the job logs endpoint. Note that this will block execution
         until the job has stopped and all log messages are retrieved.
-
-    Notes
-    -----
-    This command could miss some log entries from a currently-running job.
-    It does not re-fetch logs that might have been saved out of order, to
-    preserve the chronological order of the logs and without duplication.
     """
     if raw_client is None:
         raw_client = APIClient(return_type="raw")

--- a/src/civis/utils/_jobs.py
+++ b/src/civis/utils/_jobs.py
@@ -176,7 +176,9 @@ def job_logs(job_id, run_id=None, raw_client=None, finished_timeout=None):
     raw_client: :class:`civis.APIClient`, optional
         If not provided, an :class:`civis.APIClient` object will be
         created from the :envvar:`CIVIS_API_KEY`.
-        The return_type should be set to "raw".
+        The return_type should be set to "raw", which is needed to check
+        the "civis-cache-control" and "civis-max-id" headers when
+        list_runs_logs returns an empty list of new messages.
     finished_timeout: int or None
         If not None, then this function will return once the run has
         been finished for the specified number of seconds.

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -190,17 +190,19 @@ def sample_logs():
     ]
 
 
+@patch("civis.utils._jobs.APIClient")
 @patch("civis.utils._jobs.time")
-def test_job_logs_single_batch(mock_time, mock_client, sample_logs):
+def test_job_logs_single_batch(mock_time, mock_APIClient, mock_client, sample_logs):
     """Test when all logs are retrieved in a single batch."""
     mock_response = Mock()
     mock_response.json.return_value = sample_logs
     mock_response.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
 
     mock_client.jobs.list_runs_logs.return_value = mock_response
+    mock_APIClient.return_value = mock_client
     mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
 
-    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+    logs = list(job_logs(job_id=123, run_id=456))
 
     assert len(logs) == 3
     assert logs == sample_logs
@@ -209,8 +211,9 @@ def test_job_logs_single_batch(mock_time, mock_client, sample_logs):
     )
 
 
+@patch("civis.utils._jobs.APIClient")
 @patch("civis.utils._jobs.time")
-def test_job_logs_multiple_batches(mock_time, mock_client):
+def test_job_logs_multiple_batches(mock_time, mock_APIClient, mock_client):
     """Test when logs are retrieved in multiple batches."""
     first_batch = [
         {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:00Z"},
@@ -227,9 +230,10 @@ def test_job_logs_multiple_batches(mock_time, mock_client):
     mock_response2.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
 
     mock_client.jobs.list_runs_logs.side_effect = [mock_response1, mock_response2]
+    mock_APIClient.return_value = mock_client
     mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
 
-    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+    logs = list(job_logs(job_id=123, run_id=456))
 
     assert len(logs) == 3
     assert logs == first_batch + second_batch
@@ -237,8 +241,11 @@ def test_job_logs_multiple_batches(mock_time, mock_client):
     mock_time.sleep.assert_called_once()
 
 
+@patch("civis.utils._jobs.APIClient")
 @patch("civis.utils._jobs.time")
-def test_job_logs_no_logs_initially(mock_time, mock_client, sample_logs):
+def test_job_logs_no_logs_initially(
+    mock_time, mock_APIClient, mock_client, sample_logs
+):
     """Test behavior when no logs are available."""
 
     mock_response1 = Mock()
@@ -250,16 +257,18 @@ def test_job_logs_no_logs_initially(mock_time, mock_client, sample_logs):
     mock_response2.headers = {"civis-cache-control": "store", "civis-max-id": "3"}
 
     mock_client.jobs.list_runs_logs.side_effect = [mock_response1, mock_response2]
+    mock_APIClient.return_value = mock_client
     mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
 
-    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+    logs = list(job_logs(job_id=123, run_id=456))
 
     assert len(logs) == len(sample_logs)
     assert mock_client.jobs.list_runs_logs.call_count == 2
     mock_time.sleep.assert_called_once()
 
 
-def test_job_logs_sorted_order(mock_client):
+@patch("civis.utils._jobs.APIClient")
+def test_job_logs_sorted_order(mock_APIClient, mock_client):
     """Test that logs are properly sorted by createdAt and id.
 
     Note: logs won't be sorted if they are out of order across different API calls.
@@ -280,15 +289,18 @@ def test_job_logs_sorted_order(mock_client):
     mock_response = Mock()
     mock_response.json.return_value = unsorted_logs
     mock_response.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
-    mock_client.jobs.list_runs_logs.return_value = mock_response
 
-    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+    mock_client.jobs.list_runs_logs.return_value = mock_response
+    mock_APIClient.return_value = mock_client
+
+    logs = list(job_logs(job_id=123, run_id=456))
 
     assert logs == expected_order
 
 
+@patch("civis.utils._jobs.APIClient")
 @patch("civis.utils._jobs.time")
-def test_job_logs_no_duplicate_logs(mock_time, mock_client):
+def test_job_logs_no_duplicate_logs(mock_time, mock_APIClient, mock_client):
     """Test that duplicate log messages won't be yielded."""
     expected_logs = [
         {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:00Z"},
@@ -304,10 +316,10 @@ def test_job_logs_no_duplicate_logs(mock_time, mock_client):
     mock_response2.headers = {"civis-max-id": "2", "civis-cache-control": "store"}
 
     mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
-
     mock_client.jobs.list_runs_logs.side_effect = (mock_response1, mock_response2)
+    mock_APIClient.return_value = mock_client
 
-    actual_logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+    actual_logs = list(job_logs(job_id=123, run_id=456))
 
     assert actual_logs == expected_logs
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,9 +1,18 @@
-import pytest
-import civis
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
 
+import pytest
+
+import civis
 from civis.response import Response
 from civis.tests.mocks import create_client_mock
-from civis.utils._jobs import logging
+from civis.utils._jobs import (
+    _LOGS_PER_QUERY,
+    _compute_effective_max_log_id,
+    _job_finished_past_timeout,
+    job_logs,
+    logging,
+)
 
 
 def create_mock_client_with_job():
@@ -24,6 +33,11 @@ def create_mock_client_with_job():
     mock_client.scripts.post_custom_runs.return_value = run_post_response
     mock_client.scripts.get_custom_runs.return_value = run_get_response
     return mock_client
+
+
+@pytest.fixture
+def mock_client():
+    return create_client_mock()
 
 
 @pytest.fixture
@@ -165,3 +179,196 @@ def test_run_template_when_no_json_output(caplog, mock_client_no_json_output):
         )
     ]
     assert result is None
+
+
+@pytest.fixture
+def sample_logs():
+    return [
+        {"id": 1, "message": "First log", "createdAt": "2023-01-01T00:00:00Z"},
+        {"id": 2, "message": "Second log", "createdAt": "2023-01-01T00:00:01Z"},
+        {"id": 3, "message": "Third log", "createdAt": "2023-01-01T00:00:02Z"},
+    ]
+
+
+def test_job_logs_single_batch(mock_client, sample_logs):
+    """Test when all logs are retrieved in a single batch."""
+    mock_response = Mock()
+    mock_response.json.return_value = sample_logs
+    mock_response.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
+    mock_client.jobs.list_runs_logs.return_value = mock_response
+
+    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+
+    assert len(logs) == 3
+    assert logs == sample_logs
+    mock_client.jobs.list_runs_logs.assert_called_once_with(
+        123, 456, last_id=0, limit=_LOGS_PER_QUERY
+    )
+
+
+@patch("civis.utils._jobs.time")
+def test_job_logs_multiple_batches(mock_time, mock_client):
+    """Test when logs are retrieved in multiple batches."""
+    first_batch = [
+        {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:00Z"},
+        {"id": 2, "message": "Log 2", "createdAt": "2023-01-01T00:00:01Z"},
+    ]
+    second_batch = [{"id": 3, "message": "Log 3", "createdAt": "2023-01-01T00:00:02Z"}]
+
+    mock_response1 = Mock()
+    mock_response1.json.return_value = first_batch
+    mock_response1.headers = {"civis-max-id": "2", "civis-cache-control": "no-store"}
+
+    mock_response2 = Mock()
+    mock_response2.json.return_value = second_batch
+    mock_response2.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
+
+    mock_client.jobs.list_runs_logs.side_effect = [mock_response1, mock_response2]
+    mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
+
+    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+
+    assert len(logs) == 3
+    assert logs == first_batch + second_batch
+    assert mock_client.jobs.list_runs_logs.call_count == 2
+    mock_time.sleep.assert_called_once()
+
+
+@patch("civis.utils._jobs.time")
+def test_job_logs_no_logs_initially(mock_time, mock_client, sample_logs):
+    """Test behavior when no logs are available."""
+
+    mock_response1 = Mock()
+    mock_response1.json.return_value = []
+    mock_response1.headers = {"civis-cache-control": "store"}
+
+    mock_response2 = Mock()
+    mock_response2.json.return_value = sample_logs
+    mock_response2.headers = {"civis-cache-control": "store", "civis-max-id": "3"}
+
+    mock_client.jobs.list_runs_logs.side_effect = [mock_response1, mock_response2]
+    mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
+
+    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+
+    assert len(logs) == len(sample_logs)
+    assert mock_client.jobs.list_runs_logs.call_count == 2
+    mock_time.sleep.assert_called_once()
+
+
+def test_job_logs_sorted_order(mock_client):
+    """Test that logs are properly sorted by createdAt and id.
+
+    Note: logs won't be sorted if they are out of order across different API calls.
+    The sorting only works within a single API call.
+    """
+    unsorted_logs = [
+        {"id": 2, "message": "Log 2", "createdAt": "2023-01-01T00:00:01Z"},
+        {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:01Z"},
+        {"id": 3, "message": "Log 3", "createdAt": "2023-01-01T00:00:00Z"},
+    ]
+
+    expected_order = [
+        {"id": 3, "message": "Log 3", "createdAt": "2023-01-01T00:00:00Z"},
+        {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:01Z"},
+        {"id": 2, "message": "Log 2", "createdAt": "2023-01-01T00:00:01Z"},
+    ]
+
+    mock_response = Mock()
+    mock_response.json.return_value = unsorted_logs
+    mock_response.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
+    mock_client.jobs.list_runs_logs.return_value = mock_response
+
+    logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+
+    assert logs == expected_order
+
+
+@patch("civis.utils._jobs.time")
+def test_job_logs_no_duplicate_logs(mock_time, mock_client):
+    """Test that duplicate log messages won't be yielded."""
+    expected_logs = [
+        {"id": 1, "message": "Log 1", "createdAt": "2023-01-01T00:00:00Z"},
+        {"id": 2, "message": "Log 2", "createdAt": "2023-01-01T00:00:01Z"},
+    ]
+
+    mock_response1 = Mock()
+    mock_response1.json.return_value = expected_logs
+    mock_response1.headers = {"civis-max-id": "2", "civis-cache-control": "no-store"}
+
+    mock_response2 = Mock()
+    mock_response2.json.return_value = expected_logs
+    mock_response2.headers = {"civis-max-id": "2", "civis-cache-control": "store"}
+
+    mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
+
+    mock_client.jobs.list_runs_logs.side_effect = (mock_response1, mock_response2)
+
+    actual_logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
+
+    assert actual_logs == expected_logs
+
+
+def test_compute_effective_max_log_id_empty_logs():
+    assert _compute_effective_max_log_id([]) == 0
+
+
+@patch("civis.utils._jobs.time")
+def test_compute_effective_max_log_id_all_logs_before_cutoff(mock_time):
+    dt_now = datetime.now()
+    # The log messages were from more seconds ago than the cutoff.
+    logs = [
+        {"id": 1, "createdAt": (dt_now - timedelta(seconds=400)).isoformat()},
+        {"id": 2, "createdAt": (dt_now - timedelta(seconds=350)).isoformat()},
+    ]
+    mock_time.time.side_effect = lambda: dt_now.timestamp()
+    assert _compute_effective_max_log_id(logs) == 2
+
+
+@patch("civis.utils._jobs.time")
+def test_compute_effective_max_log_id_logs_within_cutoff(mock_time):
+    dt_now = datetime.now()
+    # Both log messages were from fewer seconds ago than the cutoff,
+    # so they'll both be retrieved again to avoid skipping any.
+    logs = [
+        {"id": 1, "createdAt": (dt_now - timedelta(seconds=200)).isoformat()},
+        {"id": 2, "createdAt": (dt_now - timedelta(seconds=150)).isoformat()},
+    ]
+    mock_time.time.side_effect = lambda: dt_now.timestamp()
+    assert _compute_effective_max_log_id(logs) == 0
+
+
+@patch("civis.utils._jobs.time")
+def test_compute_effective_max_log_id_logs_exceed_refetch_count(mock_time):
+    dt_now = datetime.now()
+    logs = [
+        {"id": i, "createdAt": (dt_now - timedelta(seconds=i)).isoformat()}
+        for i in range(110)
+    ]
+    mock_time.time.side_effect = lambda: dt_now.timestamp()
+    assert _compute_effective_max_log_id(logs) == 10
+
+
+def test_job_finished_past_timeout_no_timeout(mock_client):
+    assert not _job_finished_past_timeout(123, 456, None, mock_client)
+
+
+def test_job_finished_past_timeout_not_finished(mock_client):
+    mock_client.jobs.get_runs.return_value.json.return_value = {"finishedAt": None}
+    assert not _job_finished_past_timeout(123, 456, 10, mock_client)
+
+
+def test_job_finished_past_timeout_finished_recently(mock_client):
+    finished_at = (datetime.now() - timedelta(seconds=5)).isoformat()
+    mock_client.jobs.get_runs.return_value.json.return_value = {
+        "finishedAt": finished_at
+    }
+    assert not _job_finished_past_timeout(123, 456, 10, mock_client)
+
+
+def test_job_finished_past_timeout_finished_long_ago(mock_client):
+    finished_at = (datetime.now() - timedelta(seconds=20)).isoformat()
+    mock_client.jobs.get_runs.return_value.json.return_value = {
+        "finishedAt": finished_at
+    }
+    assert _job_finished_past_timeout(123, 456, 10, mock_client)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -190,12 +190,15 @@ def sample_logs():
     ]
 
 
-def test_job_logs_single_batch(mock_client, sample_logs):
+@patch("civis.utils._jobs.time")
+def test_job_logs_single_batch(mock_time, mock_client, sample_logs):
     """Test when all logs are retrieved in a single batch."""
     mock_response = Mock()
     mock_response.json.return_value = sample_logs
     mock_response.headers = {"civis-max-id": "3", "civis-cache-control": "store"}
+
     mock_client.jobs.list_runs_logs.return_value = mock_response
+    mock_time.time.return_value = datetime.fromisoformat("2025-01-01").timestamp()
 
     logs = list(job_logs(job_id=123, run_id=456, raw_client=mock_client))
 


### PR DESCRIPTION
This does two things:
* Adds `civis.utils.job_logs()` function to return a generator of log messages for a job run
* Revises the CLI commands `civis jobs follow-log` and `civis jobs follow-run-log` to not skip log messages for running jobs


---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
