### PR TITLE
[CIVIS-12360] DOC fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 sphinx:
   builder: html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,11 +16,11 @@ click==8.3.3
     # via civis (pyproject.toml)
 cloudpickle==3.1.2
     # via civis (pyproject.toml)
-docutils==0.22.4
+docutils==0.21.2
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.12
+idna==3.13
     # via requests
 imagesize==2.0.0
     # via sphinx
@@ -53,6 +53,8 @@ requests==2.33.1
     #   civis (pyproject.toml)
     #   sphinx
 roman-numerals==4.1.0
+    # via roman-numerals-py
+roman-numerals-py==4.1.0
     # via sphinx
 rpds-py==0.30.0
     # via
@@ -60,7 +62,7 @@ rpds-py==0.30.0
     #   referencing
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==9.1.0
+sphinx==8.2.3
     # via
     #   civis (pyproject.toml)
     #   numpydoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,11 +8,11 @@ attrs==26.1.0
     #   referencing
 babel==2.18.0
     # via sphinx
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.3.3
     # via civis (pyproject.toml)
 cloudpickle==3.1.2
     # via civis (pyproject.toml)
@@ -20,7 +20,7 @@ docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.11
+idna==3.12
     # via requests
 imagesize==2.0.0
     # via sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ dev-civisml = [
 docs = [
     # docs/requirements.txt pins all transitive dependencies for a reproducible doc build.
     "numpydoc",
-    "Sphinx",
+    # Sphinx v9 would break custom code in docs/conf.py.
+    "Sphinx < 9",
     "sphinx-rtd-theme",
 ]
 


### PR DESCRIPTION
This pull request fixes the readthedocs build failures (e.g. [here](https://app.readthedocs.org/projects/civis-python/builds/32373456/)) introduced in #534 by pinning Sphinx < v9, which is what the custom code in `docs/conf.py` is compatible with.

Historically, `docs/conf.py` is shaped around documenting the API endpoint classes and methods auto-generated at doc-build time. Recently, we've added the stub file `src/civis/client.pyi` containing the same API documentation to support type hints -- but Sphinx's autodoc prefers `client.py` over `client.pyi` when both exist. [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html) reportedly prefers `.pyi`, which would let us greatly simplify `docs/conf.py`; I'm filing a separate ticket to explore that.


---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- n/a Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
