### PR TITLE
[CIVIS-10982] ENH update Civis parallel backend internals for refactored joblib backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added examples to `civis.utils.job_logs()` docstring (#510)
 
 ### Changed
+- Updated Civis parallel backend's internals for refactored joblib's backend. (#513)
 
 ### Deprecated
 
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `civis_logger` for needing a user-provided `__name__` as best practice. (#512)
 
 ### Security
-
 - Updated `docs/requirements.txt` due to a security advisory for jinja2. See GHSA-cpwx-vrp4-4pq7 (#510)
 
 ## 2.5.0 - 2025-02-24

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ attrs==25.3.0
     #   referencing
 babel==2.17.0
     # via sphinx
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 charset-normalizer==3.4.2
     # via requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = { text = "BSD-3-Clause" }
 dependencies = [
     "click >= 6.0",
     "cloudpickle >= 0.2",
-    "joblib >= 1.3.0",
+    "joblib >= 1.5.0",
     "jsonref >= 0.1",
     "jsonschema >= 2.5.1",
     "PyYAML >= 3.0",

--- a/src/civis/parallel.py
+++ b/src/civis/parallel.py
@@ -871,7 +871,7 @@ class _CivisBackend(ParallelBackendBase):
             raise out
         return out
 
-    def apply_async(self, func, callback=None):
+    def submit(self, func, callback=None):
         """Schedule func to be run"""
         # Serialize func to a temporary file and upload it to a Civis File.
         # Make the temporary files expire in a week.


### PR DESCRIPTION
When I worked on #512, I noticed that the test suite threw a joblib deprecation warning:

```
.../site-packages/joblib/_parallel_backends.py:122: DeprecationWarning: `apply_async` is deprecated, implement and use `submit` instead.
```

Since [joblib v1.5.0 released in May 2025](https://github.com/joblib/joblib/blob/0672e76ad10e9f463221a58fb7bffa127287a4ba/CHANGES.rst?plain=1#L61-L62), joblib's `ParallelBackendBase` has been refactored [with the effect of favoring `submit` over `apply_async`](https://github.com/joblib/joblib/blob/0672e76ad10e9f463221a58fb7bffa127287a4ba/joblib/_parallel_backends.py#L89-L126). To be more forward-compatible, this pull request updates civis-python's parallel backend, which subclasses joblib's `ParallelBackendBase`. After this PR, joblib's deprecation warning no longer shows up.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- n/a If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
