### PR TITLE
[CIVIS-13165] FIX surface exceptions from a CivisFuture callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed
 ### Security
+
+## 2.9.1 - 2026-04-27
+
+### Fixed
+- Exceptions raised by `add_done_callback` callbacks on a `CivisFuture`
+  (and any other `CivisAsyncResultBase` subclass) are now captured onto
+  the future and surfaced through `.result()` and `.exception()`, instead
+  of being silently swallowed by `concurrent.futures.Future._invoke_callbacks`. (#537)
 
 ## 2.9.0 - 2026-04-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civis"
-version = "2.9.0"
+version = "2.9.1"
 description = "Civis API Python Client"
 readme = "README.rst"
 requires-python = ">= 3.11"

--- a/src/civis/base.py
+++ b/src/civis/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import threading
@@ -12,6 +13,8 @@ import requests
 import civis
 from civis.response import PaginatedResponse, convert_response_data_type, Response
 from civis._retries import retry_request
+
+log = logging.getLogger(__name__)
 
 FINISHED = ["success", "succeeded"]
 FAILED = ["failed"]
@@ -221,6 +224,23 @@ class CivisAsyncResultBase(futures.Future):
     overwritten to change how the state of the object is returned.
     """
 
+    def __init__(self):
+        super().__init__()
+        # `concurrent.futures.Future._invoke_callbacks` silently swallows
+        # exceptions raised by done-callbacks (it only logs them). That
+        # hides real failures in post-processing steps attached via
+        # `add_done_callback` — e.g., a download step that runs out of
+        # disk space after the underlying Civis job succeeded. We capture
+        # the first such exception here so `.result()` and `.exception()`
+        # can surface it to callers.
+        self._callback_exception: BaseException | None = None
+        self._callbacks_complete = threading.Event()
+        # Track the thread currently running a done-callback so that a
+        # callback calling `.result()` on its own future doesn't deadlock
+        # waiting on `_callbacks_complete` (the event it is itself
+        # responsible for setting).
+        self._invoking_callbacks_thread: int | None = None
+
     def __repr__(self):
         # Almost the same as the superclass's __repr__, except we use
         # the `_civis_state` rather than the `_state`.
@@ -316,6 +336,65 @@ class CivisAsyncResultBase(futures.Future):
                 waiter.add_exception(self)
             self._condition.notify_all()
         self._invoke_callbacks()
+
+    def _run_done_callback(self, fn):
+        prev_thread = self._invoking_callbacks_thread
+        self._invoking_callbacks_thread = threading.get_ident()
+        try:
+            fn(self)
+        except BaseException as exc:
+            if self._callback_exception is None:
+                self._callback_exception = exc
+            log.exception("exception calling callback for %r", self)
+        finally:
+            self._invoking_callbacks_thread = prev_thread
+
+    def _invoke_callbacks(self):
+        try:
+            for callback in self._done_callbacks:
+                self._run_done_callback(callback)
+        finally:
+            self._callbacks_complete.set()
+
+    def add_done_callback(self, fn):
+        # Mirrors `concurrent.futures.Future.add_done_callback` but funnels
+        # the already-done case through `_run_done_callback` so exceptions
+        # raised during immediate-fire are captured the same way as those
+        # raised during `_invoke_callbacks`.
+        with self._condition:
+            if self._state not in (
+                futures._base.CANCELLED,
+                futures._base.CANCELLED_AND_NOTIFIED,
+                futures._base.FINISHED,
+            ):
+                self._done_callbacks.append(fn)
+                return
+        try:
+            self._run_done_callback(fn)
+        finally:
+            self._callbacks_complete.set()
+
+    def result(self, timeout=None):
+        result = super().result(timeout=timeout)
+        # `concurrent.futures.Future` notifies waiters before running
+        # done-callbacks, so super().result() can return before callbacks
+        # have finished in another thread. Block until they complete so
+        # callers don't miss a callback-driven side effect or a captured
+        # callback exception. The thread-ident check lets a callback call
+        # `.result()` on its own future without deadlocking.
+        if threading.get_ident() != self._invoking_callbacks_thread:
+            self._callbacks_complete.wait(timeout=timeout)
+        if self._callback_exception is not None:
+            raise self._callback_exception
+        return result
+
+    def exception(self, timeout=None):
+        exc = super().exception(timeout=timeout)
+        if exc is not None:
+            return exc
+        if threading.get_ident() != self._invoking_callbacks_thread:
+            self._callbacks_complete.wait(timeout=timeout)
+        return self._callback_exception
 
 
 def open_session(api_key, headers=None):

--- a/src/civis/ml/_model.py
+++ b/src/civis/ml/_model.py
@@ -548,6 +548,9 @@ class ModelFuture(ContainerFuture):
         del state["client"]
         del state["poller"]
         del state["_condition"]
+        # `_callbacks_complete` is a threading.Event (holds a lock) and is
+        # not picklable; recreate it in __setstate__.
+        del state["_callbacks_complete"]
         state["_done_callbacks"] = []
         state["_self_polling_executor"] = None
 
@@ -556,6 +559,7 @@ class ModelFuture(ContainerFuture):
     def __setstate__(self, state):
         self.__dict__ = state
         self._condition = threading.Condition()
+        self._callbacks_complete = threading.Event()
         self.client = APIClient()
         self.poller = self.client.scripts.get_containers_runs
         self._next_polling_interval = 1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1188,6 +1188,64 @@ def test_download_file(m_download_file):
     assert data == expected
 
 
+def _make_succeeded_civis_future():
+    # Build a CivisFuture and drive it to a succeeded state synchronously.
+    # A poller that returns "succeeded" on first call finishes the future
+    # inside __init__ (poll_on_creation=True); the Response carries the
+    # `output` list that _download_callback reads.
+    mock_client = create_client_mock()
+    api_result = Response(
+        {
+            "state": "succeeded",
+            "output": [{"path": "http://example.com/f", "file_id": 99}],
+        }
+    )
+    poller = mock.Mock(return_value=api_result)
+    return civis.futures.CivisFuture(
+        poller, (1, 2), client=mock_client, poll_on_creation=True
+    )
+
+
+def test_civis_to_csv_propagates_download_exception():
+    # Regression test for civisanalytics/civis-python#536: when the Civis
+    # unload job succeeds but the client-side download/decompression fails
+    # (e.g., out of disk space), the exception should surface through
+    # .result() and .exception() rather than being silently swallowed by
+    # concurrent.futures._invoke_callbacks.
+    fut = _make_succeeded_civis_future()
+    assert fut.done()
+
+    boom = OSError("[Errno 28] No space left on device")
+    with mock.patch(
+        "civis.io._tables._download_file", side_effect=boom
+    ) as m_download_file:
+        callback = civis.io._tables._download_callback(1, 2, "out.csv", b"", "none")
+        # concurrent.futures.Future._invoke_callbacks swallows and only
+        # logs exceptions raised by done-callbacks; the CivisAsyncResultBase
+        # wrapper captures them onto the future instead.
+        fut.add_done_callback(callback)
+        m_download_file.assert_called_once()
+
+    assert fut._callback_exception is boom
+    assert fut._callbacks_complete.is_set()
+    with pytest.raises(OSError, match="No space left"):
+        fut.result()
+    assert fut.exception() is boom
+
+
+def test_civis_to_csv_download_success():
+    fut = _make_succeeded_civis_future()
+
+    with mock.patch("civis.io._tables._download_file", return_value=None):
+        callback = civis.io._tables._download_callback(1, 2, "out.csv", b"", "none")
+        fut.add_done_callback(callback)
+
+    assert fut._callback_exception is None
+    assert fut._callbacks_complete.is_set()
+    assert fut.exception() is None
+    assert fut.result().state == "succeeded"
+
+
 def test_get_sql_select(*mocks):
     x = "select * from schema.table"
     y = "select a, b, c from schema.table"


### PR DESCRIPTION
This pull request fixes [#536](https://github.com/civisanalytics/civis-python/issues/536), where a download/decompression error from `civis.io.civis_to_csv` (e.g., out of disk space when running in AWS Lambda) was silently swallowed instead of surfacing through the returned future's `.result()` and `.exception()` methods.

The root cause is in Python's standard library: `concurrent.futures.Future._invoke_callbacks` (and the immediate-fire path in `Future.add_done_callback`) wraps each callback in `try/except Exception` and only logs the error -- so any exception raised inside a done-callback never becomes the future's exception. `civis.io.civis_to_csv` attaches its download step as a done-callback, which is why the reporter's `OSError` was logged but never raised from `fut.result()`.

The fix lives on `CivisAsyncResultBase` (the parent of `CivisFuture`, `ContainerFuture`, `ModelFuture`, and `PollableResult`) so it benefits every future, not just `civis_to_csv`:

- `add_done_callback` and `_invoke_callbacks` now route each callback through a wrapper that captures the first exception onto the future as `_callback_exception`.
- `result()` and `exception()` now block until done-callbacks have finished running and surface any captured callback exception. This also closes a latent race: `Future` notifies waiters *before* invoking callbacks, so previously a caller could see `.result()` return before a callback-driven side effect (e.g., the download) had completed.
- A `threading.get_ident()` check lets a callback call `.result()` on its own future without deadlocking on the new completion event.

Note: this is a behavior change. Exceptions that were previously only logged from done-callbacks will now propagate from `.result()`/`.exception()`. In practice this is the behavior most users expect, and there is no known caller that relies on the silent-swallow behavior.

Only `threading` primitives (`threading.Event`, `threading.get_ident`) are used -- no `multiprocessing` -- so this is safe in AWS Lambda, unlike the issue that motivated #520.

Two regression tests are added in `tests/test_io.py` covering the OSError-surfacing path and the success path.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
