### PR TITLE
[CIVIS-12338] DEP Fix "list" versus "get" API methods; release for v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+- Added new API methods `client.<endpoint>.get*` (`client` is a `civis.APIClient` instance)
+  which are functionally equivalent to the existing `client.<endpoint>.list*` counterparts
+  which are now deprecated.
+  For the complete list of these new `get*` methods, see the "Deprecated" section below. (#530)
 - Added type annotations to public functions and classes. (#529)
 - Enabled static type checks with `mypy` on CI builds. (#529)
 - File-related `civis.io.*` functions that accept a path can now take either a string
@@ -53,6 +57,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Dropped support for Python 3.10. (#528)
 
 ### Fixed
+- Fixed the return type annotations for some of the `list*` API methods,
+  i.e., those whose method names are in the form of `client.<endpoint>.list*`
+  (`client` is a `civis.APIClient` instance), which return a singleton `civis.Response`
+  object but previously had the incorrect return annotation for an array of `civis.Response`
+  objects.
+  For the complete list of these `list*` methods, see the "Deprecated" section above. (#530)
 - Fixed `civis.utils.run_template` for the return value when `return_as="JSONValue"`. (#529)
 - Fixed retries for Civis API calls under `civis.APIClient`
   that would lead to a recursion error. (#525)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.8.0 - 2026-01-26
 
 ### Added
-- Added new API methods `client.<endpoint>.get*`
-  which are functionally equivalent to the existing `client.<endpoint>.list*` counterparts
-  that are now deprecated.
-  For the complete list of these new `get*` methods, see the "Deprecated" section below. (#530)
 - Added type annotations to public functions and classes. (#529)
 - Enabled static type checks with `mypy` on CI builds. (#529)
 - File-related `civis.io.*` functions that accept a path can now take either a string
@@ -65,10 +61,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Dropped support for Python 3.10. (#528)
 
 ### Fixed
-- Fixed the return type annotations for some of the `list*` API methods,
-  i.e., those whose method names are in the form of `client.<endpoint>.list*`, which return a singleton `civis.Response`
-  object but previously had the incorrect return annotation for an array of `civis.Response` objects.
-  For the complete list of these `list*` methods, see the "Deprecated" section above. (#530)
 - Fixed `civis.utils.run_template` for the return value when `return_as="JSONValue"`. (#529)
 - Fixed retries for Civis API calls under `civis.APIClient`
   that would lead to a recursion error. (#525)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 - Deprecated the JSONValue parameter of `civis.utils.run_template`. (#526)
+- Some of the `list*` methods from various Civis API endpoints should have been named
+  `get*`, because they return a singleton response object, as opposed to an array
+  of such objects. These `list*` methods are now deprecated. The corresponding
+  equivalent `get*` methods are available and should be preferred. The following
+  is the full list of these `list*` methods and their preferred `get*` counterparts
+  (#530; `client` is a placeholder of a `civis.APIClient` instance):
+   * `client.clusters.list_kubernetes_instance_configs_historical_graphs` -> `client.clusters.get_kubernetes_instance_configs_historical_graphs`
+   * `client.clusters.list_kubernetes_instance_configs_historical_metrics` -> `client.clusters.get_kubernetes_instance_configs_historical_metrics`
+   * `client.databases.list_advanced_settings` -> `client.databases.get_advanced_settings`
+   * `client.endpoints.list` -> `client.endpoints.get`
+   * `client.git_repos.list_refs` -> `client.git_repos.get_refs`
+   * `client.groups.list_child_groups` -> `client.groups.get_child_groups`
+   * `client.models.list_schedules` -> `client.models.get_schedules`
+   * `client.notebooks.list_update_links` -> `client.notebooks.get_update_links`
+   * `client.notebooks.list_git` -> `client.notebooks.get_git`
+   * `client.notifications.list` -> `client.notifications.get`
+   * `client.predictions.list_schedules` -> `client.predictions.get_schedules`
+   * `client.reports.list_git` -> `client.reports.get_git`
+   * `client.scripts.list_sql_git` -> `client.scripts.get_sql_git`
+   * `client.scripts.list_javascript_git` -> `client.scripts.get_javascript_git`
+   * `client.scripts.list_python3_git` -> `client.scripts.get_python3_git`
+   * `client.scripts.list_r_git` -> `client.scripts.get_r_git`
+   * `client.usage.list_llm_organization_summary` -> `client.usage.get_llm_organization_summary`
+   * `client.users.list_me` -> `client.users.get_me`
+   * `client.workflows.list_git` -> `client.workflows.get_git`
 
 ### Removed
 - Dropped support for Python 3.10. (#528)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.8.0 - 2026-01-26
 
 ### Added
-- Added new API methods `client.<endpoint>.get*` (`client` is a `civis.APIClient` instance)
+- Added new API methods `client.<endpoint>.get*`
   which are functionally equivalent to the existing `client.<endpoint>.list*` counterparts
-  which are now deprecated.
+  that are now deprecated.
   For the complete list of these new `get*` methods, see the "Deprecated" section below. (#530)
 - Added type annotations to public functions and classes. (#529)
 - Enabled static type checks with `mypy` on CI builds. (#529)
@@ -37,11 +37,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 - Deprecated the JSONValue parameter of `civis.utils.run_template`. (#526)
 - Some of the `list*` methods from various Civis API endpoints should have been named
-  `get*`, because they return a singleton response object, as opposed to an array
+  `get*`, because they return a singleton `civis.Response` object, as opposed to an array
   of such objects. These `list*` methods are now deprecated. The corresponding
   equivalent `get*` methods are available and should be preferred. The following
-  is the full list of these `list*` methods and their preferred `get*` counterparts
-  (#530; `client` is a placeholder of a `civis.APIClient` instance):
+  is the full list of these `list*` methods and their preferred `get*` counterparts (#530):
    * `client.clusters.list_kubernetes_instance_configs_historical_graphs` -> `client.clusters.get_kubernetes_instance_configs_historical_graphs`
    * `client.clusters.list_kubernetes_instance_configs_historical_metrics` -> `client.clusters.get_kubernetes_instance_configs_historical_metrics`
    * `client.databases.list_advanced_settings` -> `client.databases.get_advanced_settings`
@@ -67,10 +66,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed the return type annotations for some of the `list*` API methods,
-  i.e., those whose method names are in the form of `client.<endpoint>.list*`
-  (`client` is a `civis.APIClient` instance), which return a singleton `civis.Response`
-  object but previously had the incorrect return annotation for an array of `civis.Response`
-  objects.
+  i.e., those whose method names are in the form of `client.<endpoint>.list*`, which return a singleton `civis.Response`
+  object but previously had the incorrect return annotation for an array of `civis.Response` objects.
   For the complete list of these `list*` methods, see the "Deprecated" section above. (#530)
 - Fixed `civis.utils.run_template` for the return value when `return_as="JSONValue"`. (#529)
 - Fixed retries for Civis API calls under `civis.APIClient`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## 2.8.0 - 2026-01-26
+
+### Added
 - Added new API methods `client.<endpoint>.get*` (`client` is a `civis.APIClient` instance)
   which are functionally equivalent to the existing `client.<endpoint>.list*` counterparts
   which are now deprecated.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -122,7 +122,7 @@ your user information:
 
 .. code:: python
 
-   >>> client.users.list_me()
+   >>> client.users.get_me()
    Response({'email': 'user@email.com',
              'feature_flags': Response({'left_nav_basic': True,
                                         'results': True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.7.1"
+version = "2.8.0"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "PyYAML >= 3.0",
     "requests >= 2.32.3",
     "tenacity >= 6.2",
+    # For backporting warnings.deprecated in Python >= 3.13
+    "typing-extensions >= 4.5.0 ; python_version < '3.13'",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/civis/_deprecation.py
+++ b/src/civis/_deprecation.py
@@ -2,6 +2,12 @@ from functools import wraps
 from inspect import signature
 import warnings
 
+try:
+    from warnings import deprecated  # noqa: F401
+except ImportError:
+    # For Python < 3.13
+    from typing_extensions import deprecated  # noqa: F401
+
 
 class DeprecatedKwargDefault:
     """A stand-in default value of a deprecated keyword argument.

--- a/src/civis/base.py
+++ b/src/civis/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import platform
 import threading
-import warnings
 from concurrent import futures
 from json.decoder import JSONDecodeError
 from posixpath import join
@@ -193,13 +192,8 @@ class Endpoint:
         path=None,
         params=None,
         data=None,
-        deprecation_warning=None,
         **kwargs,
     ):
-        if deprecation_warning:
-            # stacklevel=3 to point to the call just outside civis-python
-            warnings.warn(deprecation_warning, FutureWarning, stacklevel=3)
-
         iterator = kwargs.pop("iterator", False)
 
         if iterator:

--- a/src/civis/client.py
+++ b/src/civis/client.py
@@ -115,7 +115,7 @@ class APIClient:
 
         .. deprecated:: 2.6.0
             This property is deprecated and will be removed at civis-python v3.0.0.
-            Please use ``client.users.list_me()["feature_flags"]`` instead.
+            Please use ``client.users.get_me()["feature_flags"]`` instead.
 
         Returns
         -------
@@ -124,13 +124,13 @@ class APIClient:
         warnings.warn(
             "The property `feature_flags` is deprecated and will be removed "
             "at civis-python v3.0.0. Please use "
-            "client.users.list_me()['feature_flags'] instead.",
+            "client.users.get_me()['feature_flags'] instead.",
             FutureWarning,
             stacklevel=2,  # Point to the user code that calls this method.
         )
         if self._feature_flags:
             return self._feature_flags
-        me = self.users.list_me()
+        me = self.users.get_me()
         self._feature_flags = tuple(
             flag for flag, value in me["feature_flags"].items() if value
         )
@@ -423,7 +423,7 @@ class APIClient:
     @lru_cache(maxsize=128)
     def username(self):
         """The current user's username."""
-        return self.users.list_me().username
+        return self.users.get_me().username
 
 
 APIClient.__doc__ = APIClient.__doc__.format(

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -1683,7 +1683,6 @@ class _Clusters:
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_graphs``
 
         .. warning::
-
             The method name
             ``<client>.clusters.list_kubernetes_instance_configs_historical_graphs``
             is deprecated and will be removed at civis-python v3.0.0 (no release
@@ -1770,7 +1769,6 @@ class _Clusters:
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_metrics``
 
         .. warning::
-
             The method name
             ``<client>.clusters.list_kubernetes_instance_configs_historical_metrics``
             is deprecated and will be removed at civis-python v3.0.0 (no release
@@ -3645,7 +3643,6 @@ class _Databases:
         API URL: ``GET /databases/{id}/advanced-settings``
 
         .. warning::
-
             The method name ``<client>.databases.list_advanced_settings`` is
             deprecated and will be removed at civis-python v3.0.0 (no release timeline
             yet). Please update your code to use
@@ -3777,7 +3774,6 @@ class _Endpoints:
         API URL: ``GET /endpoints``
 
         .. warning::
-
             The method name ``<client>.endpoints.list`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.endpoints.get`` instead for the same
@@ -13653,7 +13649,6 @@ class _Git_Repos:
         API URL: ``GET /git_repos/{id}/refs``
 
         .. warning::
-
             The method name ``<client>.git_repos.list_refs`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.git_repos.get_refs`` instead for the same
@@ -14501,7 +14496,6 @@ class _Groups:
         API URL: ``GET /groups/{id}/child_groups``
 
         .. warning::
-
             The method name ``<client>.groups.list_child_groups`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
             update your code to use ``<client>.groups.get_child_groups`` instead for
@@ -24005,7 +23999,6 @@ class _Models:
         API URL: ``GET /models/{id}/schedules``
 
         .. warning::
-
             The method name ``<client>.models.list_schedules`` is deprecated and will
             be removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.models.get_schedules`` instead for the same
@@ -24849,7 +24842,6 @@ class _Notebooks:
         API URL: ``GET /notebooks/{id}/update-links``
 
         .. warning::
-
             The method name ``<client>.notebooks.list_update_links`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
             update your code to use ``<client>.notebooks.get_update_links`` instead
@@ -25828,7 +25820,6 @@ class _Notebooks:
         API URL: ``GET /notebooks/{id}/git``
 
         .. warning::
-
             The method name ``<client>.notebooks.list_git`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.notebooks.get_git`` instead for the same
@@ -26115,7 +26106,6 @@ class _Notifications:
         API URL: ``GET /notifications``
 
         .. warning::
-
             The method name ``<client>.notifications.list`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.notifications.get`` instead for the same
@@ -27533,7 +27523,6 @@ class _Predictions:
         API URL: ``GET /predictions/{id}/schedules``
 
         .. warning::
-
             The method name ``<client>.predictions.list_schedules`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
             update your code to use ``<client>.predictions.get_schedules`` instead for
@@ -30837,7 +30826,6 @@ class _Reports:
         API URL: ``GET /reports/{id}/git``
 
         .. warning::
-
             The method name ``<client>.reports.list_git`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.reports.get_git`` instead for the same
@@ -45432,7 +45420,6 @@ class _Scripts:
         API URL: ``GET /scripts/sql/{id}/git``
 
         .. warning::
-
             The method name ``<client>.scripts.list_sql_git`` is deprecated and will
             be removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.scripts.get_sql_git`` instead for the same
@@ -45780,7 +45767,6 @@ class _Scripts:
         API URL: ``GET /scripts/javascript/{id}/git``
 
         .. warning::
-
             The method name ``<client>.scripts.list_javascript_git`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
             update your code to use ``<client>.scripts.get_javascript_git`` instead
@@ -46128,7 +46114,6 @@ class _Scripts:
         API URL: ``GET /scripts/python3/{id}/git``
 
         .. warning::
-
             The method name ``<client>.scripts.list_python3_git`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
             update your code to use ``<client>.scripts.get_python3_git`` instead for
@@ -46476,7 +46461,6 @@ class _Scripts:
         API URL: ``GET /scripts/r/{id}/git``
 
         .. warning::
-
             The method name ``<client>.scripts.list_r_git`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.scripts.get_r_git`` instead for the same
@@ -56658,7 +56642,6 @@ class _Tables:
         API URL: ``POST /tables/{source_table_id}/enhancements/geocodings``
 
         .. warning::
-
             Warning: The tables/:source_table_id/enhancements/geocodings endpoint is
             deprecated and will be removed after January 1, 2021.
 
@@ -56698,7 +56681,6 @@ class _Tables:
         API URL: ``POST /tables/{source_table_id}/enhancements/cass-ncoa``
 
         .. warning::
-
             Warning: The tables/:source_table_id/enhancements/cass-ncoa endpoint is
             deprecated and will be removed after January 1, 2021.
 
@@ -56761,7 +56743,6 @@ class _Tables:
         API URL: ``GET /tables/{source_table_id}/enhancements/geocodings/{id}``
 
         .. warning::
-
             Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint
             is deprecated and will be removed after January 1, 2021.
 
@@ -56799,7 +56780,6 @@ class _Tables:
         API URL: ``GET /tables/{source_table_id}/enhancements/cass-ncoa/{id}``
 
         .. warning::
-
             Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint
             is deprecated and will be removed after January 1, 2021.
 
@@ -56887,7 +56867,6 @@ class _Tables:
         API URL: ``POST /tables/{id}/refresh``
 
         .. warning::
-
             Warning: The tables/:id/refresh endpoint is deprecated. Please use
             tables/scan from now on.
 
@@ -59479,7 +59458,6 @@ class _Usage:
         API URL: ``GET /usage/llm/organization/{org_id}/summary``
 
         .. warning::
-
             The method name ``<client>.usage.list_llm_organization_summary`` is
             deprecated and will be removed at civis-python v3.0.0 (no release timeline
             yet). Please update your code to use
@@ -59987,7 +59965,6 @@ class _Users:
         API URL: ``GET /users/me``
 
         .. warning::
-
             The method name ``<client>.users.list_me`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.users.get_me`` instead for the same
@@ -62621,7 +62598,6 @@ class _Workflows:
         API URL: ``GET /workflows/{id}/git``
 
         .. warning::
-
             The method name ``<client>.workflows.list_git`` is deprecated and will be
             removed at civis-python v3.0.0 (no release timeline yet). Please update
             your code to use ``<client>.workflows.get_git`` instead for the same

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -1645,6 +1645,33 @@ class _Clusters:
         """
         ...
 
+    def get_kubernetes_instance_configs_historical_graphs(
+        self,
+        instance_config_id: int,
+        *,
+        timeframe: str | None = ...,
+    ) -> _ResponseClustersGetKubernetesInstanceConfigsHistoricalGraphs:
+        """Get graphs of historical resource usage in an Instance Config
+
+        API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_graphs``
+
+        Parameters
+        ----------
+        instance_config_id : int
+            The ID of this instance config.
+        timeframe : str, optional
+            The span of time that the graphs cover. Must be one of 1_day, 1_week.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - cpu_graph_url : str
+                URL for the graph of historical CPU usage in this instance config.
+            - mem_graph_url : str
+                URL for the graph of historical memory usage in this instance config.
+        """
+        ...
+
     def list_kubernetes_instance_configs_historical_graphs(
         self,
         instance_config_id: int,
@@ -1654,6 +1681,15 @@ class _Clusters:
         """Get graphs of historical resource usage in an Instance Config
 
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_graphs``
+
+        .. warning::
+
+            The method name
+            ``<client>.clusters.list_kubernetes_instance_configs_historical_graphs``
+            is deprecated and will be removed at civis-python v3.0.0 (no release
+            timeline yet). Please update your code to use
+            ``<client>.clusters.get_kubernetes_instance_configs_historical_graphs``
+            instead for the same functionality.
 
         Parameters
         ----------
@@ -1672,6 +1708,56 @@ class _Clusters:
         """
         ...
 
+    def get_kubernetes_instance_configs_historical_metrics(
+        self,
+        instance_config_id: int,
+        *,
+        timeframe: str | None = ...,
+        metric: str | None = ...,
+    ) -> _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetrics:
+        """Get graphs of historical resource usage in an Instance Config
+
+        API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_metrics``
+
+        Parameters
+        ----------
+        instance_config_id : int
+            The ID of this instance config.
+        timeframe : str, optional
+            The span of time that the graphs cover. Must be one of 1_day, 1_week.
+        metric : str, optional
+            The metric to retrieve. Must be one of cpu, memory.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - instance_config_id : int
+                The ID of this instance config.
+            - metric : str
+                URL for the graph of historical CPU usage in this instance config.
+            - timeframe : str
+                The span of time that the graphs cover. Must be one of 1_day, 1_week.
+            - unit : str
+                The unit of the values.
+            - metrics : :class:`civis.Response`
+                - used : :class:`civis.Response`
+                    - times : List[int]
+                        The times associated with data points, in seconds since epoch.
+                    - values : List[float]
+                        The values of the data points.
+                - requested : :class:`civis.Response`
+                    - times : List[int]
+                        The times associated with data points, in seconds since epoch.
+                    - values : List[float]
+                        The values of the data points.
+                - capacity : :class:`civis.Response`
+                    - times : List[int]
+                        The times associated with data points, in seconds since epoch.
+                    - values : List[float]
+                        The values of the data points.
+        """
+        ...
+
     def list_kubernetes_instance_configs_historical_metrics(
         self,
         instance_config_id: int,
@@ -1682,6 +1768,15 @@ class _Clusters:
         """Get graphs of historical resource usage in an Instance Config
 
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_metrics``
+
+        .. warning::
+
+            The method name
+            ``<client>.clusters.list_kubernetes_instance_configs_historical_metrics``
+            is deprecated and will be removed at civis-python v3.0.0 (no release
+            timeline yet). Please update your code to use
+            ``<client>.clusters.get_kubernetes_instance_configs_historical_metrics``
+            instead for the same functionality.
 
         Parameters
         ----------
@@ -3519,6 +3614,28 @@ class _Databases:
         """
         ...
 
+    def get_advanced_settings(
+        self,
+        id: int,
+    ) -> _ResponseDatabasesGetAdvancedSettings:
+        """Get the advanced settings for this database
+
+        API URL: ``GET /databases/{id}/advanced-settings``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the database this advanced settings object belongs to.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - export_caching_enabled : bool
+                Whether or not caching is enabled for export jobs run on this database
+                server.
+        """
+        ...
+
     def list_advanced_settings(
         self,
         id: int,
@@ -3526,6 +3643,14 @@ class _Databases:
         """Get the advanced settings for this database
 
         API URL: ``GET /databases/{id}/advanced-settings``
+
+        .. warning::
+
+            The method name ``<client>.databases.list_advanced_settings`` is
+            deprecated and will be removed at civis-python v3.0.0 (no release timeline
+            yet). Please update your code to use
+            ``<client>.databases.get_advanced_settings`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -3630,12 +3755,33 @@ class _Databases:
         ...
 
 class _Endpoints:
+    def get(
+        self,
+    ) -> Response:
+        """List API endpoints
+
+        API URL: ``GET /endpoints``
+
+        Returns
+        -------
+        None
+            Response code 200: success
+        """
+        ...
+
     def list(
         self,
     ) -> ListResponse[Response]:
         """List API endpoints
 
         API URL: ``GET /endpoints``
+
+        .. warning::
+
+            The method name ``<client>.endpoints.list`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.endpoints.get`` instead for the same
+            functionality.
 
         Returns
         -------
@@ -13475,6 +13621,29 @@ class _Git_Repos:
         """
         ...
 
+    def get_refs(
+        self,
+        id: int,
+    ) -> _ResponseGitReposGetRefs:
+        """Get all branches and tags of a bookmarked git repository
+
+        API URL: ``GET /git_repos/{id}/refs``
+
+        Parameters
+        ----------
+        id : int
+            The ID for this git repository.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - branches : List[str]
+                List of branch names of this git repository.
+            - tags : List[str]
+                List of tag names of this git repository.
+        """
+        ...
+
     def list_refs(
         self,
         id: int,
@@ -13482,6 +13651,13 @@ class _Git_Repos:
         """Get all branches and tags of a bookmarked git repository
 
         API URL: ``GET /git_repos/{id}/refs``
+
+        .. warning::
+
+            The method name ``<client>.git_repos.list_refs`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.git_repos.get_refs`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -14288,6 +14464,34 @@ class _Groups:
         """
         ...
 
+    def get_child_groups(
+        self,
+        id: int,
+    ) -> _ResponseGroupsGetChildGroups:
+        """Get child groups of this group
+
+        API URL: ``GET /groups/{id}/child_groups``
+
+        Parameters
+        ----------
+        id : int
+            The ID of this group.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - manageable : List[:class:`civis.Response`]
+                - id : int
+                - name : str
+            - writeable : List[:class:`civis.Response`]
+                - id : int
+                - name : str
+            - readable : List[:class:`civis.Response`]
+                - id : int
+                - name : str
+        """
+        ...
+
     def list_child_groups(
         self,
         id: int,
@@ -14295,6 +14499,13 @@ class _Groups:
         """Get child groups of this group
 
         API URL: ``GET /groups/{id}/child_groups``
+
+        .. warning::
+
+            The method name ``<client>.groups.list_child_groups`` is deprecated and
+            will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            update your code to use ``<client>.groups.get_child_groups`` instead for
+            the same functionality.
 
         Parameters
         ----------
@@ -23749,6 +23960,42 @@ class _Models:
         """
         ...
 
+    def get_schedules(
+        self,
+        id: int,
+    ) -> _ResponseModelsGetSchedules:
+        """Show the model build schedule
+
+        API URL: ``GET /models/{id}/schedules``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the model associated with this schedule.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - id : int
+                The ID of the model associated with this schedule.
+            - schedule : :class:`civis.Response`
+                - scheduled : bool
+                    If the item is scheduled.
+                - scheduled_days : List[int]
+                    Days of the week, based on numeric value starting at 0 for Sunday.
+                    Mutually exclusive with scheduledDaysOfMonth
+                - scheduled_hours : List[int]
+                    Hours of the day it is scheduled on.
+                - scheduled_minutes : List[int]
+                    Minutes of the day it is scheduled on.
+                - scheduled_runs_per_hour : int
+                    Deprecated in favor of scheduled minutes.
+                - scheduled_days_of_month : List[int]
+                    Days of the month it is scheduled on, mutually exclusive with
+                    scheduledDays.
+        """
+        ...
+
     def list_schedules(
         self,
         id: int,
@@ -23756,6 +24003,13 @@ class _Models:
         """Show the model build schedule
 
         API URL: ``GET /models/{id}/schedules``
+
+        .. warning::
+
+            The method name ``<client>.models.list_schedules`` is deprecated and will
+            be removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.models.get_schedules`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -24562,6 +24816,30 @@ class _Notebooks:
         """
         ...
 
+    def get_update_links(
+        self,
+        id: int,
+    ) -> _ResponseNotebooksGetUpdateLinks:
+        """Get URLs to update notebook
+
+        API URL: ``GET /notebooks/{id}/update-links``
+
+        Parameters
+        ----------
+        id : int
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - update_url : str
+                Time-limited URL to PUT new contents of the .ipynb file for this
+                notebook.
+            - update_preview_url : str
+                Time-limited URL to PUT new contents of the .htm preview file for this
+                notebook.
+        """
+        ...
+
     def list_update_links(
         self,
         id: int,
@@ -24569,6 +24847,13 @@ class _Notebooks:
         """Get URLs to update notebook
 
         API URL: ``GET /notebooks/{id}/update-links``
+
+        .. warning::
+
+            The method name ``<client>.notebooks.list_update_links`` is deprecated and
+            will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            update your code to use ``<client>.notebooks.get_update_links`` instead
+            for the same functionality.
 
         Parameters
         ----------
@@ -25496,6 +25781,44 @@ class _Notebooks:
         """
         ...
 
+    def get_git(
+        self,
+        id: int,
+    ) -> _ResponseNotebooksGetGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /notebooks/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_git(
         self,
         id: int,
@@ -25503,6 +25826,13 @@ class _Notebooks:
         """Get the git metadata attached to an item
 
         API URL: ``GET /notebooks/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.notebooks.list_git`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.notebooks.get_git`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -25746,6 +26076,33 @@ class _Notebooks:
         ...
 
 class _Notifications:
+    def get(
+        self,
+        *,
+        last_event_id: str | None = ...,
+        r: str | None = ...,
+        mock: str | None = ...,
+    ) -> Response:
+        """Receive a stream of notifications as they come in
+
+        API URL: ``GET /notifications``
+
+        Parameters
+        ----------
+        last_event_id : str, optional
+            allows browser to keep track of last event fired
+        r : str, optional
+            specifies retry/reconnect timeout
+        mock : str, optional
+            used for testing
+
+        Returns
+        -------
+        None
+            Response code 200: success
+        """
+        ...
+
     def list(
         self,
         *,
@@ -25756,6 +26113,13 @@ class _Notifications:
         """Receive a stream of notifications as they come in
 
         API URL: ``GET /notifications``
+
+        .. warning::
+
+            The method name ``<client>.notifications.list`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.notifications.get`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -27121,6 +27485,45 @@ class _Predictions:
         """
         ...
 
+    def get_schedules(
+        self,
+        id: int,
+    ) -> _ResponsePredictionsGetSchedules:
+        """Show the prediction schedule
+
+        API URL: ``GET /predictions/{id}/schedules``
+
+        Parameters
+        ----------
+        id : int
+            ID of the prediction associated with this schedule.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - id : int
+                ID of the prediction associated with this schedule.
+            - schedule : :class:`civis.Response`
+                - scheduled : bool
+                    If the item is scheduled.
+                - scheduled_days : List[int]
+                    Days of the week, based on numeric value starting at 0 for Sunday.
+                    Mutually exclusive with scheduledDaysOfMonth
+                - scheduled_hours : List[int]
+                    Hours of the day it is scheduled on.
+                - scheduled_minutes : List[int]
+                    Minutes of the day it is scheduled on.
+                - scheduled_runs_per_hour : int
+                    Deprecated in favor of scheduled minutes.
+                - scheduled_days_of_month : List[int]
+                    Days of the month it is scheduled on, mutually exclusive with
+                    scheduledDays.
+            - score_on_model_build : bool
+                Whether the prediction will run after a rebuild of the associated
+                model.
+        """
+        ...
+
     def list_schedules(
         self,
         id: int,
@@ -27128,6 +27531,13 @@ class _Predictions:
         """Show the prediction schedule
 
         API URL: ``GET /predictions/{id}/schedules``
+
+        .. warning::
+
+            The method name ``<client>.predictions.list_schedules`` is deprecated and
+            will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            update your code to use ``<client>.predictions.get_schedules`` instead for
+            the same functionality.
 
         Parameters
         ----------
@@ -30380,6 +30790,44 @@ class _Reports:
         """
         ...
 
+    def get_git(
+        self,
+        id: int,
+    ) -> _ResponseReportsGetGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /reports/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_git(
         self,
         id: int,
@@ -30387,6 +30835,13 @@ class _Reports:
         """Get the git metadata attached to an item
 
         API URL: ``GET /reports/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.reports.list_git`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.reports.get_git`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -44930,6 +45385,44 @@ class _Scripts:
         """
         ...
 
+    def get_sql_git(
+        self,
+        id: int,
+    ) -> _ResponseScriptsGetSqlGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /scripts/sql/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_sql_git(
         self,
         id: int,
@@ -44937,6 +45430,13 @@ class _Scripts:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/sql/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.scripts.list_sql_git`` is deprecated and will
+            be removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.scripts.get_sql_git`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -45233,6 +45733,44 @@ class _Scripts:
         """
         ...
 
+    def get_javascript_git(
+        self,
+        id: int,
+    ) -> _ResponseScriptsGetJavascriptGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /scripts/javascript/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_javascript_git(
         self,
         id: int,
@@ -45240,6 +45778,13 @@ class _Scripts:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/javascript/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.scripts.list_javascript_git`` is deprecated and
+            will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            update your code to use ``<client>.scripts.get_javascript_git`` instead
+            for the same functionality.
 
         Parameters
         ----------
@@ -45536,6 +46081,44 @@ class _Scripts:
         """
         ...
 
+    def get_python3_git(
+        self,
+        id: int,
+    ) -> _ResponseScriptsGetPython3Git:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /scripts/python3/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_python3_git(
         self,
         id: int,
@@ -45543,6 +46126,13 @@ class _Scripts:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/python3/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.scripts.list_python3_git`` is deprecated and
+            will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            update your code to use ``<client>.scripts.get_python3_git`` instead for
+            the same functionality.
 
         Parameters
         ----------
@@ -45839,6 +46429,44 @@ class _Scripts:
         """
         ...
 
+    def get_r_git(
+        self,
+        id: int,
+    ) -> _ResponseScriptsGetRGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /scripts/r/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_r_git(
         self,
         id: int,
@@ -45846,6 +46474,13 @@ class _Scripts:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/r/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.scripts.list_r_git`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.scripts.get_r_git`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -56018,13 +56653,14 @@ class _Tables:
         self,
         source_table_id: int,
     ) -> _ResponseTablesPostEnhancementsGeocodings:
-        """.. warning::
-
-            Warning: The tables/:source_table_id/enhancements/geocodings endpoint is deprecated and will be removed after January 1, 2021.
-
-        Geocode a table
+        """Geocode a table
 
         API URL: ``POST /tables/{source_table_id}/enhancements/geocodings``
+
+        .. warning::
+
+            Warning: The tables/:source_table_id/enhancements/geocodings endpoint is
+            deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56057,13 +56693,14 @@ class _Tables:
         output_level: str | None = ...,
         batch_size: int | None = ...,
     ) -> _ResponseTablesPostEnhancementsCassNcoa:
-        """.. warning::
-
-            Warning: The tables/:source_table_id/enhancements/cass-ncoa endpoint is deprecated and will be removed after January 1, 2021.
-
-        Standardize addresses in a table
+        """Standardize addresses in a table
 
         API URL: ``POST /tables/{source_table_id}/enhancements/cass-ncoa``
+
+        .. warning::
+
+            Warning: The tables/:source_table_id/enhancements/cass-ncoa endpoint is
+            deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56119,13 +56756,14 @@ class _Tables:
         id: int,
         source_table_id: int,
     ) -> _ResponseTablesGetEnhancementsGeocodings:
-        """.. warning::
-
-            Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint is deprecated and will be removed after January 1, 2021.
-
-        View the status of a geocoding table enhancement
+        """View the status of a geocoding table enhancement
 
         API URL: ``GET /tables/{source_table_id}/enhancements/geocodings/{id}``
+
+        .. warning::
+
+            Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint
+            is deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56156,13 +56794,14 @@ class _Tables:
         id: int,
         source_table_id: int,
     ) -> _ResponseTablesGetEnhancementsCassNcoa:
-        """.. warning::
-
-            Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint is deprecated and will be removed after January 1, 2021.
-
-        View the status of a CASS / NCOA table enhancement
+        """View the status of a CASS / NCOA table enhancement
 
         API URL: ``GET /tables/{source_table_id}/enhancements/cass-ncoa/{id}``
+
+        .. warning::
+
+            Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint
+            is deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56243,13 +56882,14 @@ class _Tables:
         self,
         id: int,
     ) -> _ResponseTablesPostRefresh:
-        """.. warning::
-
-            Warning: The tables/:id/refresh endpoint is deprecated. Please use tables/scan from now on.
-
-        Request a refresh for column and table statistics
+        """Request a refresh for column and table statistics
 
         API URL: ``POST /tables/{id}/refresh``
+
+        .. warning::
+
+            Warning: The tables/:id/refresh endpoint is deprecated. Please use
+            tables/scan from now on.
 
         Parameters
         ----------
@@ -58793,6 +59433,40 @@ class _Usage:
         """
         ...
 
+    def get_llm_organization_summary(
+        self,
+        org_id: int,
+        *,
+        start_date: str | None = ...,
+        end_date: str | None = ...,
+    ) -> _ResponseUsageGetLlmOrganizationSummary:
+        """Get summarized usage statistics for a given organization
+
+        API URL: ``GET /usage/llm/organization/{org_id}/summary``
+
+        Parameters
+        ----------
+        org_id : int
+            The ID of the organization to get usage statistics for.
+        start_date : str, optional
+            The start date of the range to get usage statistics for."\
+            "Defaults to the start of the current month if neither start_date nor
+            end_date is specified.
+        end_date : str, optional
+            The end date of the range to get usage statistics for."\
+            "Defaults to the end of the current day if neither start_date nor end_date
+            is specified.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - credits : float (float)
+                The number of credits used.
+            - organization_id : int
+                The organization for which LLM usage statistics are summarized.
+        """
+        ...
+
     def list_llm_organization_summary(
         self,
         org_id: int,
@@ -58803,6 +59477,14 @@ class _Usage:
         """Get summarized usage statistics for a given organization
 
         API URL: ``GET /usage/llm/organization/{org_id}/summary``
+
+        .. warning::
+
+            The method name ``<client>.usage.list_llm_organization_summary`` is
+            deprecated and will be removed at civis-python v3.0.0 (no release timeline
+            yet). Please update your code to use
+            ``<client>.usage.get_llm_organization_summary`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -59220,12 +59902,96 @@ class _Users:
         """
         ...
 
+    def get_me(
+        self,
+    ) -> _ResponseUsersGetMe:
+        """Show info about the logged-in user
+
+        API URL: ``GET /users/me``
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - id : int
+                The ID of this user.
+            - name : str
+                This user's name.
+            - email : str
+                This user's email address.
+            - username : str
+                This user's username.
+            - initials : str
+                This user's initials.
+            - last_checked_announcements : str (date-time)
+                The date and time at which the user last checked their announcements.
+            - feature_flags : :class:`civis.Response`
+                The feature flag settings for this user.
+            - roles : List[str]
+                The roles this user has, listed by slug.
+            - preferences : :class:`civis.Response`
+                This user's preferences.
+            - custom_branding : str
+                The branding of Platform for this user.
+            - primary_group_id : int
+                The ID of the primary group of this user.
+            - groups : List[:class:`civis.Response`]
+                An array of all the groups this user is in.
+
+                - id : int
+                    The ID of this group.
+                - name : str
+                    The name of this group.
+                - slug : str
+                    The slug of this group.
+                - organization_id : int
+                    The ID of the organization associated with this group.
+                - organization_name : str
+                    The name of the organization associated with this group.
+            - organization_name : str
+                The name of the organization the user belongs to.
+            - organization_slug : str
+                The slug of the organization the user belongs to.
+            - organization_default_theme_id : int
+                The ID of the organizations's default theme.
+            - created_at : str (date-time)
+                The date and time when the user was created.
+            - sign_in_count : int
+                The number of times the user has signed in.
+            - assuming_role : bool
+                Whether the user is assuming this role or not.
+            - role_assumer : :class:`civis.Response`
+                Details about the role assumer.
+            - assuming_admin : bool
+                Whether the user is assuming admin.
+            - assuming_admin_expiration : str (date-time)
+                When the user's admin role is set to expire.
+            - superadmin_mode_expiration : str (date-time)
+                The user is in superadmin mode when set to a DateTime. The user is not
+                in superadmin mode when set to null.
+            - disable_non_compliant_fedramp_features : bool
+                Whether to disable non-compliant fedramp features.
+            - persona_role : str
+                The high-level role representing the current user's main permissions.
+            - created_by_id : int
+                The ID of the user who created this user.
+            - last_updated_by_id : int
+                The ID of the user who last updated this user.
+        """
+        ...
+
     def list_me(
         self,
     ) -> ListResponse[_ResponseUsersListMe]:
         """Show info about the logged-in user
 
         API URL: ``GET /users/me``
+
+        .. warning::
+
+            The method name ``<client>.users.list_me`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.users.get_me`` instead for the same
+            functionality.
 
         Returns
         -------
@@ -61808,6 +62574,44 @@ class _Workflows:
         """
         ...
 
+    def get_git(
+        self,
+        id: int,
+    ) -> _ResponseWorkflowsGetGit:
+        """Get the git metadata attached to an item
+
+        API URL: ``GET /workflows/{id}/git``
+
+        Parameters
+        ----------
+        id : int
+            The ID of the item.
+
+        Returns
+        -------
+        :class:`civis.Response`
+            - git_ref : str
+                A git reference specifying an unambiguous version of the file. Can be a
+                branch name, tag or the full or shortened SHA of a commit.
+            - git_branch : str
+                The git branch that the file is on.
+            - git_path : str
+                The path of the file in the repository.
+            - git_repo : :class:`civis.Response`
+                - id : int
+                    The ID for this git repository.
+                - repo_url : str
+                    The URL for this git repository.
+                - created_at : str (time)
+                - updated_at : str (time)
+            - git_ref_type : str
+                Specifies if the file is versioned by branch or tag.
+            - pull_from_git : bool
+                Automatically pull latest commit from git. Only works for scripts and
+                workflows (assuming you have the feature enabled)
+        """
+        ...
+
     def list_git(
         self,
         id: int,
@@ -61815,6 +62619,13 @@ class _Workflows:
         """Get the git metadata attached to an item
 
         API URL: ``GET /workflows/{id}/git``
+
+        .. warning::
+
+            The method name ``<client>.workflows.list_git`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please update
+            your code to use ``<client>.workflows.get_git`` instead for the same
+            functionality.
 
         Parameters
         ----------
@@ -63355,9 +64166,47 @@ class _ResponseClustersListKubernetesInstanceConfigsUserStatistics(Response):
     running_memory_requested: int
     running_cpu_requested: int
 
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalGraphs(Response):
+    cpu_graph_url: str
+    mem_graph_url: str
+
 class _ResponseClustersListKubernetesInstanceConfigsHistoricalGraphs(Response):
     cpu_graph_url: str
     mem_graph_url: str
+
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetrics(Response):
+    instance_config_id: int
+    metric: str
+    timeframe: str
+    unit: str
+    metrics: _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetrics
+
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetrics(Response):
+    used: _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsUsed
+    requested: (
+        _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsRequested
+    )
+    capacity: (
+        _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsCapacity
+    )
+
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsUsed(
+    Response
+):
+    times: List[int]
+    values: List[float]
+
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsRequested(
+    Response
+):
+    times: List[int]
+    values: List[float]
+
+class _ResponseClustersGetKubernetesInstanceConfigsHistoricalMetricsMetricsCapacity(
+    Response
+):
+    times: List[int]
+    values: List[float]
 
 class _ResponseClustersListKubernetesInstanceConfigsHistoricalMetrics(Response):
     instance_config_id: int
@@ -64036,6 +64885,9 @@ class _ResponseDatabasesGetWhitelistIps(Response):
     is_active: bool
     created_at: str
     updated_at: str
+
+class _ResponseDatabasesGetAdvancedSettings(Response):
+    export_caching_enabled: bool
 
 class _ResponseDatabasesListAdvancedSettings(Response):
     export_caching_enabled: bool
@@ -67483,6 +68335,10 @@ class _ResponseGitReposGet(Response):
     created_at: str
     updated_at: str
 
+class _ResponseGitReposGetRefs(Response):
+    branches: List[str]
+    tags: List[str]
+
 class _ResponseGitReposListRefs(Response):
     branches: List[str]
     tags: List[str]
@@ -67782,6 +68638,23 @@ class _ResponseGroupsPutMembersMembers(Response):
     email: str
     primary_group_id: int
     active: bool
+
+class _ResponseGroupsGetChildGroups(Response):
+    manageable: List[_ResponseGroupsGetChildGroupsManageable]
+    writeable: List[_ResponseGroupsGetChildGroupsWriteable]
+    readable: List[_ResponseGroupsGetChildGroupsReadable]
+
+class _ResponseGroupsGetChildGroupsManageable(Response):
+    id: int
+    name: str
+
+class _ResponseGroupsGetChildGroupsWriteable(Response):
+    id: int
+    name: str
+
+class _ResponseGroupsGetChildGroupsReadable(Response):
+    id: int
+    name: str
 
 class _ResponseGroupsListChildGroups(Response):
     manageable: List[_ResponseGroupsListChildGroupsManageable]
@@ -71078,6 +71951,18 @@ class _ResponseModelsPutArchivePredictionsSchedule(Response):
     scheduled_runs_per_hour: int
     scheduled_days_of_month: List[int]
 
+class _ResponseModelsGetSchedules(Response):
+    id: int
+    schedule: _ResponseModelsGetSchedulesSchedule
+
+class _ResponseModelsGetSchedulesSchedule(Response):
+    scheduled: bool
+    scheduled_days: List[int]
+    scheduled_hours: List[int]
+    scheduled_minutes: List[int]
+    scheduled_runs_per_hour: int
+    scheduled_days_of_month: List[int]
+
 class _ResponseModelsListSchedules(Response):
     id: int
     schedule: _ResponseModelsListSchedulesSchedule
@@ -71353,6 +72238,10 @@ class _ResponseNotebooksPatchMostRecentDeployment(Response):
     created_at: str
     updated_at: str
     notebook_id: int
+
+class _ResponseNotebooksGetUpdateLinks(Response):
+    update_url: str
+    update_preview_url: str
 
 class _ResponseNotebooksListUpdateLinks(Response):
     update_url: str
@@ -71708,6 +72597,20 @@ class _ResponseNotebooksListDeploymentsLogs(Response):
     stream: str
     created_at: str
     source: str
+
+class _ResponseNotebooksGetGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseNotebooksGetGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseNotebooksGetGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
 
 class _ResponseNotebooksListGit(Response):
     git_ref: str
@@ -72276,6 +73179,19 @@ class _ResponsePredictionsGetScoredTablesScoreStats(Response):
     max_score: float
 
 class _ResponsePredictionsGetSchedule(Response):
+    scheduled: bool
+    scheduled_days: List[int]
+    scheduled_hours: List[int]
+    scheduled_minutes: List[int]
+    scheduled_runs_per_hour: int
+    scheduled_days_of_month: List[int]
+
+class _ResponsePredictionsGetSchedules(Response):
+    id: int
+    schedule: _ResponsePredictionsGetSchedulesSchedule
+    score_on_model_build: bool
+
+class _ResponsePredictionsGetSchedulesSchedule(Response):
     scheduled: bool
     scheduled_days: List[int]
     scheduled_hours: List[int]
@@ -74188,6 +75104,20 @@ class _ResponseReportsPostLastRun(Response):
     started_at: str
     finished_at: str
     error: str
+
+class _ResponseReportsGetGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseReportsGetGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseReportsGetGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
 
 class _ResponseReportsListGit(Response):
     git_ref: str
@@ -79049,6 +79979,20 @@ class _ResponseScriptsPostCustomRunsOutputs(Response):
     link: str
     value: object
 
+class _ResponseScriptsGetSqlGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseScriptsGetSqlGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseScriptsGetSqlGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
+
 class _ResponseScriptsListSqlGit(Response):
     git_ref: str
     git_branch: str
@@ -79120,6 +80064,20 @@ class _ResponseScriptsPostSqlGitCheckout(Response):
     type: str
     size: int
     file_hash: str
+
+class _ResponseScriptsGetJavascriptGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseScriptsGetJavascriptGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseScriptsGetJavascriptGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
 
 class _ResponseScriptsListJavascriptGit(Response):
     git_ref: str
@@ -79193,6 +80151,20 @@ class _ResponseScriptsPostJavascriptGitCheckout(Response):
     size: int
     file_hash: str
 
+class _ResponseScriptsGetPython3Git(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseScriptsGetPython3GitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseScriptsGetPython3GitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
+
 class _ResponseScriptsListPython3Git(Response):
     git_ref: str
     git_branch: str
@@ -79264,6 +80236,20 @@ class _ResponseScriptsPostPython3GitCheckout(Response):
     type: str
     size: int
     file_hash: str
+
+class _ResponseScriptsGetRGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseScriptsGetRGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseScriptsGetRGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
 
 class _ResponseScriptsListRGit(Response):
     git_ref: str
@@ -84536,6 +85522,10 @@ class _ResponseUsageGetLlm(Response):
     output_tokens: int
     model_id: str
 
+class _ResponseUsageGetLlmOrganizationSummary(Response):
+    credits: float
+    organization_id: int
+
 class _ResponseUsageListLlmOrganizationSummary(Response):
     credits: float
     organization_id: int
@@ -84633,6 +85623,41 @@ class _ResponseUsersPost(Response):
     account_status: str
 
 class _ResponseUsersPostGroups(Response):
+    id: int
+    name: str
+    slug: str
+    organization_id: int
+    organization_name: str
+
+class _ResponseUsersGetMe(Response):
+    id: int
+    name: str
+    email: str
+    username: str
+    initials: str
+    last_checked_announcements: str
+    feature_flags: dict
+    roles: List[str]
+    preferences: dict
+    custom_branding: str
+    primary_group_id: int
+    groups: List[_ResponseUsersGetMeGroups]
+    organization_name: str
+    organization_slug: str
+    organization_default_theme_id: int
+    created_at: str
+    sign_in_count: int
+    assuming_role: bool
+    role_assumer: dict
+    assuming_admin: bool
+    assuming_admin_expiration: str
+    superadmin_mode_expiration: str
+    disable_non_compliant_fedramp_features: bool
+    persona_role: str
+    created_by_id: int
+    last_updated_by_id: int
+
+class _ResponseUsersGetMeGroups(Response):
     id: int
     name: str
     slug: str
@@ -85461,6 +86486,20 @@ class _ResponseWorkflowsListProjectsUsers(Response):
     username: str
     initials: str
     online: bool
+
+class _ResponseWorkflowsGetGit(Response):
+    git_ref: str
+    git_branch: str
+    git_path: str
+    git_repo: _ResponseWorkflowsGetGitGitRepo
+    git_ref_type: str
+    pull_from_git: bool
+
+class _ResponseWorkflowsGetGitGitRepo(Response):
+    id: int
+    repo_url: str
+    created_at: str
+    updated_at: str
 
 class _ResponseWorkflowsListGit(Response):
     git_ref: str

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -7,6 +7,7 @@ from typing import List
 import tenacity
 
 from civis.response import Response, ListResponse, PaginatedResponse
+from civis._deprecation import deprecated
 
 class _Admin:
     def list_organizations(
@@ -1672,6 +1673,16 @@ class _Clusters:
         """
         ...
 
+    @deprecated(
+        """
+        The method name
+        <client>.clusters.list_kubernetes_instance_configs_historical_graphs is
+        deprecated and will be removed at civis-python v3.0.0 (no release
+        timeline yet). Please switch to
+        <client>.clusters.get_kubernetes_instance_configs_historical_graphs for
+        the same method.
+        """
+    )
     def list_kubernetes_instance_configs_historical_graphs(
         self,
         instance_config_id: int,
@@ -1684,11 +1695,11 @@ class _Clusters:
 
         .. warning::
             The method name
-            ``<client>.clusters.list_kubernetes_instance_configs_historical_graphs``
-            is deprecated and will be removed at civis-python v3.0.0 (no release
-            timeline yet). Please update your code to use
-            ``<client>.clusters.get_kubernetes_instance_configs_historical_graphs``
-            instead for the same functionality.
+            ``<client>.clusters.list_kubernetes_instance_configs_historical_graphs`` is
+            deprecated and will be removed at civis-python v3.0.0 (no release timeline
+            yet). Please switch to
+            ``<client>.clusters.get_kubernetes_instance_configs_historical_graphs`` for
+            the same method.
 
         Parameters
         ----------
@@ -1757,6 +1768,16 @@ class _Clusters:
         """
         ...
 
+    @deprecated(
+        """
+        The method name
+        <client>.clusters.list_kubernetes_instance_configs_historical_metrics is
+        deprecated and will be removed at civis-python v3.0.0 (no release
+        timeline yet). Please switch to
+        <client>.clusters.get_kubernetes_instance_configs_historical_metrics for
+        the same method.
+        """
+    )
     def list_kubernetes_instance_configs_historical_metrics(
         self,
         instance_config_id: int,
@@ -1770,11 +1791,11 @@ class _Clusters:
 
         .. warning::
             The method name
-            ``<client>.clusters.list_kubernetes_instance_configs_historical_metrics``
-            is deprecated and will be removed at civis-python v3.0.0 (no release
-            timeline yet). Please update your code to use
-            ``<client>.clusters.get_kubernetes_instance_configs_historical_metrics``
-            instead for the same functionality.
+            ``<client>.clusters.list_kubernetes_instance_configs_historical_metrics`` is
+            deprecated and will be removed at civis-python v3.0.0 (no release timeline
+            yet). Please switch to
+            ``<client>.clusters.get_kubernetes_instance_configs_historical_metrics`` for
+            the same method.
 
         Parameters
         ----------
@@ -3634,6 +3655,13 @@ class _Databases:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.databases.list_advanced_settings is deprecated and will
+        be removed at civis-python v3.0.0 (no release timeline yet). Please
+        switch to <client>.databases.get_advanced_settings for the same method.
+        """
+    )
     def list_advanced_settings(
         self,
         id: int,
@@ -3643,11 +3671,9 @@ class _Databases:
         API URL: ``GET /databases/{id}/advanced-settings``
 
         .. warning::
-            The method name ``<client>.databases.list_advanced_settings`` is
-            deprecated and will be removed at civis-python v3.0.0 (no release timeline
-            yet). Please update your code to use
-            ``<client>.databases.get_advanced_settings`` instead for the same
-            functionality.
+            The method name ``<client>.databases.list_advanced_settings`` is deprecated
+            and will be removed at civis-python v3.0.0 (no release timeline yet). Please
+            switch to ``<client>.databases.get_advanced_settings`` for the same method.
 
         Parameters
         ----------
@@ -3766,6 +3792,13 @@ class _Endpoints:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.endpoints.list is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.endpoints.get for the same method.
+        """
+    )
     def list(
         self,
     ) -> Response:
@@ -3775,9 +3808,8 @@ class _Endpoints:
 
         .. warning::
             The method name ``<client>.endpoints.list`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.endpoints.get`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.endpoints.get`` for the same method.
 
         Returns
         -------
@@ -13640,6 +13672,13 @@ class _Git_Repos:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.git_repos.list_refs is deprecated and will be removed
+        at civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.git_repos.get_refs for the same method.
+        """
+    )
     def list_refs(
         self,
         id: int,
@@ -13650,9 +13689,8 @@ class _Git_Repos:
 
         .. warning::
             The method name ``<client>.git_repos.list_refs`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.git_repos.get_refs`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.git_repos.get_refs`` for the same method.
 
         Parameters
         ----------
@@ -14487,6 +14525,13 @@ class _Groups:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.groups.list_child_groups is deprecated and will be
+        removed at civis-python v3.0.0 (no release timeline yet). Please switch
+        to <client>.groups.get_child_groups for the same method.
+        """
+    )
     def list_child_groups(
         self,
         id: int,
@@ -14496,10 +14541,9 @@ class _Groups:
         API URL: ``GET /groups/{id}/child_groups``
 
         .. warning::
-            The method name ``<client>.groups.list_child_groups`` is deprecated and
-            will be removed at civis-python v3.0.0 (no release timeline yet). Please
-            update your code to use ``<client>.groups.get_child_groups`` instead for
-            the same functionality.
+            The method name ``<client>.groups.list_child_groups`` is deprecated and will
+            be removed at civis-python v3.0.0 (no release timeline yet). Please switch
+            to ``<client>.groups.get_child_groups`` for the same method.
 
         Parameters
         ----------
@@ -23990,6 +24034,13 @@ class _Models:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.models.list_schedules is deprecated and will be removed
+        at civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.models.get_schedules for the same method.
+        """
+    )
     def list_schedules(
         self,
         id: int,
@@ -23999,10 +24050,9 @@ class _Models:
         API URL: ``GET /models/{id}/schedules``
 
         .. warning::
-            The method name ``<client>.models.list_schedules`` is deprecated and will
-            be removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.models.get_schedules`` instead for the same
-            functionality.
+            The method name ``<client>.models.list_schedules`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.models.get_schedules`` for the same method.
 
         Parameters
         ----------
@@ -24833,6 +24883,13 @@ class _Notebooks:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.notebooks.list_update_links is deprecated and will be
+        removed at civis-python v3.0.0 (no release timeline yet). Please switch
+        to <client>.notebooks.get_update_links for the same method.
+        """
+    )
     def list_update_links(
         self,
         id: int,
@@ -24844,8 +24901,7 @@ class _Notebooks:
         .. warning::
             The method name ``<client>.notebooks.list_update_links`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
-            update your code to use ``<client>.notebooks.get_update_links`` instead
-            for the same functionality.
+            switch to ``<client>.notebooks.get_update_links`` for the same method.
 
         Parameters
         ----------
@@ -25811,6 +25867,13 @@ class _Notebooks:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.notebooks.list_git is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.notebooks.get_git for the same method.
+        """
+    )
     def list_git(
         self,
         id: int,
@@ -25821,9 +25884,8 @@ class _Notebooks:
 
         .. warning::
             The method name ``<client>.notebooks.list_git`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.notebooks.get_git`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.notebooks.get_git`` for the same method.
 
         Parameters
         ----------
@@ -26094,6 +26156,13 @@ class _Notifications:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.notifications.list is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.notifications.get for the same method.
+        """
+    )
     def list(
         self,
         *,
@@ -26107,9 +26176,8 @@ class _Notifications:
 
         .. warning::
             The method name ``<client>.notifications.list`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.notifications.get`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.notifications.get`` for the same method.
 
         Parameters
         ----------
@@ -27514,6 +27582,13 @@ class _Predictions:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.predictions.list_schedules is deprecated and will be
+        removed at civis-python v3.0.0 (no release timeline yet). Please switch
+        to <client>.predictions.get_schedules for the same method.
+        """
+    )
     def list_schedules(
         self,
         id: int,
@@ -27525,8 +27600,7 @@ class _Predictions:
         .. warning::
             The method name ``<client>.predictions.list_schedules`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
-            update your code to use ``<client>.predictions.get_schedules`` instead for
-            the same functionality.
+            switch to ``<client>.predictions.get_schedules`` for the same method.
 
         Parameters
         ----------
@@ -30817,6 +30891,13 @@ class _Reports:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.reports.list_git is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.reports.get_git for the same method.
+        """
+    )
     def list_git(
         self,
         id: int,
@@ -30827,9 +30908,8 @@ class _Reports:
 
         .. warning::
             The method name ``<client>.reports.list_git`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.reports.get_git`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.reports.get_git`` for the same method.
 
         Parameters
         ----------
@@ -45411,6 +45491,13 @@ class _Scripts:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.scripts.list_sql_git is deprecated and will be removed
+        at civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.scripts.get_sql_git for the same method.
+        """
+    )
     def list_sql_git(
         self,
         id: int,
@@ -45420,10 +45507,9 @@ class _Scripts:
         API URL: ``GET /scripts/sql/{id}/git``
 
         .. warning::
-            The method name ``<client>.scripts.list_sql_git`` is deprecated and will
-            be removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.scripts.get_sql_git`` instead for the same
-            functionality.
+            The method name ``<client>.scripts.list_sql_git`` is deprecated and will be
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.scripts.get_sql_git`` for the same method.
 
         Parameters
         ----------
@@ -45758,6 +45844,13 @@ class _Scripts:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.scripts.list_javascript_git is deprecated and will be
+        removed at civis-python v3.0.0 (no release timeline yet). Please switch
+        to <client>.scripts.get_javascript_git for the same method.
+        """
+    )
     def list_javascript_git(
         self,
         id: int,
@@ -45769,8 +45862,7 @@ class _Scripts:
         .. warning::
             The method name ``<client>.scripts.list_javascript_git`` is deprecated and
             will be removed at civis-python v3.0.0 (no release timeline yet). Please
-            update your code to use ``<client>.scripts.get_javascript_git`` instead
-            for the same functionality.
+            switch to ``<client>.scripts.get_javascript_git`` for the same method.
 
         Parameters
         ----------
@@ -46105,6 +46197,13 @@ class _Scripts:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.scripts.list_python3_git is deprecated and will be
+        removed at civis-python v3.0.0 (no release timeline yet). Please switch
+        to <client>.scripts.get_python3_git for the same method.
+        """
+    )
     def list_python3_git(
         self,
         id: int,
@@ -46114,10 +46213,9 @@ class _Scripts:
         API URL: ``GET /scripts/python3/{id}/git``
 
         .. warning::
-            The method name ``<client>.scripts.list_python3_git`` is deprecated and
-            will be removed at civis-python v3.0.0 (no release timeline yet). Please
-            update your code to use ``<client>.scripts.get_python3_git`` instead for
-            the same functionality.
+            The method name ``<client>.scripts.list_python3_git`` is deprecated and will
+            be removed at civis-python v3.0.0 (no release timeline yet). Please switch
+            to ``<client>.scripts.get_python3_git`` for the same method.
 
         Parameters
         ----------
@@ -46452,6 +46550,13 @@ class _Scripts:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.scripts.list_r_git is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.scripts.get_r_git for the same method.
+        """
+    )
     def list_r_git(
         self,
         id: int,
@@ -46462,9 +46567,8 @@ class _Scripts:
 
         .. warning::
             The method name ``<client>.scripts.list_r_git`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.scripts.get_r_git`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.scripts.get_r_git`` for the same method.
 
         Parameters
         ----------
@@ -56633,6 +56737,12 @@ class _Table_Tags:
         ...
 
 class _Tables:
+    @deprecated(
+        """
+        Warning: The tables/:source_table_id/enhancements/geocodings endpoint is
+        deprecated and will be removed after January 1, 2021.
+        """
+    )
     def post_enhancements_geocodings(
         self,
         source_table_id: int,
@@ -56667,6 +56777,12 @@ class _Tables:
         """
         ...
 
+    @deprecated(
+        """
+        Warning: The tables/:source_table_id/enhancements/cass-ncoa endpoint is
+        deprecated and will be removed after January 1, 2021.
+        """
+    )
     def post_enhancements_cass_ncoa(
         self,
         source_table_id: int,
@@ -56733,6 +56849,12 @@ class _Tables:
         """
         ...
 
+    @deprecated(
+        """
+        Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint is
+        deprecated and will be removed after January 1, 2021.
+        """
+    )
     def get_enhancements_geocodings(
         self,
         id: int,
@@ -56743,8 +56865,8 @@ class _Tables:
         API URL: ``GET /tables/{source_table_id}/enhancements/geocodings/{id}``
 
         .. warning::
-            Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint
-            is deprecated and will be removed after January 1, 2021.
+            Warning: The tables/:source_table_id/enhancements/geocodings/:id endpoint is
+            deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56770,6 +56892,12 @@ class _Tables:
         """
         ...
 
+    @deprecated(
+        """
+        Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint is
+        deprecated and will be removed after January 1, 2021.
+        """
+    )
     def get_enhancements_cass_ncoa(
         self,
         id: int,
@@ -56780,8 +56908,8 @@ class _Tables:
         API URL: ``GET /tables/{source_table_id}/enhancements/cass-ncoa/{id}``
 
         .. warning::
-            Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint
-            is deprecated and will be removed after January 1, 2021.
+            Warning: The tables/:source_table_id/enhancements/cass-ncoa/:id endpoint is
+            deprecated and will be removed after January 1, 2021.
 
         Parameters
         ----------
@@ -56858,6 +56986,12 @@ class _Tables:
         """
         ...
 
+    @deprecated(
+        """
+        Warning: The tables/:id/refresh endpoint is deprecated. Please use tables/scan
+        from now on.
+        """
+    )
     def post_refresh(
         self,
         id: int,
@@ -59446,6 +59580,14 @@ class _Usage:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.usage.list_llm_organization_summary is deprecated and
+        will be removed at civis-python v3.0.0 (no release timeline yet). Please
+        switch to <client>.usage.get_llm_organization_summary for the same
+        method.
+        """
+    )
     def list_llm_organization_summary(
         self,
         org_id: int,
@@ -59460,9 +59602,8 @@ class _Usage:
         .. warning::
             The method name ``<client>.usage.list_llm_organization_summary`` is
             deprecated and will be removed at civis-python v3.0.0 (no release timeline
-            yet). Please update your code to use
-            ``<client>.usage.get_llm_organization_summary`` instead for the same
-            functionality.
+            yet). Please switch to ``<client>.usage.get_llm_organization_summary`` for
+            the same method.
 
         Parameters
         ----------
@@ -59957,6 +60098,13 @@ class _Users:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.users.list_me is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.users.get_me for the same method.
+        """
+    )
     def list_me(
         self,
     ) -> _ResponseUsersListMe:
@@ -59965,10 +60113,9 @@ class _Users:
         API URL: ``GET /users/me``
 
         .. warning::
-            The method name ``<client>.users.list_me`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.users.get_me`` instead for the same
-            functionality.
+            The method name ``<client>.users.list_me`` is deprecated and will be removed
+            at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.users.get_me`` for the same method.
 
         Returns
         -------
@@ -62589,6 +62736,13 @@ class _Workflows:
         """
         ...
 
+    @deprecated(
+        """
+        The method name <client>.workflows.list_git is deprecated and will be removed at
+        civis-python v3.0.0 (no release timeline yet). Please switch to
+        <client>.workflows.get_git for the same method.
+        """
+    )
     def list_git(
         self,
         id: int,
@@ -62599,9 +62753,8 @@ class _Workflows:
 
         .. warning::
             The method name ``<client>.workflows.list_git`` is deprecated and will be
-            removed at civis-python v3.0.0 (no release timeline yet). Please update
-            your code to use ``<client>.workflows.get_git`` instead for the same
-            functionality.
+            removed at civis-python v3.0.0 (no release timeline yet). Please switch to
+            ``<client>.workflows.get_git`` for the same method.
 
         Parameters
         ----------

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -1677,7 +1677,7 @@ class _Clusters:
         instance_config_id: int,
         *,
         timeframe: str | None = ...,
-    ) -> ListResponse[_ResponseClustersListKubernetesInstanceConfigsHistoricalGraphs]:
+    ) -> _ResponseClustersListKubernetesInstanceConfigsHistoricalGraphs:
         """Get graphs of historical resource usage in an Instance Config
 
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_graphs``
@@ -1763,7 +1763,7 @@ class _Clusters:
         *,
         timeframe: str | None = ...,
         metric: str | None = ...,
-    ) -> ListResponse[_ResponseClustersListKubernetesInstanceConfigsHistoricalMetrics]:
+    ) -> _ResponseClustersListKubernetesInstanceConfigsHistoricalMetrics:
         """Get graphs of historical resource usage in an Instance Config
 
         API URL: ``GET /clusters/kubernetes/instance_configs/{instance_config_id}/historical_metrics``
@@ -3637,7 +3637,7 @@ class _Databases:
     def list_advanced_settings(
         self,
         id: int,
-    ) -> ListResponse[_ResponseDatabasesListAdvancedSettings]:
+    ) -> _ResponseDatabasesListAdvancedSettings:
         """Get the advanced settings for this database
 
         API URL: ``GET /databases/{id}/advanced-settings``
@@ -3768,7 +3768,7 @@ class _Endpoints:
 
     def list(
         self,
-    ) -> ListResponse[Response]:
+    ) -> Response:
         """List API endpoints
 
         API URL: ``GET /endpoints``
@@ -13643,7 +13643,7 @@ class _Git_Repos:
     def list_refs(
         self,
         id: int,
-    ) -> ListResponse[_ResponseGitReposListRefs]:
+    ) -> _ResponseGitReposListRefs:
         """Get all branches and tags of a bookmarked git repository
 
         API URL: ``GET /git_repos/{id}/refs``
@@ -14490,7 +14490,7 @@ class _Groups:
     def list_child_groups(
         self,
         id: int,
-    ) -> ListResponse[_ResponseGroupsListChildGroups]:
+    ) -> _ResponseGroupsListChildGroups:
         """Get child groups of this group
 
         API URL: ``GET /groups/{id}/child_groups``
@@ -23993,7 +23993,7 @@ class _Models:
     def list_schedules(
         self,
         id: int,
-    ) -> ListResponse[_ResponseModelsListSchedules]:
+    ) -> _ResponseModelsListSchedules:
         """Show the model build schedule
 
         API URL: ``GET /models/{id}/schedules``
@@ -24836,7 +24836,7 @@ class _Notebooks:
     def list_update_links(
         self,
         id: int,
-    ) -> ListResponse[_ResponseNotebooksListUpdateLinks]:
+    ) -> _ResponseNotebooksListUpdateLinks:
         """Get URLs to update notebook
 
         API URL: ``GET /notebooks/{id}/update-links``
@@ -25814,7 +25814,7 @@ class _Notebooks:
     def list_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseNotebooksListGit]:
+    ) -> _ResponseNotebooksListGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /notebooks/{id}/git``
@@ -26100,7 +26100,7 @@ class _Notifications:
         last_event_id: str | None = ...,
         r: str | None = ...,
         mock: str | None = ...,
-    ) -> ListResponse[Response]:
+    ) -> Response:
         """Receive a stream of notifications as they come in
 
         API URL: ``GET /notifications``
@@ -27517,7 +27517,7 @@ class _Predictions:
     def list_schedules(
         self,
         id: int,
-    ) -> ListResponse[_ResponsePredictionsListSchedules]:
+    ) -> _ResponsePredictionsListSchedules:
         """Show the prediction schedule
 
         API URL: ``GET /predictions/{id}/schedules``
@@ -30820,7 +30820,7 @@ class _Reports:
     def list_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseReportsListGit]:
+    ) -> _ResponseReportsListGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /reports/{id}/git``
@@ -45414,7 +45414,7 @@ class _Scripts:
     def list_sql_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseScriptsListSqlGit]:
+    ) -> _ResponseScriptsListSqlGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/sql/{id}/git``
@@ -45761,7 +45761,7 @@ class _Scripts:
     def list_javascript_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseScriptsListJavascriptGit]:
+    ) -> _ResponseScriptsListJavascriptGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/javascript/{id}/git``
@@ -46108,7 +46108,7 @@ class _Scripts:
     def list_python3_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseScriptsListPython3Git]:
+    ) -> _ResponseScriptsListPython3Git:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/python3/{id}/git``
@@ -46455,7 +46455,7 @@ class _Scripts:
     def list_r_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseScriptsListRGit]:
+    ) -> _ResponseScriptsListRGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /scripts/r/{id}/git``
@@ -59452,7 +59452,7 @@ class _Usage:
         *,
         start_date: str | None = ...,
         end_date: str | None = ...,
-    ) -> ListResponse[_ResponseUsageListLlmOrganizationSummary]:
+    ) -> _ResponseUsageListLlmOrganizationSummary:
         """Get summarized usage statistics for a given organization
 
         API URL: ``GET /usage/llm/organization/{org_id}/summary``
@@ -59959,7 +59959,7 @@ class _Users:
 
     def list_me(
         self,
-    ) -> ListResponse[_ResponseUsersListMe]:
+    ) -> _ResponseUsersListMe:
         """Show info about the logged-in user
 
         API URL: ``GET /users/me``
@@ -62592,7 +62592,7 @@ class _Workflows:
     def list_git(
         self,
         id: int,
-    ) -> ListResponse[_ResponseWorkflowsListGit]:
+    ) -> _ResponseWorkflowsListGit:
         """Get the git metadata attached to an item
 
         API URL: ``GET /workflows/{id}/git``

--- a/src/civis/client.pyi
+++ b/src/civis/client.pyi
@@ -1710,7 +1710,7 @@ class _Clusters:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - cpu_graph_url : str
                 URL for the graph of historical CPU usage in this instance config.
             - mem_graph_url : str
@@ -1808,7 +1808,7 @@ class _Clusters:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - instance_config_id : int
                 The ID of this instance config.
             - metric : str
@@ -3682,7 +3682,7 @@ class _Databases:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - export_caching_enabled : bool
                 Whether or not caching is enabled for export jobs run on this database
                 server.
@@ -13699,7 +13699,7 @@ class _Git_Repos:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - branches : List[str]
                 List of branch names of this git repository.
             - tags : List[str]
@@ -14552,7 +14552,7 @@ class _Groups:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - manageable : List[:class:`civis.Response`]
                 - id : int
                 - name : str
@@ -24061,7 +24061,7 @@ class _Models:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - id : int
                 The ID of the model associated with this schedule.
             - schedule : :class:`civis.Response`
@@ -24909,7 +24909,7 @@ class _Notebooks:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - update_url : str
                 Time-limited URL to PUT new contents of the .ipynb file for this
                 notebook.
@@ -25894,7 +25894,7 @@ class _Notebooks:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -27609,7 +27609,7 @@ class _Predictions:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - id : int
                 ID of the prediction associated with this schedule.
             - schedule : :class:`civis.Response`
@@ -30918,7 +30918,7 @@ class _Reports:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -45518,7 +45518,7 @@ class _Scripts:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -45871,7 +45871,7 @@ class _Scripts:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -46224,7 +46224,7 @@ class _Scripts:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -46577,7 +46577,7 @@ class _Scripts:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.
@@ -59620,7 +59620,7 @@ class _Usage:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - credits : float (float)
                 The number of credits used.
             - organization_id : int
@@ -60119,7 +60119,7 @@ class _Users:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - id : int
                 The ID of this user.
             - name : str
@@ -62763,7 +62763,7 @@ class _Workflows:
 
         Returns
         -------
-        :class:`civis.ListResponse`
+        :class:`civis.Response`
             - git_ref : str
                 A git reference specifying an unambiguous version of the file. Can be a
                 branch name, tag or the full or shortened SHA of a commit.

--- a/src/civis/ml/_helper.py
+++ b/src/civis/ml/_helper.py
@@ -61,7 +61,7 @@ def list_models(job_type="train", author=SENTINEL, client=None, **kwargs):
     template_id_str = ", ".join(str(tmp) for tmp in set(template_id_list))
 
     if author is SENTINEL:
-        author = client.users.list_me().id
+        author = client.users.get_me().id
 
     # default to showing most recent models first
     kwargs.setdefault("order_dir", "desc")

--- a/src/civis/resources/_api_spec.py
+++ b/src/civis/resources/_api_spec.py
@@ -18,8 +18,12 @@ def download_latest_api_spec(path):
         else:
             raise
     fut = civis.utils.run_job(job.id, client=client, polling_interval=5)
+    print(
+        "created custom script run https://platform.civisanalytics.com/"
+        f"spa/#/scripts/custom/{fut.job_id}?runId={fut.run_id}"
+    )
     fut.result()
-    print(f"custom script {fut.job_id} run {fut.run_id} has succeeded")
+    print("custom script run has succeeded")
     outputs = client.scripts.list_custom_runs_outputs(fut.job_id, fut.run_id)
     file_id = civis.find_one(outputs, name="civis_api_spec.json").object_id
     with open(path, "wb") as f:

--- a/src/civis/resources/_client_pyi.py
+++ b/src/civis/resources/_client_pyi.py
@@ -104,6 +104,9 @@ from civis._deprecation import deprecated
                             asterisk_added = True
                         method_def += f"        {param_name}: {annotation} = ...,\n"
 
+                # warnings.deprecated / typing_extensions.deprecated adds
+                # the __deprecated__ attribute to a deprecated method.
+                # See https://peps.python.org/pep-0702/ for __deprecated__.
                 if hasattr(method, "__deprecated__"):
                     msg = textwrap.fill(
                         method.__deprecated__.replace("`", ""),

--- a/src/civis/resources/_client_pyi.py
+++ b/src/civis/resources/_client_pyi.py
@@ -1,21 +1,16 @@
 import inspect
 import os
-import re
 import textwrap
 import typing
 
 from civis.resources import generate_classes_maybe_cached
 from civis.response import Response
+from civis.resources._resources import REGEX_DEP_WARN_LEGACY_LIST
 
 
 CLIENT_PYI_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
     "client.pyi",
-)
-
-_REGEX_DOCSTRING_LEGACY_LIST_METHOD_NAME = re.compile(
-    r"The method name.*?is\s+deprecated.*?Please\s+switch\s+to.*?",
-    re.DOTALL,
 )
 
 
@@ -46,7 +41,7 @@ def _extract_nested_response_classes(response_classes, return_type):
 
 def _is_using_legacy_method_name(method_name, method):
     is_list_method = method_name.startswith("list")
-    is_deprecated = _REGEX_DOCSTRING_LEGACY_LIST_METHOD_NAME.search(method.__doc__)
+    is_deprecated = REGEX_DEP_WARN_LEGACY_LIST.search(method.__doc__)
     return is_list_method and is_deprecated
 
 

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -576,7 +576,6 @@ def parse_param_body(parameter):
     return arguments
 
 
-# TODO: Write tests for this function.
 def get_response_is_array(path, operation) -> bool:
     schema = operation["responses"].get("200", {}).get("schema", {})
     if schema.get("type") == "array":
@@ -618,7 +617,9 @@ def parse_method_name(verb, path, operation=None, use_legacy_names=True):
         elif prev_elem and bracketed(prev_elem):
             name_elems.append(prev_elem.strip("{|}"))
     if use_legacy_names:
-        # When releasing civis-python v3.0.0, this block can be removed.
+        # When releasing civis-python v3.0.0, this `if` block can be removed,
+        # leaving the `else` block as the only code path.
+
         final_elem = path_elems[-1] if path_elems else ""
         verb = "list" if verb == "get" and (not bracketed(final_elem)) else verb
     else:
@@ -684,6 +685,9 @@ def parse_path(path, operations, api_version):
         # If the method name starts with "list" and the response is not an array,
         # then this method name is a legacy name and is deprecated.
         if name.startswith("list") and not get_response_is_array(path, op):
+            # When releasing civis-python v3.0.0, this `if` block can be removed,
+            # leaving the `else` block as the only code path.
+
             name_preferred, method_preferred = parse_method(
                 verb, op, path, use_legacy_names=False
             )

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -175,13 +175,13 @@ def deprecated_notice(deprecation_warning):
     """Return a doc string element for the deprecation notice. The
     doc string can be an empty string if the warning is None
     """
-    if deprecation_warning is None:
+    if not deprecation_warning:
         return ""
 
     msg = textwrap.fill(
         deprecation_warning, width=78, initial_indent=" " * 4, subsequent_indent=" " * 4
     )
-    return f".. warning::\n\n{msg}"
+    return f".. warning::\n{msg}"
 
 
 def doc_from_responses(responses, is_iterable, is_list):

--- a/src/civis/resources/_resources.py
+++ b/src/civis/resources/_resources.py
@@ -605,7 +605,7 @@ def parse_method_name(verb, path, operation=None, use_legacy_names=True):
     get_containers
     >>> parse_method_name("get", "url.com/containers/{id}/runs/{run_id}")
     get_containers_runs
-    >>> parse_method_name("post", "containers/{id}/runs/{run_id}")
+    >>> parse_method_name("post", "/containers/{id}/runs/{run_id}")
     post_containers_runs
     """
     path_elems = path.split("/")[1:]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,6 +39,7 @@ def test_feature_flags_memoized(mock_spec):
             client.feature_flags
             assert client.users.get_me.call_count == 1
 
+
 def test_get_table_id():
     client = APIClient(local_api_spec=API_SPEC, api_key="none")
     client.get_database_id = mock.Mock(return_value=123)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ with open(API_SPEC_PATH) as f:
 
 
 class FakeUsersEndpoint:
-    def list_me(self):
+    def get_me(self):
         return {"feature_flags": {"foo": True, "bar": True, "baz": False}}
 
 
@@ -33,12 +33,11 @@ def test_feature_flags_memoized(mock_spec):
     client = APIClient()
     setattr(client, "users", FakeUsersEndpoint())
     with warnings.catch_warnings():
-        with mock.patch.object(client.users, "list_me", wraps=client.users.list_me):
+        with mock.patch.object(client.users, "get_me", wraps=client.users.get_me):
             warnings.simplefilter("ignore")
             client.feature_flags
             client.feature_flags
-            assert client.users.list_me.call_count == 1
-
+            assert client.users.get_me.call_count == 1
 
 def test_get_table_id():
     client = APIClient(local_api_spec=API_SPEC, api_key="none")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -56,7 +56,7 @@ def test_create_method_iterator_kwarg():
         "get",
         "mock_name",
         "/objects",
-        "deprecation",
+        None,  # no deprecation
         "param_doc",
         "resp_doc",
         "return_annotation",
@@ -65,7 +65,7 @@ def test_create_method_iterator_kwarg():
 
     method(mock_endpoint, iterator=True)
     mock_endpoint._call_api.assert_called_once_with(
-        "get", "/objects", {}, {}, "deprecation", iterator=True
+        "get", "/objects", {}, {}, iterator=True
     )
 
 
@@ -79,7 +79,7 @@ def test_create_method_no_iterator_kwarg():
         "get",
         "mock_name",
         "/objects",
-        "deprecation",
+        None,  # no deprecation
         "param_doc",
         "resp_doc",
         "return_annotation",
@@ -99,7 +99,7 @@ def test_create_method_no_iterator_kwarg():
         "get",
         "mock_name",
         "/objects",
-        "deprecation",
+        None,  # no deprecation
         "param_doc",
         "resp_doc",
         "return_annotation",
@@ -591,7 +591,7 @@ def _create_mock_endpoint():
         "get",
         "mock_name",
         "/objects",
-        "deprecation",
+        None,  # no deprecation
         "param_doc",
         "resp_doc",
         "return_annotation",
@@ -606,7 +606,7 @@ def test_create_method_unexpected_kwargs():
     # Method works without unexpected kwarg
     method(mock_endpoint, foo=0, bar=0)
     mock_endpoint._call_api.assert_called_once_with(
-        "get", "/objects", {"foo": 0, "bar": 0}, {}, "deprecation", iterator=False
+        "get", "/objects", {"foo": 0, "bar": 0}, {}, iterator=False
     )
 
     # Method raises TypeError with unexpected kwarg
@@ -651,7 +651,7 @@ def test_create_method_deprecation_warning():
         "get",
         "mock_name",
         "/objects",
-        "deprecation",
+        "custom deprecation warning",
         "param_doc",
         "resp_doc",
         "return_annotation",
@@ -659,7 +659,7 @@ def test_create_method_deprecation_warning():
     mock_endpoint = Endpoint({"api_key": "abc"}, client=create_client_mock())
     mock_endpoint._make_request = mock.Mock()
 
-    with pytest.warns(FutureWarning, match="deprecation"):
+    with pytest.warns(FutureWarning, match="custom deprecation warning"):
         method(mock_endpoint, foo=0)
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -446,7 +446,7 @@ def test_parse_params():
         "description": "nah!",
         "type": "integer",
     }
-    x, y = _resources.parse_params([param, param2], "summary!", "get", "objects")
+    x, y = _resources.parse_params([param, param2], "summary!", "get", "objects", "no!")
     expect_x = [
         {
             "in": "query",
@@ -467,6 +467,7 @@ def test_parse_params():
     expect_y = (
         "summary!\n\n"
         "API URL: ``GET /objects``\n\n"
+        ".. warning::\n    no!\n\n"
         "Parameters\n"
         "----------\n"
         "b : int\n"


### PR DESCRIPTION
Some of the `list*` methods from various Civis API endpoints should have been named `get*`, because they return a singleton `civis.Response` object, as opposed to an array of such objects. These `list*` methods are now deprecated. The corresponding equivalent `get*` methods are added and should be preferred. The full list of these methods are in the new changelog entry.

For most users, the impact is expected to be minimal. The vast majority of the `list*` methods in question are not commonly used, with the notable exception of `client.users.list_me`.

After this pull request is merged, I'll make a new civis-python release for v2.8.0.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
