### PR TITLE
[CIVIS-10251] Add examples to `civis.utils.job_logs` docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added examples to `civis.utils.job_logs()` docstring (#510)
+
 ### Changed
 
 ### Deprecated
@@ -17,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 ### Security
+
+- Updated `docs/requirements.txt` due to a security advisory for jinja2. See GHSA-cpwx-vrp4-4pq7 (#510)
 
 ## 2.5.0 - 2025-02-24
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,19 +6,19 @@
 #
 alabaster==1.0.0
     # via sphinx
-attrs==24.3.0
+attrs==25.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.16.0
+babel==2.17.0
     # via sphinx
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via civis (pyproject.toml)
-cloudpickle==3.1.0
+cloudpickle==3.1.1
     # via civis (pyproject.toml)
 docutils==0.21.2
     # via
@@ -28,7 +28,7 @@ idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via sphinx
 joblib==1.4.2
     # via civis (pyproject.toml)
@@ -44,11 +44,11 @@ numpydoc==1.8.0
     # via civis (pyproject.toml)
 packaging==24.2
     # via sphinx
-pygments==2.18.0
+pygments==2.19.1
     # via sphinx
 pyyaml==6.0.2
     # via civis (pyproject.toml)
-referencing==0.35.1
+referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -56,7 +56,7 @@ requests==2.32.3
     # via
     #   civis (pyproject.toml)
     #   sphinx
-rpds-py==0.22.3
+rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
@@ -88,5 +88,7 @@ tabulate==0.9.0
     # via numpydoc
 tenacity==9.0.0
     # via civis (pyproject.toml)
+typing-extensions==4.12.2
+    # via referencing
 urllib3==2.3.0
     # via requests

--- a/src/civis/utils/_jobs.py
+++ b/src/civis/utils/_jobs.py
@@ -187,6 +187,16 @@ def job_logs(job_id, run_id=None, finished_timeout=None):
         A log message dictionary with "message", "createdAt" and other attributes
         provided by the job logs endpoint. Note that this will block execution
         until the job has stopped and all log messages are retrieved.
+
+    Examples
+    --------
+    >>> # Print all log messages from a job's most recent run
+    >>> for log in job_logs(job_id=123456):
+    ...     print(f"{log['createdAt']}: {log['message']}")
+    ...
+    >>> # Get logs from a specific run with a 30 second timeout
+    >>> for log in job_logs(job_id=123456, run_id=789, finished_timeout=30):
+    ...     print(log['message'])
     """
     # The return_type for the client is "raw" in order to check
     # the "civis-cache-control" and "civis-max-id" headers when


### PR DESCRIPTION
This adds some examples to the `job_logs` function added in #509.

It also updates the requirements due to GHSA-cpwx-vrp4-4pq7.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- N/A If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
