### PR TITLE
[CIVIS-11076] FIX add kwarg `user_agent` in `civis.APIClient` in stub file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Security
 
+## 2.7.1 - 2025-07-03
+
+### Fixed
+- Fixed `civis.APIClient` in the stub file for the new `user_agent` keyword argument. (#522)
+
 ## 2.7.0 - 2025-07-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.7.0"
+version = "2.7.1"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.10"

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -84391,6 +84391,7 @@ class APIClient:
         api_version: str = ...,
         local_api_spec: OrderedDict | str | None = ...,
         force_refresh_api_spec: bool = ...,
+        user_agent: str | None = ...,
     ): ...
     def get_aws_credential_id(
         self,

--- a/src/civis/resources/_client_pyi.py
+++ b/src/civis/resources/_client_pyi.py
@@ -150,6 +150,7 @@ class APIClient:
         api_version: str = ...,
         local_api_spec: OrderedDict | str | None = ...,
         force_refresh_api_spec: bool = ...,
+        user_agent: str | None = ...,
     ): ...
     def get_aws_credential_id(
         self,


### PR DESCRIPTION
In #521, I forgot to add the new kwarg `user_agent` for `civis.APIClient` in the stub file `client.pyi`. This PR fixes this issue.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
